### PR TITLE
[AD-117] Use BIP-44 in imported code

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
@@ -138,9 +138,10 @@ createHdAccount rootId name checkpoint = runUpdate' . zoom dbHdWallets $
 
 createHdAddress :: HdAddressId
                 -> InDb Core.Address
+                -> HdAddressChain
                 -> Update DB (Either HD.CreateHdAddressError ())
-createHdAddress addrId address = runUpdate' . zoom dbHdWallets $
-    HD.createHdAddress addrId address
+createHdAddress addrId address chain = runUpdate' . zoom dbHdWallets $
+    HD.createHdAddress addrId address chain
 
 updateHdRootAssurance :: HdRootId
                       -> AssuranceLevel

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -11,6 +11,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet (
   , HdWallets(..)
   , HdRootId(..)
   , HdAccountId(..)
+  , HdAddressChain(..)
   , HdAddressId(..)
   , HdRoot(..)
   , HdAccount(..)
@@ -34,7 +35,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet (
   , hdAddressId
   , hdAddressAddress
   , hdAddressIsUsed
-  , hdAddressIsChange
+  , hdAddressChain
     -- ** Composite lenses
   , hdAccountRootId
   , hdAddressRootId
@@ -80,6 +81,10 @@ newtype AccountName = AccountName Text
 newtype HdAccountIx = HdAccountIx Word32
   deriving (Eq, Ord)
 
+-- | Whether the chain is an external or an internal one
+data HdAddressChain = HdChainExternal | HdChainInternal
+  deriving (Eq, Ord)
+
 -- | Address index
 newtype HdAddressIx = HdAddressIx Word32
   deriving (Eq, Ord)
@@ -103,6 +108,7 @@ data HasSpendingPassword =
 deriveSafeCopy 1 'base ''WalletName
 deriveSafeCopy 1 'base ''AccountName
 deriveSafeCopy 1 'base ''HdAccountIx
+deriveSafeCopy 1 'base ''HdAddressChain
 deriveSafeCopy 1 'base ''HdAddressIx
 deriveSafeCopy 1 'base ''AssuranceLevel
 deriveSafeCopy 1 'base ''HasSpendingPassword
@@ -175,22 +181,21 @@ data HdAccount = HdAccount {
 -- | Address in an account of a HD wallet
 data HdAddress = HdAddress {
       -- | Address ID
-      _hdAddressId       :: HdAddressId
+      _hdAddressId      :: HdAddressId
 
       -- | The actual address
-    , _hdAddressAddress  :: InDb Core.Address
+    , _hdAddressAddress :: InDb Core.Address
 
       -- | Has this address been involved in a transaction?
       --
       -- TODO: How is this determined? What is the definition? How is it set?
       -- TODO: This will likely move to the 'BlockMeta' instead.
-    , _hdAddressIsUsed   :: Bool
+    , _hdAddressIsUsed  :: Bool
 
-      -- | Was this address used as a change address?
-      --
-      -- TODO: How is this derived when we do wallet recovery?
-      -- TODO: Do we need this at all?
-    , _hdAddressIsChange :: Bool
+      -- | Whether this address is derived on the external or internal chain.
+      -- Invariant: this must match the actual derivation scheme which
+      -- yields _hdAddressAddress.
+    , _hdAddressChain   :: HdAddressChain
     }
 
 makeLenses ''HdAccountId

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
@@ -125,8 +125,9 @@ createHdAccount rootId name checkpoint = do
 -- address index, as we do not have access to a random number generator here.
 createHdAddress :: HdAddressId
                 -> InDb Core.Address
+                -> HdAddressChain
                 -> Update' HdWallets CreateHdAddressError ()
-createHdAddress addrId address = do
+createHdAddress addrId address chain = do
     -- Check that the account ID exists
     zoomHdAccountId CreateHdAddressUnknown (addrId ^. hdAddressIdParent) $
       return ()
@@ -138,8 +139,8 @@ createHdAddress addrId address = do
   where
     hdAddress :: HdAddress
     hdAddress = HdAddress {
-          _hdAddressId       = addrId
-        , _hdAddressAddress  = address
-        , _hdAddressIsUsed   = error "TODO: _hdAddressIsUsed"
-        , _hdAddressIsChange = error "TODO: _hdAddressIsChange"
+          _hdAddressId      = addrId
+        , _hdAddressAddress = address
+        , _hdAddressIsUsed  = error "TODO: _hdAddressIsUsed"
+        , _hdAddressChain   = chain
         }


### PR DESCRIPTION
This PR only affects the imported code and does not touch other parts of the wallet. In particular, `ariadne/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs` (which calls `deriveLvl2KeyPair` from `cardano-sl/core/Pos/Core/Common/Address.hs`) is unaffected. Actually switching Ariadne to BIP-44 is the subject of https://issues.serokell.io/issue/AD-126.

Note: naming with the `change` level is not nearly as nice as with wallets / accounts / addresses, so if you have any better ideas, be sure to share them.