### PR TITLE
[AD-96] Add Daedalus mnemonic restore

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -322,7 +322,7 @@ newWallet walletConfig face runCardanoMode pp mbWalletName mbEntropySize = do
   -- advanced feature and do not provide it for now.
   let seed = mnemonicToSeed (unwords mnemonic) ""
   let (_, esk) = safeDeterministicKeyGen seed pp
-  mnemonic <$ addWallet face runCardanoMode esk mbWalletName mempty
+  mnemonic ++ ["ariadne-v0"] <$ addWallet face runCardanoMode esk mbWalletName mempty
 
 -- | Construct a wallet from given data and add it to the storage.
 addWallet ::


### PR DESCRIPTION
This adds `restore-daedalus` command.

It seem to work, but I haven't tested it on any actual wallet, all I did is to generate some throwaway wallet in development Daedalus I had and got mnemonic from there.

I think it will be better if someone else also tests that it does indeed work.