### PR TITLE
[AD-83] Make Wallet configurable

### DIFF
--- a/ariadne/app/Main.hs
+++ b/ariadne/app/Main.hs
@@ -30,13 +30,14 @@ main :: IO ()
 main = do
   ariadneConfig <- getConfig
   let cardanoConfig = acCardano ariadneConfig
+      walletConfig = acWallet ariadneConfig
 
   (uiFace, mkUiAction) <- createAriadneUI
   (cardanoFace, mkCardanoAction) <- createCardanoBackend cardanoConfig
   let CardanoFace { cardanoRunCardanoMode = runCardanoMode
                   } = cardanoFace
   taskManagerFace <- createTaskManagerFace
-  mkWallet <- createWalletBackend
+  mkWallet <- createWalletBackend walletConfig
 
   let
     mkWalletFace :: (Doc -> IO ()) -> WalletFace

--- a/ariadne/ariadne.cabal
+++ b/ariadne/ariadne.cabal
@@ -90,6 +90,7 @@ library
       Ariadne.Cardano.Backend
       Ariadne.Cardano.Face
       Ariadne.Cardano.Orphans
+      Ariadne.Config.Wallet
       Ariadne.Config.Ariadne
       Ariadne.Config.CLI
       Ariadne.Config.Cardano

--- a/ariadne/src/Ariadne/Config/Ariadne.hs
+++ b/ariadne/src/Ariadne/Config/Ariadne.hs
@@ -5,6 +5,8 @@ module Ariadne.Config.Ariadne
 import Universum
 
 import Ariadne.Config.Cardano
+import Ariadne.Config.DhallUtil (parseField)
+import Ariadne.Config.Wallet
 import qualified Data.Map as Map
 import qualified Dhall as D
 import Dhall.Core (Expr(..))
@@ -13,15 +15,16 @@ import Dhall.TypeCheck (X)
 
 -- default Ariadne config with Cardano mainnet config
 defaultAriadneConfig :: AriadneConfig
-defaultAriadneConfig = AriadneConfig defaultCardanoConfig
+defaultAriadneConfig = AriadneConfig defaultCardanoConfig defaultWalletConfig
 
 parseFieldAriadne :: Map D.Text (Expr Src X) -> D.Text -> D.Type a -> Maybe a
-parseFieldAriadne dhallRec name type_ = Map.lookup (ariadneFieldModifier name) dhallRec >>= D.extract type_
+parseFieldAriadne = parseField ariadneFieldModifier
 
 ariadneFieldModifier :: D.Text -> D.Text
 ariadneFieldModifier = f
   where
     f "acCardano" = "cardano"
+    f "acWallet" = "wallet"
     f x = x
 
 -- dhall representation of AriadneConfig is a record
@@ -29,17 +32,21 @@ ariadneFieldModifier = f
 -- It will be a Map Text Config if dhall representation
 -- is changed to a List
 data AriadneConfig = AriadneConfig
-  { acCardano :: CardanoConfig } deriving (Eq, Show)
+  { acCardano :: CardanoConfig
+  , acWallet :: WalletConfig
+  } deriving (Eq, Show)
 
 instance D.Interpret AriadneConfig where
   autoWith _ = D.Type extractOut expectedOut
     where
       extractOut (RecordLit fields) = do
         acCardano <- parseFieldAriadne fields "acCardano" (D.auto @CardanoConfig)
+        acWallet <- parseFieldAriadne fields "acWallet" (D.auto @WalletConfig)
         return AriadneConfig {..}
       extractOut _ = Nothing
 
       expectedOut =
         Record
             (Map.fromList
-                [(ariadneFieldModifier "acCardano", D.expected (D.auto @CardanoConfig))])
+                [ (ariadneFieldModifier "acCardano", D.expected (D.auto @CardanoConfig))
+                , (ariadneFieldModifier "acWallet", D.expected (D.auto @WalletConfig))])

--- a/ariadne/src/Ariadne/Config/Cardano.hs
+++ b/ariadne/src/Ariadne/Config/Cardano.hs
@@ -75,7 +75,7 @@ instance D.Inject CardanoConfig where
   injectWith _ = contramap getCardanoConfig injectCommonNodeArgs
 
 parseFieldCardano :: Map D.Text (Expr Src X) -> D.Text -> D.Type a -> Maybe a
-parseFieldCardano dhallRec name type_ = Map.lookup (cardanoFieldModifier name) dhallRec >>= D.extract type_
+parseFieldCardano = parseField cardanoFieldModifier
 
 cardanoFieldModifier :: D.Text -> D.Text
 cardanoFieldModifier = f

--- a/ariadne/src/Ariadne/Config/Wallet.hs
+++ b/ariadne/src/Ariadne/Config/Wallet.hs
@@ -1,0 +1,42 @@
+module Ariadne.Config.Wallet
+  ( defaultWalletConfig
+  , WalletConfig (..)) where
+
+import Universum
+
+import Ariadne.Config.DhallUtil (interpretByte, parseField)
+import qualified Data.Map as Map
+import qualified Dhall as D
+import Dhall.Core (Expr(..))
+import Dhall.Parser (Src(..))
+import Dhall.TypeCheck (X)
+import Serokell.Data.Memory.Units (Byte)
+
+defaultWalletConfig :: WalletConfig
+defaultWalletConfig = WalletConfig 16
+
+parseFieldWallet :: Map D.Text (Expr Src X) -> D.Text -> D.Type a -> Maybe a
+parseFieldWallet = parseField walletFieldModifier
+
+walletFieldModifier :: D.Text -> D.Text
+walletFieldModifier = f
+  where
+    f "wcEntropySize" = "entropy-size"
+    f x = x
+
+data WalletConfig = WalletConfig
+  { wcEntropySize :: Byte
+  } deriving (Eq, Show)
+
+instance D.Interpret WalletConfig where
+  autoWith _ = D.Type extractOut expectedOut
+    where
+      extractOut (RecordLit fields) = do
+        wcEntropySize <- parseFieldWallet fields "wcEntropySize" interpretByte
+        return WalletConfig {..}
+      extractOut _ = Nothing
+
+      expectedOut =
+        Record
+            (Map.fromList
+                [(walletFieldModifier "wcEntropySize", D.expected interpretByte)])

--- a/ariadne/src/Ariadne/Wallet/Backend.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend.hs
@@ -9,17 +9,18 @@ import Data.Constraint (withDict)
 import IiExtras ((:~>)(..))
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
+import Ariadne.Config.Wallet (WalletConfig(..))
 import Ariadne.Wallet.Backend.KeyStorage
 import Ariadne.Wallet.Backend.Tx
 import Ariadne.Wallet.Face
 
-createWalletBackend :: IO
+createWalletBackend :: WalletConfig -> IO
   (
     CardanoFace ->
     (WalletEvent -> IO ()) ->
     ((Doc -> IO ()) -> WalletFace, IO ())
   )
-createWalletBackend = do
+createWalletBackend walletConfig = do
   walletSelRef <- newIORef Nothing
   return $ \cf@CardanoFace {..} sendWalletEvent ->
     let
@@ -29,7 +30,7 @@ createWalletBackend = do
          withDicts $ fix $ \this -> WalletFace
           { walletAddAddress = addAddress this walletSelRef runCardanoMode
           , walletAddAccount = addAccount this walletSelRef runCardanoMode
-          , walletAddWallet = addWallet this runCardanoMode
+          , walletAddWallet = addWallet walletConfig this runCardanoMode
           , walletRefreshUserSecret =
               refreshUserSecret walletSelRef runCardanoMode sendWalletEvent
           , walletSelect = select this walletSelRef runCardanoMode

--- a/ariadne/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/src/Ariadne/Wallet/Face.hs
@@ -10,6 +10,7 @@ module Ariadne.Wallet.Face
 import Universum
 
 import Ariadne.Cardano.Face
+import Serokell.Data.Memory.Units (Byte)
 
 data WalletSelection =
   WalletSelection
@@ -31,7 +32,7 @@ data WalletFace =
   WalletFace
     { walletAddAddress :: AccountReference -> PassPhrase -> IO ()
     , walletAddAccount :: WalletReference -> Maybe Text -> IO ()
-    , walletAddWallet :: PassPhrase -> Maybe Text -> IO [Text]
+    , walletAddWallet :: PassPhrase -> Maybe Text -> Maybe Byte -> IO [Text]
     , walletRefreshUserSecret :: IO ()
     , walletSelect :: Maybe WalletReference -> [Word] -> IO ()
     , walletSend :: PassPhrase -> WalletReference -> NonEmpty TxOut -> IO TxId

--- a/config/ariadne-config.dhall
+++ b/config/ariadne-config.dhall
@@ -1,3 +1,4 @@
 {
-    cardano = ./config/cardano/cardano-config.dhall
+      cardano = ./config/cardano/cardano-config.dhall
+    , wallet = ./config/wallet/wallet.dhall
 }

--- a/config/wallet/wallet.dhall
+++ b/config/wallet/wallet.dhall
@@ -1,0 +1,3 @@
+{
+    entropy-size = +16
+}


### PR DESCRIPTION
Now entropy size can be set via either wallet-config.dhall or optional knit
argument "entropy-size"