### PR TITLE
[AD-50] Optimize log view scrolling

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty/Scrolling.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Scrolling.hs
@@ -3,7 +3,6 @@ module Ariadne.UI.Vty.Scrolling
      , keyToScrollingAction
      , handleScrollingEvent
      , scrollToEnd
-     , keepScrollingToEnd
      , fixedViewport
      ) where
 
@@ -23,6 +22,7 @@ data ScrollingAction
   | ScrollingEnd
   | ScrollingLeft
   | ScrollingRight
+  deriving (Eq)
 
 keyToScrollingAction :: KeyboardEvent -> Maybe ScrollingAction
 keyToScrollingAction = \case
@@ -54,12 +54,6 @@ handleScrollingEvent name = \case
 
 scrollToEnd :: n -> B.EventM n ()
 scrollToEnd = B.vScrollToEnd . B.viewportScroll
-
-keepScrollingToEnd :: Ord n => n -> Int -> B.EventM n ()
-keepScrollingToEnd name lineCount =
-  whenJustM (B.lookupViewport name) $ \vp ->
-    when (vp ^. B.vpTop + vp ^. B.vpSize ^. _2 >= lineCount) $
-      B.vScrollToEnd $ B.viewportScroll name
 
 -- Unidirectional Brick viewport doesn't defer its sizing policy
 -- to underlying widget. Brick author considers it okay.


### PR DESCRIPTION
Instead of #109 

The two scrolling modes are now rendered differently:
1. Automatic scroll-to-bottom mode now only renders the messages that fit on the screen.
   Therefore, appends don't trigger full log render and are faster.
2. Manual scroll mode renders and caches the whole log to allow fast scrolling, as before.

This also fixes a bug when log view was rendered scrolled to the top on first render.