### PR TITLE
Fix infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Cabal
+dist
+dist-newstyle
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.project.local
+.ghc.environment*
+
+# Profiling
+*.prof
+
+# Stack
+.stack-work
+
+# Emacs
+TAGS
+.dir-locals.el
+
+# Vim
+tags
+*.swp

--- a/ariadne.cabal
+++ b/ariadne.cabal
@@ -7,7 +7,6 @@ author:         @serokell
 maintainer:     Serokell <hi@serokell.io>
 copyright:      2018 Author name here
 license:        BSD3
-license-file:   LICENSE
 build-type:     Simple
 cabal-version:  >= 1.10
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,28 +1,46 @@
-{ pkgs ? import <nixpkgs> {}, ghc ? pkgs.ghc }: with pkgs;
+{ _nixpkgs ? import <nixpkgs> {} }:
 
 let
-  jemalloc450 = import ./jemalloc450.nix { inherit pkgs; };
-  rocksdb = pkgs.rocksdb.override { jemalloc = jemalloc450; };
-  hsPkgs = haskell.packages.ghc802;
-in 
+  jemalloc450 = import ./jemalloc450.nix { pkgs = nixpkgs; };
+  rocksdb = nixpkgs.rocksdb.override { jemalloc = jemalloc450; };
 
-haskell.lib.buildStackProject {
+  nixpkgs = import (_nixpkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "e7a327da5cffdf5e77e1924906a4f0983591bd3e";
+    sha256 = "1xzil4mayhggg2miwspbk12nihlszg0y4n6i4qacrxql5n75f0hr";
+  }){ overlays = [cabalHashes]; };
+
+  cabalHashes = sel: super: {
+    all-cabal-hashes = super.fetchurl {
+      url    = "https://github.com/commercialhaskell/all-cabal-hashes/archive/b2b93ae610f5f1b51d22b191f972dc3dec8f94c6.tar.gz";
+      sha256 = "0bffclpqbw62xff36qlzxghr042mhv0m06k5ml4298w6fv7ly1xw";
+    };
+  };
+
+  ghc = nixpkgs.haskell.compiler.ghc802;
+  haskellPackages = nixpkgs.haskell.packages.ghc802;
+
+in
+
+nixpkgs.haskell.lib.buildStackProject {
   inherit ghc;
-  name = "myEnv";
-  buildInputs = [ autoreconfHook
-                  bsdiff
-                  gcc 
-                  git 
-                  gmp 
-                  hsPkgs.cpphs
-                  hsPkgs.happy
-                  lzma 
-                  ncurses 
-                  openssl 
-                  openssh
-                  rocksdb 
-                  zlib 
-                ];
+  name = "ariadne-env";
+  buildInputs = with nixpkgs;
+    [ autoreconfHook
+      bsdiff
+      gcc
+      git
+      gmp
+      haskellPackages.cpphs
+      haskellPackages.happy
+      lzma
+      ncurses
+      openssl
+      openssh
+      rocksdb
+      zlib
+    ];
   buildPhase = ''
     export LANG=en_US.UTF-8
     '';

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,9 @@
 resolver: lts-9.1
 
+flags:
+  ether:
+    disable-tup-instances: true
+
 packages:
 - .
 
@@ -176,3 +180,6 @@ extra-deps:
 - vty-5.20
 
 extra-package-dbs: []
+
+nix:
+  shell-file: shell.nix


### PR DESCRIPTION
1. add `.gitignore`
2. remove `license:` from the cabal file, as the actual file is missing
3. pin `nixpkgs` and the compiler version
4. specify `disable-tup-instances: true` for `ether` (speeds up dep building)
5. make `stack` aware of `shell.nix`

Now it's possible to `stack build ariadne` on a nix-enabled system.