### PR TITLE
Hotfix universum bump

### DIFF
--- a/ariadne/src/Ariadne/Config/CLI.hs
+++ b/ariadne/src/Ariadne/Config/CLI.hs
@@ -228,7 +228,7 @@ getConfig commitHash = do
       configDirs <- ConfigDirectories <$> getXdgDirectory XdgData "ariadne" <*> getCurrentDirectory
       return (resolvePaths unresolved configPath configDirs))
     (do
-      putText $ sformat ("File "%string%" not found. Default config will be used.") configPath
+      putStrLn $ sformat ("File "%string%" not found. Default config will be used.") configPath
       return defaultAriadneConfig)
 
   return $ mergeConfigs cli_config config


### PR DESCRIPTION
`putText` has different semantics: it doesn't print newline character anymore.
`putStrLn` does print newline character.