### PR TITLE
[AD-128] Get rid of cardano-sl-wallet dependency

### DIFF
--- a/ariadne/ariadne.cabal
+++ b/ariadne/ariadne.cabal
@@ -51,7 +51,6 @@ library
     , formatting
     , http-client
     , http-client-tls
-    , hashable
     , filepath
     , kademlia
     , knit

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Decrypt.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Decrypt.hs
@@ -7,59 +7,32 @@ module Ariadne.Wallet.Cardano.Kernel.Decrypt
        , isTxEntryInteresting
        , buildTHEntryExtra
 
-       , WalletDecrCredentials
-       , eskToWalletDecrCredentials
+       , HDPassphrase
+       , eskToHDPassphrase
        , selectOwnAddresses
        , decryptAddress
        ) where
 
 import Universum
 
-import Data.Hashable (Hashable(..))
 import Data.List ((!!))
 import qualified Data.List.NonEmpty as NE
 import Pos.Client.Txp.History (TxHistoryEntry(..))
 import Pos.Core
   (Address(..), ChainDifficulty, Timestamp, aaPkDerivationPath,
-  addrAttributesUnwrapped, makeRootPubKeyAddress)
+  addrAttributesUnwrapped)
 import Pos.Core.Txp
   (Tx(..), TxIn(..), TxOut, TxOutAux(..), TxUndo, toaOut, txOutAddress)
 import Pos.Crypto
   (EncryptedSecretKey, HDPassphrase, WithHash(..), deriveHDPassphrase,
   encToPublic, unpackHDAddressAttr)
-import Pos.Util.Servant (encodeCType)
 import Serokell.Util (enumerate)
 
--- | Client hash
-newtype CHash = CHash Text
-    deriving (Show, Eq, Ord, Generic, Buildable)
-
-instance Hashable CHash where
-    hashWithSalt s (CHash h) = hashWithSalt s h
-
-newtype CId w = CId CHash
-    deriving (Show, Eq, Ord, Generic, Hashable, Buildable)
-
--- instance Buildable (SecureLog $ CId w) where
---     build _ = "<id>"
-
--- | Marks address as belonging to wallet set.
-data Wal = Wal
-    deriving (Show, Generic)
-
 data WAddressMeta = WAddressMeta
-    { _wamWalletId     :: CId Wal
-    , _wamAccountIndex :: Word32
+    { _wamAccountIndex :: Word32
     , _wamAddressIndex :: Word32
     , _wamAddress      :: Address
     } deriving (Eq, Ord, Show, Generic, Typeable)
-
--- makeClassy ''WAddressMeta
--- instance Hashable WAddressMeta
--- instance Buildable WAddressMeta where
---     build WAddressMeta{..} =
---         F.bprint (F.build%"@"%F.build%"@"%F.build%" ("%F.build%")")
---         _wamWalletId _wamAccountIndex _wamAddressIndex _wamAddress
 
 type OwnTxInOuts = [((TxIn, TxOutAux), WAddressMeta)]
 
@@ -82,11 +55,11 @@ isTxEntryInteresting THEntryExtra{..} =
     else Nothing
 
 buildTHEntryExtra
-    :: WalletDecrCredentials
+    :: HDPassphrase
     -> (WithHash Tx, TxUndo)
     -> (Maybe ChainDifficulty, Maybe Timestamp)
     -> THEntryExtra
-buildTHEntryExtra wdc (WithHash tx txId, NE.toList -> undoL) (mDiff, mTs) =
+buildTHEntryExtra hdPass (WithHash tx txId, NE.toList -> undoL) (mDiff, mTs) =
     let (UnsafeTx (NE.toList -> inps) (NE.toList -> outs) _) = tx
         toTxInOut (idx, out) = (TxInUtxo txId idx, TxOutAux out)
 
@@ -96,33 +69,30 @@ buildTHEntryExtra wdc (WithHash tx txId, NE.toList -> undoL) (mDiff, mTs) =
         txInputs = map (toaOut . snd) resolvedInputs
 
         theeInputs :: [((TxIn, TxOutAux), WAddressMeta)]
-        theeInputs = selectOwnAddresses wdc (txOutAddress . toaOut . snd) resolvedInputs
+        theeInputs = selectOwnAddresses hdPass (txOutAddress . toaOut . snd) resolvedInputs
         theeOutputsRaw :: [((Word32, TxOut), WAddressMeta)]
-        theeOutputsRaw = selectOwnAddresses wdc (txOutAddress . snd) (enumerate outs)
+        theeOutputsRaw = selectOwnAddresses hdPass (txOutAddress . snd) (enumerate outs)
         theeOutputs = map (first toTxInOut) theeOutputsRaw
         theeTxEntry = THEntry txId tx mDiff txInputs txOutgoings mTs in
     THEntryExtra {..}
 
-type WalletDecrCredentials = (HDPassphrase, CId Wal)
-
-eskToWalletDecrCredentials :: EncryptedSecretKey -> WalletDecrCredentials
-eskToWalletDecrCredentials encSK = do
+eskToHDPassphrase :: EncryptedSecretKey -> HDPassphrase
+eskToHDPassphrase encSK = do
     let pubKey = encToPublic encSK
     let hdPass = deriveHDPassphrase pubKey
-    let wCId = encodeCType $ makeRootPubKeyAddress pubKey
-    (hdPass, wCId)
+    hdPass
 
 selectOwnAddresses
-    :: WalletDecrCredentials
+    :: HDPassphrase
     -> (a -> Address)
     -> [a]
     -> [(a, WAddressMeta)]
-selectOwnAddresses wdc getAddr =
-    mapMaybe (\a -> (a,) <$> decryptAddress wdc (getAddr a))
+selectOwnAddresses hdPass getAddr =
+    mapMaybe (\a -> (a,) <$> decryptAddress hdPass (getAddr a))
 
-decryptAddress :: WalletDecrCredentials -> Address -> Maybe WAddressMeta
-decryptAddress (hdPass, wCId) addr = do
+decryptAddress :: HDPassphrase -> Address -> Maybe WAddressMeta
+decryptAddress hdPass addr = do
     hdPayload <- aaPkDerivationPath $ addrAttributesUnwrapped addr
     derPath <- unpackHDAddressAttr hdPass hdPayload
     guard $ length derPath == 2
-    pure $ WAddressMeta wCId (derPath !! 0) (derPath !! 1) addr
+    pure $ WAddressMeta (derPath !! 0) (derPath !! 1) addr

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/PrefilterTx.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/PrefilterTx.hs
@@ -15,8 +15,8 @@ import Formatting (bprint, (%))
 import Serokell.Util (listJson, mapJson)
 
 import Ariadne.Wallet.Cardano.Kernel.Decrypt
-  (WalletDecrCredentials, eskToWalletDecrCredentials, selectOwnAddresses)
-import Pos.Core (Address(..), HasConfiguration)
+  (HDPassphrase, eskToHDPassphrase, selectOwnAddresses)
+import Pos.Core (Address(..))
 import Pos.Core.Txp (TxIn(..), TxOut(..), TxOutAux(..))
 import Pos.Crypto (EncryptedSecretKey)
 import Pos.Txp.Toil.Types (Utxo)
@@ -51,35 +51,35 @@ prefilterBlock esk block = PrefilteredBlock {
   where
     inpss :: [[(TxIn, TxOutAux)]]
     outss :: [Utxo]
-    (inpss, outss) = unzip $ map (prefilterTx wdc) (block ^. rbTxs)
+    (inpss, outss) = unzip $ map (prefilterTx hdPass) (block ^. rbTxs)
 
-    wdc :: WalletDecrCredentials
-    wdc = eskToWalletDecrCredentials esk
+    hdPass :: HDPassphrase
+    hdPass = eskToHDPassphrase esk
 
-prefilterTx :: WalletDecrCredentials
+prefilterTx :: HDPassphrase
             -> ResolvedTx
             -> ([(TxIn, TxOutAux)], Utxo)
-prefilterTx wdc tx = (
-      ourResolvedTxPairs wdc (toList (tx ^. rtxInputs  . fromDb))
-    , ourUtxo_           wdc         (tx ^. rtxOutputs . fromDb)
+prefilterTx hdPass tx = (
+      ourResolvedTxPairs hdPass (toList (tx ^. rtxInputs  . fromDb))
+    , ourUtxo_           hdPass         (tx ^. rtxOutputs . fromDb)
     )
 
-ourResolvedTxPairs :: WalletDecrCredentials
+ourResolvedTxPairs :: HDPassphrase
                    -> [(TxIn, TxOutAux)]
                    -> [(TxIn, TxOutAux)]
-ourResolvedTxPairs wdc = ours wdc (txOutAddress . toaOut . snd)
+ourResolvedTxPairs hdPass = ours hdPass (txOutAddress . toaOut . snd)
 
 ourUtxo :: EncryptedSecretKey -> Utxo -> Utxo
-ourUtxo esk = ourUtxo_ $ eskToWalletDecrCredentials esk
+ourUtxo esk = ourUtxo_ $ eskToHDPassphrase esk
 
-ourUtxo_ :: WalletDecrCredentials -> Utxo -> Utxo
-ourUtxo_ wdc utxo = Map.fromList $ ourResolvedTxPairs wdc $ Map.toList utxo
+ourUtxo_ :: HDPassphrase -> Utxo -> Utxo
+ourUtxo_ hdPass utxo = Map.fromList $ ourResolvedTxPairs hdPass $ Map.toList utxo
 
-ours :: WalletDecrCredentials
+ours :: HDPassphrase
      -> (a -> Address)
      -> [a]
      -> [a]
-ours wdc selectAddr rtxs = map fst $ selectOwnAddresses wdc selectAddr rtxs
+ours hdPass selectAddr rtxs = map fst $ selectOwnAddresses hdPass selectAddr rtxs
 
 {-------------------------------------------------------------------------------
   Pretty-printing


### PR DESCRIPTION
AFAIU there is no need in `_wamWalletId  :: CId Wal` field, so I removed it.