### PR TITLE
[AD-301] Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,30 @@
-.PHONY: dev dev-tui dev-qt test stylish clean
+.PHONY: dev dev-lib dev-tui dev-qt test stylish clean
 
 ARIADNE_PACKAGES = ariadne
 VTY_PACKAGES = ariadne-vty
 QT_PACKAGES = ariadne-qt
 
+# Options for development
 STACK_DEV_OPTIONS = --fast --ghc-options -Wwarn --file-watch
+# Options to build more stuff (tests and benchmarks)
+STACK_BUILD_MORE_OPTIONS = --test --bench --no-run-tests --no-run-benchmarks
 
+# Build everything (including tests and benchmarks) with development options.
 dev:
-	stack build $(ARIADNE_PACKAGES) $(VTY_PACKAGES) $(QT_PACKAGES) $(STACK_DEV_OPTIONS)
+	stack build $(STACK_DEV_OPTIONS) $(STACK_BUILD_MORE_OPTIONS) .
 
+# Build only `ariadne` library with development options.
+# Useful because logs will be printed.
 dev-lib:
 	stack build $(ARIADNE_PACKAGES) $(STACK_DEV_OPTIONS)
 
+# Build only TUI with development options.
 dev-vty:
-	stack build $(ARIADNE_PACKAGES) $(VTY_PACKAGES) $(STACK_DEV_OPTIONS)
+	stack build $(VTY_PACKAGES) $(STACK_DEV_OPTIONS)
 
+# Build only Qt GUI with development options.
 dev-qt:
-	stack build $(ARIADNE_PACKAGES) $(QT_PACKAGES) $(STACK_DEV_OPTIONS)
+	stack build $(QT_PACKAGES) $(STACK_DEV_OPTIONS)
 
 test:
 	stack test ii-extras knit ariadne-vty-ui ariadne


### PR DESCRIPTION
Various improvements to Makefile:
1. Added forgotten target to .PHONY.
2. Added comments.
3. `make dev` now also builds tests and benchmarks, I find it good,
   because when I use `make dev` I normally want to check that *everything*
   compiles.
4. `dev-vty` and `dev-qt` pass only one target to `stack build`, so there
   will be some logs while build is going on.