### PR TITLE
[AD-129] Fix deadlock on early exit

### DIFF
--- a/ariadne/app-qt/Main.hs
+++ b/ariadne/app-qt/Main.hs
@@ -64,4 +64,4 @@ main = do
     serviceAction :: IO ()
     serviceAction = uiAction `race_` cardanoAction
 
-  concurrently_ walletInitAction serviceAction
+  withAsync walletInitAction $ \_ -> serviceAction

--- a/ariadne/app/Main.hs
+++ b/ariadne/app/Main.hs
@@ -19,8 +19,8 @@ import Ariadne.Wallet.Backend
 
 import qualified Ariadne.Cardano.Knit as Knit
 import qualified Ariadne.TaskManager.Knit as Knit
-import qualified Ariadne.Wallet.Knit as Knit
 import qualified Ariadne.UI.Vty.Knit as Knit
+import qualified Ariadne.Wallet.Knit as Knit
 import qualified Knit
 
 import Glue
@@ -73,4 +73,4 @@ main = do
     serviceAction :: IO ()
     serviceAction = uiAction `race_` cardanoAction
 
-  concurrently_ initAction serviceAction
+  withAsync initAction $ \_ -> serviceAction


### PR DESCRIPTION
Deadlock was possible when UI was closed very early, before
`walletInitAction` finishes. In this case `serviceAction` stops
(because it's raced with `uiAction`), but init action is still running.
Init action needs to run `CardanoMode`, but it only becomes possible
after one `MVar` is filled by `serviceAction` (which doesn't happen when
it's stopped early).

`withAsync` still makes these actions run concurrently, but if
`serviceAction` is stopped then init action will be cancelled.