### PR TITLE
[AD-233] Add "account" arguments to the 'send' command

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/src/Ariadne/Wallet/Face.hs
@@ -4,6 +4,7 @@ module Ariadne.Wallet.Face
   , WalletEvent(..)
   , WalletReference(..)
   , AccountReference(..)
+  , LocalAccountReference(..)
   , WalletSelection(..)
   , WalletName(..)
   , Mnemonic(..)
@@ -36,6 +37,13 @@ data AccountReference
   | AccountRefByIndex !Word32 !WalletReference
   | AccountRefByName !Text !WalletReference
 
+-- | Reference to an account inside a wallet.
+data LocalAccountReference
+  = LocalAccountRefByIndex !Word
+  -- ^ Reference by index in UI.
+  | LocalAccountRefByName !Text
+  -- ^ Reference by account name.
+
 -- | Single string representing a mnemonic, presumably space-separated
 -- list of words.
 newtype Mnemonic = Mnemonic
@@ -62,7 +70,8 @@ data WalletFace =
     , walletRemove :: IO ()
     , walletRefreshUserSecret :: IO ()
     , walletSelect :: Maybe WalletReference -> [Word] -> IO ()
-    , walletSend :: PassPhrase -> WalletReference -> NonEmpty TxOut -> IO TxId
+    , walletSend ::
+        PassPhrase -> WalletReference -> [LocalAccountReference] -> NonEmpty TxOut -> IO TxId
     , walletGetSelection :: IO (Maybe WalletSelection, UserSecret)
     , walletBalance :: IO Coin
     }

--- a/docs/usage-tui.md
+++ b/docs/usage-tui.md
@@ -73,7 +73,10 @@ and these functions in more detail.
 ### General syntax
 
 To begin with, all `Knit` functions accept keyword arguments, some of which may be optional.
-Optional arguments are marked with "`?`" suffix in the help. To specify a keyword argument, write
+Optional arguments are marked with "`?`" suffix in the help. If an
+argument can be specified many times (including zero), it's marked
+with "`*`" suffix. If it can be specified many times, but at least
+once, it's marked with "`+`" suffix. To specify a keyword argument, write
 its name followed by `:` and the value. Types are checked while executing the command, not when
 parsing it.  Functions may also have variable number of arguments.
 
@@ -176,7 +179,7 @@ annotated with its arguments and their types. Optional arguments will be marked 
 
 There is also a command to send a transaction from your wallet:
 
-    send wallet: String or Word? pass: String? out: TxOut out: TxOut...
+    send wallet: String or Word? account: (String or Word)* pass: String? out: TxOut+
 
 Since one transaction can have multiple outputs, you have to pass these outputs to the `send`
 command. An output is constructed with `tx-out` command, which takes a receiver's address and an
@@ -198,8 +201,20 @@ So, to construct an output, do this:
 Note that receiver's address does not take quotes.
 
 Finally, send a transaction by giving `send` command a list of outputs (`out` argument), wallet
-passphrase (`pass` argument) if any and, optionally, wallet's name or index (`wallet` argument). If
-you don't specify a wallet, the selected one will be used. Here's an example:
+passphrase (`pass` argument) if any and, optionally, wallet's name or
+index (`wallet` argument) as well as list of source accounts (as names
+or indices). If you don't specify a wallet, the selected one will be used.
+
+Transaction inputs are selected automatically from a set of accounts
+which depends on `account` arguments and current selection:
+* If at least one account is explicitly specified, only the specified
+  accounts can be used as inputs.
+* If no accounts are explicitly specified and an account from the
+  input wallet is selected, only its addresses will be used as inputs.
+* Otherwise, addresses will be picked from all accounts in the input
+  wallet.
+
+Here's an example:
 
 ```
 send pass: "cat"


### PR DESCRIPTION
Only interface is provided, because it's needed for UI.
It will be implemented a bit later, after we finally start using
the new backend.