### PR TITLE
[AD-1] Add REPL output scrolling

### DIFF
--- a/knit/src/Knit/Argument.hs
+++ b/knit/src/Knit/Argument.hs
@@ -23,7 +23,6 @@ module Knit.Argument
 import Control.Lens
 import Control.Monad
 import Control.Monad.State
-import Data.Functor.Identity
 import Data.List (sortOn)
 import Data.List.NonEmpty
 import Data.Maybe


### PR DESCRIPTION
What works:

* Scrolling with arrows
* PgUp/PgDown

What doesn't work:

* O(1) time and memory for each successive scrolling event. Currently the scrolling position is a function that calls all previous similar functions before returning its result. This might also cause stack overflow.
* Properly fixing the current position if it's not at the end of the output (if the "follow mode" is off).

Fixing these two will require changing quite a lot. The best idea we've come up with @int-index is to have

```
data ScrollingOffset
    = OffsetFollowing
    | OffsetFixed Int Int -- ^ number of output element, line within output element

...

replWidgetScrollingOffset :: ViewportHeight -> [OutputElementSize] -> ScrollingOffset
```

but that requires propagating `OutputElementSIze`, which is nontrivial.