### PR TITLE
[AD-239] Enable ariadne tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,20 +10,20 @@ with nixpkgs;
 let
   closure = (stackClosure haskell.compiler.ghc822 ./.).override {
     overrides = final: previous: with haskell.lib; {
-      ariadne = overrideCabal previous.ariadne (super: {
+      ariadne = haskell.lib.doCheck (overrideCabal previous.ariadne (super: {
         buildTools = [ git ];
-      });
+      }));
 
       ariadne-qt = disableLibraryProfiling (overrideCabal previous.ariadne-qt (super: {
         # https://github.com/NixOS/nixpkgs/issues/25585
         # RPATH of binary contains a forbidden reference to /tmp/nix-build...
         preFixup = ''rm -rf "$(pwd)"'';
       }));
-    
+
       qtah-cpp = overrideCabal previous.qtah-cpp (super: {
         librarySystemDepends = [ qt5.qtbase ];
       });
-    
+
       qtah = overrideCabal previous.qtah (super: {
         libraryToolDepends = [ qt5.qtbase ];
       });


### PR DESCRIPTION
For unknown reason (probably accidentally) tests stopped being built and launched in #137. This PR fixes it.