### PR TITLE
Unbind ^H

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty.hs
+++ b/ui/vty/src/Ariadne/UI/Vty.hs
@@ -74,15 +74,7 @@ runUI eventChan history langFace = do
 mkVtyConfig :: IO V.Config
 mkVtyConfig = do
   stdConfig <- V.standardIOConfig
-  return stdConfig
-    { V.mouseMode = Just True
-    , V.inputMap =
-      [
-        -- Terminals map ^H to an escape sequence, we
-        -- unmap it back.
-        (Nothing, "\b", V.EvKey (V.KChar 'h') [V.MCtrl])
-      ]
-    }
+  return stdConfig { V.mouseMode = Just True }
 
 -- Create a channel for application events that aren't user input. This channel
 -- is bounded to avoid infinite accumulation of events, but the bound is


### PR DESCRIPTION
Now that the Navigation mode is merged, we don't need this hack.