### PR TITLE
[AD-52] Make the nav mode more apparent

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty/Theme.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Theme.hs
@@ -29,7 +29,7 @@ defaultAttrMap = attrMap
   , ("selected", currentAttr `withStyle` standout)
   , ("menu", black `on` white)
   , ("menu.selected", white `on` black)
-  , ("menu.key", currentAttr `withForeColor` red)
+  , ("menu.key", currentAttr `withForeColor` red `withStyle` underline)
   , ("status", black `on` white)
   , ("status.content", currentAttr `withForeColor` blue)
   ]


### PR DESCRIPTION
Now navigation mode is slightly different visually:

![image](https://user-images.githubusercontent.com/4061728/38961063-800d98c4-436f-11e8-8ea5-f95ad19d5699.png)

1. We don't show the current widget selection, prompting the user to select some widget.
2. We underline key shortcuts in addition to making them red.