### PR TITLE
[AD-68] Knit tests

### DIFF
--- a/ariadne/src/Ariadne/TaskManager/Face.hs
+++ b/ariadne/src/Ariadne/TaskManager/Face.hs
@@ -4,11 +4,12 @@ import Universum
 
 import Control.Concurrent.Async
 import Control.Exception (Exception, SomeException)
+import Numeric.Natural
 
 -- | This type reperesents a unique task identifier.
 -- The uniqueness is handled by the backend: each time a command is spawned
 -- it is assigned a new unique TaskId
-data TaskId = TaskId Int
+data TaskId = TaskId Natural
   deriving (Eq, Ord, Show)
 
 -- | The process manager context is a map from CommandId to an async object that

--- a/ariadne/src/Ariadne/TaskManager/Knit.hs
+++ b/ariadne/src/Ariadne/TaskManager/Knit.hs
@@ -46,6 +46,7 @@ data instance ComponentLit TaskManager
 
 data instance ComponentToken TaskManager
   = TokenTaskId TaskId
+  deriving (Eq, Ord, Show)
 
 makePrisms 'TokenTaskId
 
@@ -65,7 +66,7 @@ instance Elem components TaskManager => ComponentTokenizer components TaskManage
 
 instance ComponentDetokenizer TaskManager where
   componentTokenRender = \case
-    TokenTaskId (TaskId cid) -> sformat ("<"%build%">") cid
+    TokenTaskId (TaskId cid) -> sformat ("<"%build%">") (toInteger cid)
 
 instance Elem components TaskManager => ComponentLitGrammar components TaskManager where
   componentLitGrammar =

--- a/knit/knit.cabal
+++ b/knit/knit.cabal
@@ -20,6 +20,7 @@ library
       union,
       vinyl,
       text,
+      formatting,
       scientific,
       split,
       text-format,
@@ -94,12 +95,51 @@ test-suite knit-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , universum
+    , ariadne
+    , formatting
+    , scientific
+    , loc
+    , knit
     , ii-extras
     , megaparsec
+    , generic-arbitrary
     , text
     , hspec
+    , QuickCheck
   other-modules:
   default-language: Haskell2010
   default-extensions:
+      NoImplicitPrelude
+      ApplicativeDo
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DeriveGeneric
+      DeriveFunctor
+      DeriveFoldable
+      DeriveTraversable
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NegativeLiterals
       OverloadedStrings
+      PatternSynonyms
+      PolyKinds
+      RankNTypes
+      RecordWildCards
+      RecursiveDo
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      UndecidableInstances
+      ViewPatterns
   ghc-options: -Wall

--- a/knit/src/Knit/Core.hs
+++ b/knit/src/Knit/Core.hs
@@ -116,10 +116,7 @@ instance Elem components Core => ComponentTokenizer components Core where
 
 instance ComponentDetokenizer Core where
   componentTokenRender = \case
-    TokenNumber n ->
-      case floatingOrInteger n of
-        Left (_ :: Double) -> fromString (show n)
-        Right (n' :: Integer) -> fromString (show n')
+    TokenNumber n -> fromString (show n)
     TokenString s -> fromString (show s)
     TokenFilePath s ->
       let

--- a/knit/src/Knit/Tokenizer.hs
+++ b/knit/src/Knit/Tokenizer.hs
@@ -15,6 +15,7 @@ import Data.Proxy
 import Data.Text as T
 import Data.Union
 import Data.Void
+import Formatting (build, sformat, (%))
 import IiExtras
 
 import Control.Applicative.Combinators.NonEmpty as NonEmpty
@@ -87,8 +88,8 @@ tokenRender = \case
   TokenParenthesis bs -> withBracketSide "(" ")" bs
   TokenEquals -> "="
   TokenSemicolon -> ";"
-  TokenName name -> T.pack (show name)
-  TokenKey name -> T.pack (shows name ":")
+  TokenName name -> sformat build name
+  TokenKey name -> sformat (build%":") name
   TokenUnknown (UnknownChar c) -> T.singleton c
 
 detokenize

--- a/knit/test/Spec.hs
+++ b/knit/test/Spec.hs
@@ -1,15 +1,34 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+import Universum
+
+import qualified Ariadne.Cardano.Knit as Knit
+import Ariadne.TaskManager.Face (TaskId(..))
+import qualified Ariadne.TaskManager.Knit as Knit
+import Data.List.NonEmpty (fromList)
+import Data.Scientific
 import Data.Text (Text)
-import Data.Void
-import IiExtras (longestMatch)
+import qualified Data.Text as T
+import IiExtras
+import Knit
 import Test.Hspec (Expectation, Spec, describe, hspec, it, shouldBe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+  (Arbitrary(..), Gen, Property, elements, listOf, property)
+import Test.QuickCheck.Gen (listOf1, oneof)
 import Text.Megaparsec (Parsec, runParser)
-import Text.Megaparsec.Char (string)
+import Text.Megaparsec.Char as P
 
 main :: IO ()
-main = hspec spec
+main = do
+  hspec specLongestMatch
+  hspec specTokenizer
 
-spec :: Spec
-spec = describe "longestMatch"$ do
+-- longestMatch tests
+
+specLongestMatch :: Spec
+specLongestMatch = describe "longestMatch" $ do
     it "parses a" unitTest1
     it "parses aa" unitTest2
 
@@ -22,8 +41,113 @@ unitTest2 =
   runParser (longestMatch parserList) "" "aa" `shouldBe` (Right False)
 
 parserList :: [Parser Bool]
-parserList = [True <$ string "a", False <$ string "aa"]
+parserList = [True <$ P.string "a", False <$ P.string "aa"]
 
 type Parser = Parsec Void Text
 
+-- Tokenizer tests
 
+specTokenizer :: Spec
+specTokenizer = describe "Knit.Tokenizer" $ do
+    prop "accepts any input" propAcceptsAnyInput
+    prop "handles valid input" propHandlesValidInput
+
+-- The only components that have tokens
+type Components = '[Knit.Core, Knit.Cardano, Knit.TaskManager]
+
+propAcceptsAnyInput :: Property
+propAcceptsAnyInput = property $ isJust . (tokenize' @Components) . fromString
+
+propHandlesValidInput :: Property
+propHandlesValidInput = property $ liftA2 (==) (map snd . tokenize . (detokenize @Components)) identity
+
+instance Arbitrary (Token Components) where
+  arbitrary = genTokenComponents @Components
+
+class ComponentTokenGen components component where
+  componentTokenGen :: [Gen (Knit.Token components)]
+
+instance Elem components Knit.Core => ComponentTokenGen components Knit.Core where
+  componentTokenGen =
+    [ toToken . TokenNumber <$> arbitrary @Scientific
+    , toToken . TokenString <$> arbitrary @String
+    , toToken . TokenFilePath <$> genValidFilePath
+    ]
+
+instance Elem components Knit.Cardano => ComponentTokenGen components Knit.Cardano where
+  componentTokenGen =
+    [ toToken . Knit.TokenAddress <$> arbitrary
+    , toToken . Knit.TokenPublicKey <$> arbitrary
+    , toToken . Knit.TokenStakeholderId <$> arbitrary
+    , toToken . Knit.TokenHash <$> arbitrary
+    , toToken . Knit.TokenBlockVersion <$> arbitrary
+    ]
+
+instance Elem components Knit.TaskManager => ComponentTokenGen components Knit.TaskManager where
+  componentTokenGen =
+    [ toToken . Knit.TokenTaskId . TaskId <$> arbitrary]
+
+genName :: Gen Name
+genName = (Name . fromList) <$> listOf1 letters
+  where
+    letters :: Gen (NonEmpty Letter)
+    letters = fromList <$> listOf1 (unsafeMkLetter <$> elements alphasList)
+
+genValidFilePath :: Gen FilePath
+genValidFilePath = do
+  prefix <- genPrefix
+  path <- listOf (elements symbList)
+  return $ prefix <> path
+  where
+    genPrefix :: Gen FilePath
+    genPrefix = elements ["./", "/", "../"]
+
+    symbList :: FilePath
+    symbList =
+        alphasList
+        <> ['0'..'9']
+        <> ['.', '/', '-', '_']
+
+alphasList :: [Char]
+alphasList = ['A'..'Z'] <> ['a'..'z']
+
+tokenUnknownList :: forall components.
+  (KnownSpine components, AllConstrained (ComponentTokenizer components) components)
+  => [Knit.Token components]
+tokenUnknownList = filter unknown $ map snd
+  (foldMap ((tokenize @components) . T.singleton) ([minBound..maxBound] :: [Char]))
+  where
+    unknown :: Token components -> Bool
+    unknown (TokenUnknown _) = True
+    unknown _ = False
+
+genTokenComponents
+  :: forall components.
+  ( KnownSpine components
+  , AllConstrained (ComponentTokenGen components) components
+  , AllConstrained (ComponentTokenizer components) components)
+  => Gen (Knit.Token components)
+genTokenComponents = oneof $ componentTokens <> baseTokens
+  where
+    baseTokens :: [Gen (Token components)]
+    baseTokens =
+      [ TokenSquareBracket <$> elements [BracketSideOpening, BracketSideClosing]
+      , TokenParenthesis <$> elements [BracketSideOpening, BracketSideClosing]
+      , return TokenEquals
+      , return TokenSemicolon
+      , TokenName <$> genName
+      , TokenKey <$> genName
+      , elements (tokenUnknownList @components)
+      ]
+
+    componentTokens :: [Gen (Token components)]
+    componentTokens = go (knownSpine @components)
+
+    go
+      :: forall components'.
+         AllConstrained (ComponentTokenGen components) components'
+      => Spine components'
+      -> [Gen (Knit.Token components)]
+    go RNil = []
+    go ((Proxy :: Proxy component) :& xs) =
+      (componentTokenGen @components @component) ++ (go xs)

--- a/ui/qt/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt/src/Ariadne/UI/Qt/Face.hs
@@ -19,6 +19,7 @@ import Universum
 
 import Data.Loc.Span (Span)
 import Data.Tree (Tree)
+import Numeric.Natural
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 data UiCommandId =
@@ -72,8 +73,8 @@ data UiEvent
 data UiOperation
   = UiSelect [Word]
   | UiBalance
-  | UiKill Int
   | UiSend Text Text  -- ^ Address, amount
+  | UiKill Natural
 
 -- The backend language (Knit by default) interface as perceived by the UI.
 data UiLangFace =

--- a/ui/vty/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Face.hs
@@ -22,6 +22,7 @@ import Universum
 
 import Data.Loc.Span (Span)
 import Data.Tree (Tree)
+import Numeric.Natural
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 data UiCommandId =
@@ -29,14 +30,14 @@ data UiCommandId =
   { -- This field is used to compare whether two command identifiers are equal.
     -- The mapping from actual command identifiers to these integers must be
     -- injective.
-    cmdIdEqObject :: Integer
+    cmdIdEqObject :: Natural
   , -- This field is the visual representation of a command identifier. The
     -- mapping from actual command identifiers to text need not be injective,
     -- but it would be very unfair to the user, as different command identifiers
     -- would appear the same to her.
     cmdTaskIdRendered :: Maybe Text
     -- Task identifier object.
-  , cmdTaskId :: Maybe Int
+  , cmdTaskId :: Maybe Natural
   }
 
 -- A REPL command has either finished or sent some information.
@@ -81,7 +82,7 @@ data UiEvent
 data UiOperation
   = UiSelect [Word]
   | UiBalance
-  | UiKill Int
+  | UiKill Natural
 
 -- The backend language (Knit by default) interface as perceived by the UI.
 data UiLangFace =


### PR DESCRIPTION
I'll squash after the approvement.

To pass tests some changes were made in ariadne and knit.  

Before: Scientific detokenized to Integer/Double and tokenized back as AbstractHash. 
Now: It detokenized in Scientific.

Before: TaskId tokenizer expected a positive number.
Now: `TaskId Int` changed to `TaskId Natural`. Some changes were made to make the code compile.  

Before: Name was detokenized in quotes, latter tokenized back as `TokenUnknown Char "`.
Now: Name is detokenized without quotes. 