### PR TITLE
AD-74 Add `copy-selection`

### DIFF
--- a/ariadne/app/Glue.hs
+++ b/ariadne/app/Glue.hs
@@ -11,6 +11,7 @@ module Glue
          -- * Wallet ↔ Vty
        , walletEventToUI
        , putWalletEventToUI
+       , uiGetSelectedItem
        ) where
 
 import Universum
@@ -28,9 +29,9 @@ import Ariadne.TaskManager.Face
 import Ariadne.UI.Vty.Face
 import Ariadne.Wallet.Face
 
-import qualified Knit
 import qualified Ariadne.TaskManager.Knit as Knit
 import qualified Ariadne.Wallet.Knit as Knit
+import qualified Knit
 
 ----------------------------------------------------------------------------
 -- Glue between Knit backend and Vty frontend
@@ -204,3 +205,27 @@ walletSelectionToPane us WalletSelection{..} = UiWalletPaneInfo{..}
             addrIdx:_ -> case _adAddresses ^? ix (fromIntegral addrIdx) of
               Nothing -> error "Invalid address index"
               Just (_, address) -> (Just UiWalletPaneInfoAddress, Just $ pretty address)
+
+-- | Get currently selected item from the backend and convert it to
+-- 'UiSelectedItem'.
+uiGetSelectedItem :: WalletFace -> IO UiSelectedItem
+uiGetSelectedItem WalletFace {walletGetSelection} =
+    walletGetSelection <&> \case
+        (Nothing, _) -> UiNoSelection
+        (Just WalletSelection {..}, us) ->
+            getItem (us ^? usWallets . ix (fromIntegral wsWalletIndex)) wsPath
+  where
+    getItem :: Maybe WalletData -> [Word] -> UiSelectedItem
+    getItem Nothing _ = error "Non-existing wallet is selected"
+    getItem (Just wd) [] = UiSelectedWallet (_wdName wd)
+    getItem (Just wd) (accIdx:rest) =
+        case wd ^? wdAccounts . ix (fromIntegral accIdx) of
+            Nothing -> error "Non-existing account is selected"
+            Just ad ->
+                case rest of
+                    [] -> UiSelectedAccount (_adName ad)
+                    [addrIdx] ->
+                        case ad ^? adAddresses . ix (fromIntegral addrIdx) of
+                            Nothing -> error "Non-existing address is selected"
+                            Just (_, addr) -> UiSelectedAddress (pretty addr)
+                    _ -> error "Invalid selection: too long"

--- a/ariadne/app/Main.hs
+++ b/ariadne/app/Main.hs
@@ -56,10 +56,12 @@ main = do
     knitExecContext putCommandOutput =
       Knit.CoreExecCtx (putCommandOutput . Knit.ppValue) :&
       Knit.CardanoExecCtx (runNat runCardanoMode) :&
-      Knit.WalletExecCtx (mkWalletFace putCommandOutput) :&
+      Knit.WalletExecCtx walletFace :&
       Knit.TaskManagerExecCtx taskManagerFace :&
-      Knit.UiExecCtx uiFace :&
+      Knit.UiExecCtx uiFace (uiGetSelectedItem walletFace) :&
       RNil
+      where
+        walletFace = mkWalletFace putCommandOutput
 
     knitFace = createKnitBackend knitExecContext taskManagerFace
 

--- a/ariadne/ariadne.cabal
+++ b/ariadne/ariadne.cabal
@@ -193,6 +193,7 @@ executable ariadne
     , containers
     , ansi-wl-pprint
     , text
+    , vector
   other-modules:
       Paths_ariadne
   default-language: Haskell2010

--- a/ariadne/src/Ariadne/Cardano/Face.hs
+++ b/ariadne/src/Ariadne/Cardano/Face.hs
@@ -20,7 +20,10 @@ module Ariadne.Cardano.Face
        , decodeTextAddress
 
        , AccountData (..)
+       , adAddresses
        , WalletData (..)
+       , wdName
+       , wdAccounts
        , UserSecret
        , usWallets
        ) where
@@ -39,7 +42,8 @@ import Pos.Diffusion.Types (Diffusion)
 import Pos.Launcher (HasConfigurations)
 import Pos.Util.CompileInfo (HasCompileInfo)
 import Pos.Util.UserSecret
-  (AccountData(..), UserSecret, WalletData(..), usWallets)
+  (AccountData(..), UserSecret, WalletData(..), adAddresses, usWallets,
+  wdAccounts, wdName)
 import Pos.WorkMode (EmptyMempoolExt, RealModeContext)
 
 data CardanoStatusUpdate = CardanoStatusUpdate

--- a/ariadne/src/Ariadne/Wallet/Backend.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend.hs
@@ -9,6 +9,8 @@ import Data.Constraint (withDict)
 import IiExtras ((:~>)(..))
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
+import Pos.Client.KeyStorage (getSecretDefault)
+
 import Ariadne.Config.Wallet (WalletConfig(..))
 import Ariadne.Wallet.Backend.Balance
 import Ariadne.Wallet.Backend.KeyStorage
@@ -41,7 +43,8 @@ createWalletBackend walletConfig = do
           , walletSelect = select this walletSelRef runCardanoMode
           , walletSend =
               sendTx this cf walletSelRef putCommandOutput
-          , walletSelection = readIORef walletSelRef
+          , walletGetSelection =
+              (,) <$> readIORef walletSelRef <*> runCardanoMode getSecretDefault
           , walletBalance = do
               addrs <- getSelectedAddresses this walletSelRef runCardanoMode
               runCardanoMode $ getBalance addrs

--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -23,13 +23,13 @@ import Universum
 
 import Ariadne.Config.Wallet (WalletConfig(..))
 import Control.Exception (Exception(displayException))
-import Control.Lens (ix, (%=), (<>=), (.=), zoom)
+import Control.Lens (ix, zoom, (%=), (.=), (<>=))
 import Control.Monad.Catch.Pure (Catch, CatchT, runCatchT)
 import Data.List (findIndex)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Text.Buildable
-import qualified Data.Vector as V (findIndex, fromList, mapMaybe, ifilter)
-import qualified Data.List.NonEmpty as NE
+import qualified Data.Vector as V (findIndex, fromList, ifilter, mapMaybe)
 import Formatting (bprint, int, (%))
 import IiExtras
 import Loot.Crypto.Bip39 (entropyToMnemonic, mnemonicToSeed)

--- a/ariadne/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/src/Ariadne/Wallet/Face.hs
@@ -61,7 +61,7 @@ data WalletFace =
     , walletRefreshUserSecret :: IO ()
     , walletSelect :: Maybe WalletReference -> [Word] -> IO ()
     , walletSend :: PassPhrase -> WalletReference -> NonEmpty TxOut -> IO TxId
-    , walletSelection :: IO (Maybe WalletSelection)
+    , walletGetSelection :: IO (Maybe WalletSelection, UserSecret)
     , walletBalance :: IO Coin
     }
 

--- a/ui/vty/ariadne-vty-ui.cabal
+++ b/ui/vty/ariadne-vty-ui.cabal
@@ -16,31 +16,33 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.7 && <5
-    , universum
-    , serokell-util
-    , containers
+      ansi-wl-pprint
+    , ansi-terminal
+    , base >=4.7 && <5
     , brick
+    , containers
+    , directory
+    , Hclip
     , vty
     , text
     , lens
     , transformers
     , loc
     , text-zipper
-    , ansi-wl-pprint
-    , ansi-terminal
+    , serokell-util
     , vector
     , ii-extras
-    , directory
     , named
     -- UI is independent of Knit, but provides Knit command bindings
     , knit
     , Earley
+    , universum
 
   exposed-modules:
       Ariadne.UI.Vty
       Ariadne.UI.Vty.App
       Ariadne.UI.Vty.AnsiToVty
+      Ariadne.UI.Vty.Clipboard
       Ariadne.UI.Vty.CommandHistory
       Ariadne.UI.Vty.Widget.Help
       Ariadne.UI.Vty.Widget.Logs

--- a/ui/vty/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/App.hs
@@ -12,8 +12,8 @@ import IiExtras
 
 import qualified Brick as B
 import qualified Brick.Widgets.Border as B
-import qualified Graphics.Vty as V
 import qualified Data.List.NonEmpty as NE
+import qualified Graphics.Vty as V
 
 import Ariadne.UI.Vty.CommandHistory
 import Ariadne.UI.Vty.Face

--- a/ui/vty/src/Ariadne/UI/Vty/Clipboard.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Clipboard.hs
@@ -1,0 +1,28 @@
+-- | Clipboard operations.
+
+module Ariadne.UI.Vty.Clipboard
+       ( copySelected
+       ) where
+
+import Universum
+
+import Control.Exception (Exception(..))
+import System.Hclip (setClipboard)
+
+import Ariadne.UI.Vty.Face
+
+data NoSelection = NoSelection deriving (Show)
+
+instance Exception NoSelection where
+    displayException NoSelection = "Nothing is selected"
+
+copySelected :: UiSelectedItem -> IO ()
+copySelected UiNoSelection = throwM NoSelection
+copySelected selection = setClipboard . toString $ formattedSelection
+  where
+    formattedSelection =
+        case selection of
+            UiNoSelection -> error "UiNoSelection is unreachable"
+            UiSelectedWallet name -> name
+            UiSelectedAccount name -> name
+            UiSelectedAddress addr -> addr

--- a/ui/vty/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Face.hs
@@ -7,6 +7,7 @@ module Ariadne.UI.Vty.Face
        , UiCommandEvent (..)
        , UiEvent (..)
        , UiOperation (..)
+       , UiSelectedItem (..)
        , UiLangFace (..)
        , UiFace (..)
 
@@ -83,6 +84,13 @@ data UiOperation
   = UiSelect [Word]
   | UiBalance
   | UiKill Natural
+
+-- | Item which is currently selected by the backend.
+data UiSelectedItem
+    = UiNoSelection
+    | UiSelectedWallet { uswWalletName :: !Text }
+    | UiSelectedAccount { usaAccountName :: !Text }
+    | UiSelectedAddress { usaAddress :: !Text }
 
 -- The backend language (Knit by default) interface as perceived by the UI.
 data UiLangFace =


### PR DESCRIPTION
This command is useful if one wants to copy selection without using mouse.
`UiExecCtx` (TUI) was extended to make it possible to know current selection.