### PR TITLE
[AD-103] Make widget get help data themselves instead of passing events

### DIFF
--- a/ariadne/app-qt/Glue.hs
+++ b/ariadne/app-qt/Glue.hs
@@ -58,6 +58,7 @@ knitFaceToUI UiFace{..} KnitFace{..} =
     , langPpExpr = Knit.ppExpr
     , langPpParseError = Knit.ppParseError
     , langParseErrSpans = Knit.parseErrorSpans
+    , langGetHelp = getKnitHelp (Proxy @components)
     , langMkExpr = convertOperation
     }
   where

--- a/ariadne/app-qt/Main.hs
+++ b/ariadne/app-qt/Main.hs
@@ -10,7 +10,6 @@ import Ariadne.Cardano.Backend
 import Ariadne.Cardano.Face (CardanoFace(..))
 import Ariadne.Config.Ariadne (AriadneConfig(..))
 import Ariadne.Config.CLI (getConfig)
-import Ariadne.Help
 import Ariadne.Knit.Backend
 import Ariadne.TaskManager.Backend
 import Ariadne.UI.Qt
@@ -44,9 +43,6 @@ main = do
     (mkWalletFace, walletInitAction) =
       mkWallet cardanoFace (putWalletEventToUI uiFace)
 
-    helpData :: [Doc]
-    helpData = generateKnitHelp (Proxy @Components)
-
     knitExecContext :: (Doc -> IO ()) -> Knit.ExecContext IO Components
     knitExecContext putCommandOutput =
       Knit.CoreExecCtx (putCommandOutput . Knit.ppValue) :&
@@ -58,10 +54,13 @@ main = do
     knitFace = createKnitBackend knitExecContext taskManagerFace
 
     uiAction, cardanoAction :: IO ()
-    uiAction = mkUiAction helpData $ knitFaceToUI uiFace knitFace
+    uiAction = mkUiAction (knitFaceToUI uiFace knitFace)
     cardanoAction = mkCardanoAction (putCardanoEventToUI uiFace)
+
+    initAction :: IO ()
+    initAction = walletInitAction
 
     serviceAction :: IO ()
     serviceAction = uiAction `race_` cardanoAction
 
-  withAsync walletInitAction $ \_ -> serviceAction
+  withAsync initAction $ \_ -> serviceAction

--- a/ariadne/app/Glue.hs
+++ b/ariadne/app/Glue.hs
@@ -59,6 +59,7 @@ knitFaceToUI UiFace{..} KnitFace{..} =
     , langPpExpr = Knit.ppExpr
     , langPpParseError = Knit.ppParseError
     , langParseErrSpans = Knit.parseErrorSpans
+    , langGetHelp = getKnitHelp (Proxy @components)
     , langMkExpr = convertOperation
     }
   where

--- a/ariadne/app/Main.hs
+++ b/ariadne/app/Main.hs
@@ -10,11 +10,9 @@ import Ariadne.Cardano.Backend
 import Ariadne.Cardano.Face (CardanoFace(..))
 import Ariadne.Config.Ariadne (AriadneConfig(..))
 import Ariadne.Config.CLI (getConfig)
-import Ariadne.Help
 import Ariadne.Knit.Backend
 import Ariadne.TaskManager.Backend
 import Ariadne.UI.Vty
-import Ariadne.UI.Vty.Face
 import Ariadne.Wallet.Backend
 
 import qualified Ariadne.Cardano.Knit as Knit
@@ -46,12 +44,6 @@ main = do
     (mkWalletFace, walletInitAction) =
       mkWallet cardanoFace (putWalletEventToUI uiFace)
 
-    helpData :: [Doc]
-    helpData = generateKnitHelp (Proxy @Components)
-
-    helpInitAction :: IO ()
-    helpInitAction = putUiEvent uiFace $ UiHelpUpdateData helpData
-
     knitExecContext :: (Doc -> IO ()) -> Knit.ExecContext IO Components
     knitExecContext putCommandOutput =
       Knit.CoreExecCtx (putCommandOutput . Knit.ppValue) :&
@@ -70,7 +62,7 @@ main = do
     cardanoAction = mkCardanoAction (putCardanoEventToUI uiFace)
 
     initAction :: IO ()
-    initAction = concurrently_ walletInitAction helpInitAction
+    initAction = walletInitAction
 
     serviceAction :: IO ()
     serviceAction = uiAction `race_` cardanoAction

--- a/ariadne/ariadne.cabal
+++ b/ariadne/ariadne.cabal
@@ -111,7 +111,7 @@ library
       Ariadne.Wallet.Face
       Ariadne.Knit.Backend
       Ariadne.Knit.Face
-      Ariadne.Help
+      Ariadne.Knit.Help
 
       Ariadne.Wallet.Cardano.Kernel.Actions
       Ariadne.Wallet.Cardano.Kernel.Types

--- a/ariadne/src/Ariadne/Knit/Backend.hs
+++ b/ariadne/src/Ariadne/Knit/Backend.hs
@@ -11,6 +11,7 @@ import IiExtras
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.Knit.Face
+import Ariadne.Knit.Help
 import Ariadne.TaskManager.Face
 import qualified Knit
 
@@ -51,7 +52,7 @@ createKnitBackend mkExecCtxs TaskManagerFace{..} =
           Right (Right v) -> do
             putCommandResult (Just taskId) $ KnitCommandSuccess v
             return v
-  in KnitFace putCommand
+  in KnitFace putCommand generateKnitHelp
   where
     commandProcs = Knit.commandProcs @components
     resolveProcNames =

--- a/ariadne/src/Ariadne/Knit/Face.hs
+++ b/ariadne/src/Ariadne/Knit/Face.hs
@@ -28,11 +28,13 @@ data KnitCommandHandle components
   }
 
 -- API for the knit interpreter.
-newtype KnitFace components =
+data KnitFace components =
   KnitFace
     {
       -- Execute a knit expression asynchronously. Does not block unless the
       -- queue of commands is full (should not normally happen) -- the result of
       -- execution will be returned later as an application event.
       putKnitCommand :: KnitCommandHandle components -> Knit.Expr Knit.CommandId components -> IO (Maybe TaskId)
+      -- Get list of help items for each Knit command available
+    , getKnitHelp :: Proxy components -> [Doc]
     }

--- a/ariadne/src/Ariadne/Knit/Help.hs
+++ b/ariadne/src/Ariadne/Knit/Help.hs
@@ -1,4 +1,4 @@
-module Ariadne.Help (generateKnitHelp) where
+module Ariadne.Knit.Help (generateKnitHelp) where
 
 import qualified Data.Text as T
 import IiExtras

--- a/ui/qt/src/Ariadne/UI/Qt.hs
+++ b/ui/qt/src/Ariadne/UI/Qt.hs
@@ -8,8 +8,6 @@ import Universum
 import Control.Concurrent
 import Control.Monad.Extra (loopM)
 
-import Text.PrettyPrint.ANSI.Leijen (Doc)
-
 import Ariadne.UI.Qt.Face (UiEvent(..), UiFace(..), UiLangFace)
 
 import Foreign.Hoppy.Runtime (withScopedPtr)
@@ -24,7 +22,7 @@ import Control.Concurrent.STM.TBQueue
 import Ariadne.UI.Qt.MainWindow
 import Ariadne.UI.Qt.UI
 
-type UiAction = [Doc] -> UiLangFace -> IO ()
+type UiAction = UiLangFace -> IO ()
 
 type UiEventBQueue = TBQueue UiEvent
 
@@ -34,16 +32,14 @@ createAriadneUI = do
   dispatcherIORef :: IORef (Maybe QObject.QObject) <- newIORef Nothing
   return (mkUiFace eventQueue dispatcherIORef, runUIEventLoop eventQueue dispatcherIORef)
 
-runUIEventLoop :: UiEventBQueue -> IORef (Maybe QObject.QObject) -> [Doc] -> UiLangFace -> IO ()
-runUIEventLoop eventIORef dispatcherIORef helpData langFace =
+runUIEventLoop :: UiEventBQueue -> IORef (Maybe QObject.QObject) -> UiAction
+runUIEventLoop eventIORef dispatcherIORef langFace =
   runInBoundThread $ withScopedPtr (getArgs >>= QApplication.new) $ \_ -> do
     eventDispatcher <- QObject.new
     writeIORef dispatcherIORef $ Just eventDispatcher
     mainWindow <- initMainWindow langFace
     void $ Event.onEvent eventDispatcher $
       \(_ :: QEvent.QEvent) -> handleAppEvent eventIORef mainWindow >> return True
-
-    runUI (handleMainWindowEvent $ UiHelpUpdateData helpData) mainWindow
 
     QCoreApplication.exec
 

--- a/ui/qt/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt/src/Ariadne/UI/Qt/Face.hs
@@ -68,7 +68,6 @@ data UiEvent
   = UiCommandEvent UiCommandId UiCommandEvent
   | UiCardanoEvent UiCardanoEvent
   | UiWalletEvent UiWalletEvent
-  | UiHelpUpdateData [Doc]
 
 data UiOperation
   = UiSelect [Word]
@@ -84,6 +83,7 @@ data UiLangFace =
   , langPpExpr :: expr -> Doc
   , langPpParseError :: err -> Doc
   , langParseErrSpans :: err -> [Span]
+  , langGetHelp :: [Doc]
   , langMkExpr :: UiOperation -> Either Text expr
   }
 

--- a/ui/qt/src/Ariadne/UI/Qt/MainWindow.hs
+++ b/ui/qt/src/Ariadne/UI/Qt/MainWindow.hs
@@ -47,7 +47,7 @@ initMainWindow langFace = do
   (qRepl, repl) <- initRepl langFace
   (qMenuBar, menuBar) <- initMenuBar
   (qLogs, logs) <- initLogs
-  (qHelp, help) <- initHelp
+  (qHelp, help) <- initHelp langFace
 
   QMainWindow.setMenuBar mainWindow qMenuBar
   QWidget.setParentWithFlags qLogs mainWindow Dialog
@@ -85,8 +85,6 @@ handleMainWindowEvent = \case
       _ -> return ()
   UiWalletEvent UiWalletUpdate{..} ->
     magnify walletL $ handleWalletEvent $ WalletUpdateEvent wuTrees wuSelection
-  UiHelpUpdateData docs ->
-    magnify helpL $ setHelpData docs
 
 connectGlobalSignals :: UI MainWindow ()
 connectGlobalSignals = do

--- a/ui/qt/src/Ariadne/UI/Qt/Widgets/Help.hs
+++ b/ui/qt/src/Ariadne/UI/Qt/Widgets/Help.hs
@@ -2,7 +2,6 @@ module Ariadne.UI.Qt.Widgets.Help
     ( Help
     , initHelp
     , showHelpWindow
-    , setHelpData
     ) where
 
 import Universum
@@ -21,6 +20,7 @@ import qualified Graphics.UI.Qtah.Widgets.QVBoxLayout as QVBoxLayout
 import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
 
 import Ariadne.UI.Qt.AnsiToHTML
+import Ariadne.UI.Qt.Face
 import Ariadne.UI.Qt.UI
 
 data Help =
@@ -31,8 +31,8 @@ data Help =
 
 makeLensesWith postfixLFields ''Help
 
-initHelp :: IO (QDialog.QDialog, Help)
-initHelp = do
+initHelp :: UiLangFace -> IO (QDialog.QDialog, Help)
+initHelp UiLangFace{..} = do
   dialog <- QDialog.new
   QWidget.setWindowTitle dialog ("Help" :: String)
   QWidget.resizeRaw dialog 800 600
@@ -41,6 +41,8 @@ initHelp = do
 
   helpEdit <- QTextEdit.new
   QTextEdit.setReadOnly helpEdit True
+  QTextEdit.setHtml helpEdit $ toString $ T.intercalate "<br>" $
+    (simpleDocToHTML . PP.renderPretty 0.985 200) <$> langGetHelp
 
   QLayout.addWidget layout helpEdit
 
@@ -51,10 +53,3 @@ showHelpWindow = do
   dialog <- view dialogL
 
   liftIO $ QWidget.show dialog
-
-setHelpData :: [PP.Doc] -> UI Help ()
-setHelpData docs = do
-  helpEdit <- view helpEditL
-
-  liftIO $ QTextEdit.setHtml helpEdit $ toString $ T.intercalate "<br>" $
-    (simpleDocToHTML . PP.renderPretty 0.985 200) <$> docs

--- a/ui/vty/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/App.hs
@@ -77,7 +77,7 @@ initialAppState langFace history =
     , appStateRepl = initReplWidget langFace history AppBrickReplOutput AppBrickReplInput
     , appStateMenu = initMenuWidget menuItems 0 AppBrickMenu
     , appStateStatus = initStatusWidget
-    , appStateHelp = initHelpWidget AppBrickHelp
+    , appStateHelp = initHelpWidget langFace AppBrickHelp
     , appStateLogs = initLogsWidget AppBrickLogs
     , appStateWalletTree = initWalletTreeWidget AppBrickWalletTree
     , appStateWalletPane = initWalletPaneWidget AppBrickWalletPane
@@ -384,9 +384,6 @@ handleAppEvent langFace ev =
             handleStatusWidgetEvent $
               StatusUpdateEvent statusUpdate
       return AppInProgress
-    B.AppEvent (UiHelpUpdateData doc) -> do
-        zoom appStateHelpL $ handleHelpWidgetEvent $ HelpData doc
-        return AppInProgress
     B.AppEvent (UiCommandEvent commandEvent) -> do
       case commandEvent of
         UiCommandHelp -> do

--- a/ui/vty/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Face.hs
@@ -77,7 +77,6 @@ data UiEvent
   = UiCommandResultEvent UiCommandId UiCommandResultEvent
   | UiCardanoEvent UiCardanoEvent
   | UiWalletEvent UiWalletEvent
-  | UiHelpUpdateData [Doc]
   | UiCommandEvent UiCommandEvent
 
 data UiOperation
@@ -100,6 +99,7 @@ data UiLangFace =
   , langPpExpr :: expr -> Doc
   , langPpParseError :: err -> Doc
   , langParseErrSpans :: err -> [Span]
+  , langGetHelp :: [Doc]
   , langMkExpr :: UiOperation -> expr
   }
 

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Help.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Help.hs
@@ -3,8 +3,9 @@ module Ariadne.UI.Vty.Widget.Help where
 import Universum
 
 import Ariadne.UI.Vty.AnsiToVty
+import Ariadne.UI.Vty.Face
 import Ariadne.UI.Vty.Scrolling
-import Control.Lens (makeLensesWith, zoom)
+import Control.Lens (makeLensesWith)
 import IiExtras
 
 import qualified Brick as B
@@ -21,10 +22,11 @@ makeLensesWith postfixLFields ''HelpWidgetState
 
 initHelpWidget
   :: (Ord n, Show n)
-  => n
+  => UiLangFace
+  -> n
   -> HelpWidgetState n
-initHelpWidget name = HelpWidgetState
-  { helpWidgetData = []
+initHelpWidget UiLangFace{..} name = HelpWidgetState
+  { helpWidgetData = langGetHelp
   , helpWidgetBrickName = name
   }
 
@@ -58,7 +60,6 @@ data HelpCompleted = HelpCompleted | HelpInProgress
 
 data HelpWidgetEvent
   = HelpScrollingEvent ScrollingAction
-  | HelpData [PP.Doc]
 
 handleHelpWidgetEvent
   :: (Ord n, Show n)
@@ -69,6 +70,3 @@ handleHelpWidgetEvent ev = do
   case ev of
     HelpScrollingEvent action ->
       lift $ handleScrollingEvent name action
-    HelpData doc -> do
-      zoom helpWidgetDataL $ modify $ const doc
-      lift $ B.invalidateCacheEntry name


### PR DESCRIPTION
Help update event was counterintuitive and unneccessary.
Help generation is now explicitly part of Knit backend and `KnitFace`.