### PR TITLE
[AD-67] WalletTree: use 0-based indices

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty/Widget/WalletTree.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/WalletTree.hs
@@ -102,7 +102,7 @@ renderWalletTreeItem selection _ UiWalletTreeItem {..} = V.text' attr toDisplay
             NotSelected -> V.defAttr
             Selected -> selAttr
     selAttr = V.defAttr `V.withForeColor` V.black `V.withBackColor` V.white
-    pathText = T.intercalate "-" $ map (pretty . succ) wtiPath
+    pathText = T.intercalate "-" $ map pretty wtiPath
 
 drawWalletTreeWidget
   :: Bool


### PR DESCRIPTION
For consistency with e. g. the `select` command.