### PR TITLE
[AD-121] Fix Qt crash caused by running foreign IO in unbound thread

### DIFF
--- a/ui/qt/src/Ariadne/UI/Qt.hs
+++ b/ui/qt/src/Ariadne/UI/Qt.hs
@@ -5,6 +5,7 @@ module Ariadne.UI.Qt
 
 import Universum
 
+import Control.Concurrent
 import Control.Monad.Extra (loopM)
 
 import Text.PrettyPrint.ANSI.Leijen (Doc)
@@ -35,7 +36,7 @@ createAriadneUI = do
 
 runUIEventLoop :: UiEventBQueue -> IORef (Maybe QObject.QObject) -> [Doc] -> UiLangFace -> IO ()
 runUIEventLoop eventIORef dispatcherIORef helpData langFace =
-  withScopedPtr (getArgs >>= QApplication.new) $ \_ -> do
+  runInBoundThread $ withScopedPtr (getArgs >>= QApplication.new) $ \_ -> do
     eventDispatcher <- QObject.new
     writeIORef dispatcherIORef $ Just eventDispatcher
     mainWindow <- initMainWindow langFace


### PR DESCRIPTION
Apparently, one Haskell thread can run across several OS threads if some blocking IO is involved.
Qt, on the other hand, _must_ be worked with in a single OS thread.
Running Qt code in _bound thread_ helps to achieve that.