### PR TITLE
[AD-118] Add address checkpoints

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -36,6 +36,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet (
   , hdAddressAddress
   , hdAddressIsUsed
   , hdAddressChain
+  , hdAddressCheckpoints
     -- ** Composite lenses
   , hdAccountRootId
   , hdAddressRootId
@@ -174,8 +175,9 @@ data HdAccount = HdAccount {
       -- | Account name
     , _hdAccountName        :: AccountName
 
-      -- | State of the " wallet " as stipulated by the wallet specification
-    , _hdAccountCheckpoints :: NonEmpty Checkpoint
+      -- | Part of the wallet state pertaining to this account,
+      -- as stipulated by the wallet specification
+    , _hdAccountCheckpoints :: NonEmpty AccCheckpoint
     }
 
 -- | Address in an account of a HD wallet
@@ -196,6 +198,10 @@ data HdAddress = HdAddress {
       -- Invariant: this must match the actual derivation scheme which
       -- yields _hdAddressAddress.
     , _hdAddressChain   :: HdAddressChain
+
+      -- | Part of the wallet state pertaining to this address,
+      -- as stipulated by the wallet specification
+    , _hdAddressCheckpoints :: NonEmpty AddrCheckpoint
     }
 
 makeLenses ''HdAccountId

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
@@ -93,7 +93,7 @@ createHdRoot rootId name hasPass assurance created =
 -- store a public key or an address or something?
 createHdAccount :: HdRootId
                 -> AccountName
-                -> Checkpoint
+                -> AccCheckpoint
                 -> Update' HdWallets CreateHdAccountError HdAccountId
 createHdAccount rootId name checkpoint = do
     -- Check that the root ID exists
@@ -126,8 +126,9 @@ createHdAccount rootId name checkpoint = do
 createHdAddress :: HdAddressId
                 -> InDb Core.Address
                 -> HdAddressChain
+                -> AddrCheckpoint
                 -> Update' HdWallets CreateHdAddressError ()
-createHdAddress addrId address chain = do
+createHdAddress addrId address chain checkpoint = do
     -- Check that the account ID exists
     zoomHdAccountId CreateHdAddressUnknown (addrId ^. hdAddressIdParent) $
       return ()
@@ -139,8 +140,9 @@ createHdAddress addrId address chain = do
   where
     hdAddress :: HdAddress
     hdAddress = HdAddress {
-          _hdAddressId      = addrId
-        , _hdAddressAddress = address
-        , _hdAddressIsUsed  = error "TODO: _hdAddressIsUsed"
-        , _hdAddressChain   = chain
+          _hdAddressId          = addrId
+        , _hdAddressAddress     = address
+        , _hdAddressIsUsed      = error "TODO: _hdAddressIsUsed"
+        , _hdAddressChain       = chain
+        , _hdAddressCheckpoints = checkpoint :| []
         }

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
@@ -70,16 +70,22 @@ check f g = using' f (const g)
   Computed balances information
 -------------------------------------------------------------------------------}
 
+-- | Current balance of the entire root
 hdRootBalance :: HdRootId -> HdQuery Integer
-hdRootBalance rootId = sumCoins
-                     . map hdAccountBalance
-                     . toList
-                     . IxSet.getEQ rootId
-                     . view hdWalletsAccounts
+hdRootBalance rootId =
+    sumCoins
+    . map hdAddressBalance
+    . toList
+    . IxSet.getEQ rootId
+    . view hdWalletsAddresses
 
 -- | Current balance of an account
 hdAccountBalance :: HdAccount -> Coin
-hdAccountBalance = view (hdAccountCheckpoints . currentUtxoBalance)
+hdAccountBalance = view (hdAccountCheckpoints . currentAccUtxoBalance)
+
+-- | Current balance of an address
+hdAddressBalance :: HdAddress -> Coin
+hdAddressBalance = view (hdAddressCheckpoints . currentAddrUtxoBalance)
 
 {-------------------------------------------------------------------------------
   Accumulate across wallets/accounts

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
@@ -72,12 +72,11 @@ check f g = using' f (const g)
 
 -- | Current balance of the entire root
 hdRootBalance :: HdRootId -> HdQuery Integer
-hdRootBalance rootId =
-    sumCoins
-    . map hdAddressBalance
-    . toList
-    . IxSet.getEQ rootId
-    . view hdWalletsAddresses
+hdRootBalance rootId = sumCoins
+                     . map hdAccountBalance
+                     . toList
+                     . IxSet.getEQ rootId
+                     . view hdWalletsAccounts
 
 -- | Current balance of an account
 hdAccountBalance :: HdAccount -> Coin

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
@@ -2,26 +2,32 @@
 module Ariadne.Wallet.Cardano.Kernel.DB.Spec (
     -- * Wallet state as mandated by the spec
     Pending(..)
-  , Checkpoint(..)
-  , Checkpoints
+  , AccCheckpoint(..)
+  , AccCheckpoints
+  , AddrCheckpoint(..)
+  , AddrCheckpoints
   , emptyPending
   , singletonPending
   , unionPending
   , removePending
     -- ** Lenses
   , pendingTransactions
-  , checkpointUtxo
-  , checkpointUtxoBalance
-  , checkpointExpected
-  , checkpointPending
-  , checkpointBlockMeta
+  , accCheckpointUtxo
+  , accCheckpointUtxoBalance
+  , accCheckpointExpected
+  , accCheckpointPending
+  , accCheckpointBlockMeta
+  , addrCheckpointUtxo
+  , addrCheckpointUtxoBalance
     -- ** Lenses into the current checkpoint
-  , currentCheckpoint
-  , currentUtxo
-  , currentUtxoBalance
-  , currentExpected
-  , currentPending
-  , currentBlockMeta
+  , currentAccCheckpoint
+  , currentAccUtxo
+  , currentAccUtxoBalance
+  , currentAccExpected
+  , currentAccPending
+  , currentAccBlockMeta
+  , currentAddrCheckpoint
+  , currentAddrUtxoBalance
   ) where
 
 import Universum
@@ -40,13 +46,17 @@ import qualified Pos.Txp as Core
 import Ariadne.Wallet.Cardano.Kernel.DB.BlockMeta
 import Ariadne.Wallet.Cardano.Kernel.DB.InDb
 
+-- This file belongs under Kernel/DB/Spec/State.hs or something similar.
+-- However, we don't move it because we want to minimize diff with IOHK.
+-- The downside is that Kernel.DB.Spec.Update imports Kernel.DB.Spec.
+
 {-------------------------------------------------------------------------------
   Wallet state as mandated by the spec
 -------------------------------------------------------------------------------}
 
 -- | Pending transactions
 data Pending = Pending {
-      _pendingTransactions :: InDb (Map Core.TxId Core.TxAux)
+      _pendingTransactions :: !(InDb (Map Core.TxId Core.TxAux))
      } deriving Eq
 
 
@@ -70,44 +80,63 @@ removePending ids (Pending (InDb old)) = Pending (InDb $ old `withoutKeys` ids)
         withoutKeys :: Ord k => Map k a -> Set k -> Map k a
         m `withoutKeys` s = m `M.difference` M.fromSet (const ()) s
 
--- | Per-wallet state
---
--- This is the same across all wallet types.
-data Checkpoint = Checkpoint {
-      _checkpointUtxo        :: InDb Core.Utxo
-    , _checkpointUtxoBalance :: InDb Core.Coin
-    , _checkpointExpected    :: InDb Core.Utxo
-    , _checkpointPending     :: Pending
-    , _checkpointBlockMeta   :: BlockMeta
+-- | Per-account state
+data AccCheckpoint = AccCheckpoint {
+      -- Invariant: this must match the union of utxos of all
+      -- addresses in this account.
+      _accCheckpointUtxo        :: !(InDb Core.Utxo)
+      -- Invariant: this must match the sum of balances of all
+      -- addresses in this account.
+    , _accCheckpointUtxoBalance :: !(InDb Core.Coin)
+    , _accCheckpointExpected    :: !(InDb Core.Utxo)
+    , _accCheckpointPending     :: !Pending
+    , _accCheckpointBlockMeta   :: !BlockMeta
     }
 
--- | List of checkpoints
-type Checkpoints = NonEmpty Checkpoint
+-- | List of account checkpoints
+type AccCheckpoints = NonEmpty AccCheckpoint
+
+-- | Per-address state
+data AddrCheckpoint = AddrCheckpoint {
+      _addrCheckpointUtxo        :: !(InDb Core.Utxo)
+    , _addrCheckpointUtxoBalance :: !(InDb Core.Coin)
+    }
+
+-- | List of address checkpoints
+type AddrCheckpoints = NonEmpty AddrCheckpoint
 
 makeLenses ''Pending
-makeLenses ''Checkpoint
+makeLenses ''AccCheckpoint
+makeLenses ''AddrCheckpoint
 
 deriveSafeCopySimple 1 'base ''Pending
-deriveSafeCopySimple 1 'base ''Checkpoint
+deriveSafeCopySimple 1 'base ''AccCheckpoint
+deriveSafeCopySimple 1 'base ''AddrCheckpoint
 
 {-------------------------------------------------------------------------------
   Lenses for accessing current checkpoint
 -------------------------------------------------------------------------------}
 
-currentCheckpoint :: Lens' Checkpoints Checkpoint
-currentCheckpoint = neHead
+currentAccCheckpoint :: Lens' AccCheckpoints AccCheckpoint
+currentAccCheckpoint = neHead
 
-currentUtxo        :: Lens' Checkpoints Core.Utxo
-currentUtxoBalance :: Lens' Checkpoints Core.Coin
-currentExpected    :: Lens' Checkpoints Core.Utxo
-currentPending     :: Lens' Checkpoints Pending
-currentBlockMeta   :: Lens' Checkpoints BlockMeta
+currentAccUtxo        :: Lens' AccCheckpoints Core.Utxo
+currentAccUtxoBalance :: Lens' AccCheckpoints Core.Coin
+currentAccExpected    :: Lens' AccCheckpoints Core.Utxo
+currentAccPending     :: Lens' AccCheckpoints Pending
+currentAccBlockMeta   :: Lens' AccCheckpoints BlockMeta
 
-currentUtxo        = currentCheckpoint . checkpointUtxo        . fromDb
-currentUtxoBalance = currentCheckpoint . checkpointUtxoBalance . fromDb
-currentExpected    = currentCheckpoint . checkpointExpected    . fromDb
-currentPending     = currentCheckpoint . checkpointPending
-currentBlockMeta   = currentCheckpoint . checkpointBlockMeta
+currentAccUtxo        = currentAccCheckpoint . accCheckpointUtxo        . fromDb
+currentAccUtxoBalance = currentAccCheckpoint . accCheckpointUtxoBalance . fromDb
+currentAccExpected    = currentAccCheckpoint . accCheckpointExpected    . fromDb
+currentAccPending     = currentAccCheckpoint . accCheckpointPending
+currentAccBlockMeta   = currentAccCheckpoint . accCheckpointBlockMeta
+
+currentAddrCheckpoint :: Lens' AddrCheckpoints AddrCheckpoint
+currentAddrCheckpoint = neHead
+
+currentAddrUtxoBalance :: Lens' AddrCheckpoints Core.Coin
+currentAddrUtxoBalance = currentAddrCheckpoint . addrCheckpointUtxoBalance . fromDb
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
@@ -3,9 +3,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Update (
     -- * Errors
     NewPendingFailed(..)
     -- * Updates
-  , newPending
-  , applyBlock
-  , switchToFork
+  , UpdatableWalletState(newPending, applyBlock, switchToFork)
   ) where
 
 import Universum
@@ -36,49 +34,59 @@ deriveSafeCopySimple 1 'base ''NewPendingFailed
   Wallet spec mandated updates
 -------------------------------------------------------------------------------}
 
--- | Insert new pending transaction into the specified wallet
---
--- NOTE: Transactions to be inserted must be fully constructed and signed; we do
--- not offer input selection at this layer. Instead, callers must get a snapshot
--- of the database, construct a transaction asynchronously, and then finally
--- submit the transaction. It is of course possible that the state of the
--- database has changed at this point, possibly making the generated transaction
--- invalid; 'newPending' therefore returns whether or not the transaction could
--- be inserted. If this fails, the process must be started again. This is
--- important for a number of reasons:
---
--- * Input selection may be an expensive computation, and we don't want to
---   lock the database while input selection is ongoing.
--- * Transactions may be signed off-site (on a different machine or on a
---   a specialized hardware device).
--- * We do not actually have access to the key storage inside the DB layer
---   (and do not store private keys) so we cannot actually sign transactions.
-newPending :: InDb (Core.TxAux)
-           -> Update' Checkpoints NewPendingFailed ()
-newPending _tx = error "newPending"
+class UpdatableWalletState state where
+    -- | Insert new pending transaction into the specified wallet
+    --
+    -- NOTE: Transactions to be inserted must be fully constructed and signed; we do
+    -- not offer input selection at this layer. Instead, callers must get a snapshot
+    -- of the database, construct a transaction asynchronously, and then finally
+    -- submit the transaction. It is of course possible that the state of the
+    -- database has changed at this point, possibly making the generated transaction
+    -- invalid; 'newPending' therefore returns whether or not the transaction could
+    -- be inserted. If this fails, the process must be started again. This is
+    -- important for a number of reasons:
+    --
+    -- * Input selection may be an expensive computation, and we don't want to
+    --   lock the database while input selection is ongoing.
+    -- * Transactions may be signed off-site (on a different machine or on a
+    --   a specialized hardware device).
+    -- * We do not actually have access to the key storage inside the DB layer
+    --   (and do not store private keys) so we cannot actually sign transactions.
+    newPending
+        :: InDb (Core.TxAux)
+        -> Update' state NewPendingFailed ()
 
--- | Apply a block to /all/ wallets' UTxO.
---
--- Ideally the block is prefiltered (see 'prefilter').
-applyBlock :: (ResolvedBlock, BlockMeta) -> Checkpoints -> Checkpoints
-applyBlock (_resolvedBlock, _blockMeta) = error "applyBlock"
+    -- | Apply a block to /all/ wallets' UTxO.
+    --
+    -- Ideally the block is prefiltered (see 'prefilter').
+    applyBlock :: (ResolvedBlock, BlockMeta) -> state -> state
 
--- | Rollback
---
--- This is an internal function only, and not exported. See 'switchToFork'.
-rollback :: Checkpoints -> Checkpoints
-rollback = error "rollback"
+    -- | Rollback
+    --
+    -- This is an internal function only, and not exported. See 'switchToFork'.
+    rollback :: state -> state
 
--- | Switch to a fork
-switchToFork :: Int  -- ^ Number of blocks to rollback
-             -> OldestFirst [] (ResolvedBlock, BlockMeta)  -- ^ Blocks to apply
-             -> Checkpoints -> Checkpoints
-switchToFork = \n bs -> applyBlocks (getOldestFirst bs) . rollbacks n
-  where
-    applyBlocks :: [(ResolvedBlock, BlockMeta)] -> Checkpoints -> Checkpoints
-    applyBlocks []     = identity
-    applyBlocks (b:bs) = applyBlocks bs . applyBlock b
+    -- | Switch to a fork
+    switchToFork
+        :: Int  -- ^ Number of blocks to rollback
+        -> OldestFirst [] (ResolvedBlock, BlockMeta)  -- ^ Blocks to apply
+        -> state -> state
+    switchToFork = \n bs -> applyBlocks (getOldestFirst bs) . rollbacks n
+      where
+        applyBlocks :: [(ResolvedBlock, BlockMeta)] -> state -> state
+        applyBlocks []     = identity
+        applyBlocks (b:bs) = applyBlocks bs . applyBlock b
 
-    rollbacks :: Int -> Checkpoints -> Checkpoints
-    rollbacks 0 = identity
-    rollbacks n = rollbacks (n - 1) . rollback
+        rollbacks :: Int -> state -> state
+        rollbacks 0 = identity
+        rollbacks n = rollbacks (n - 1) . rollback
+
+instance UpdatableWalletState AccCheckpoints where
+    newPending _tx = error "AccCheckpoints: newPending"
+    applyBlock (_resolvedBlock, _blockMeta) = error "AccCheckpoints: applyBlock"
+    rollback = error "AccCheckpoints: rollback"
+
+instance UpdatableWalletState AddrCheckpoints where
+    newPending _tx = error "AddrCheckpoints: newPending"
+    applyBlock (_resolvedBlock, _blockMeta) = error "AddrCheckpoints: applyBlock"
+    rollback = error "AddrCheckpoints: rollback"


### PR DESCRIPTION
There are a few disputable decisions made here, please review with care.

* Account checkpoints remain in place, only the type `Checkpoint` is renamed to `AccCheckpoint`.
* Address checkpoints are added. They contain address balance.
* All state-modifying functions (`applyBlock`, `newPending`, `switchToFork`) are now generalized to work on `UpdatableWalletState`. There are two instances of it (both are stubbed with `error`): one for `AccCheckpoints` and the other for `AddrCheckpoints`.