### PR TITLE
[AD-222] Change arrow keys behavior in Tree

### DIFF
--- a/docs/usage-tui.md
+++ b/docs/usage-tui.md
@@ -48,9 +48,10 @@ The tree can be navigated in several ways. First of all, you can select any entr
 with mouse. You can also change the current selection with the keyboard. Up and Down keys will go to
 the previous and the next item respectively, including the `[ + Add wallet ]` button. Right key will
 go to the first child of the current item and Left key will go to the parent. Ctrl-Up and Ctrl-Down
-can be used to switch between items of the same type &mdash; e.g. go to the next or previous wallet,
-if a wallet is currently selected. Finally, `h`, `j`, `k`, `l` keys will work exactly as arrow keys
-(without Ctrl).
+can be used to jump between wallets: Ctrl-Up will first go to the current wallet, when an account or
+address is selected, then to the previous wallet. Ctrl-Down will always go to the next wallet.
+Finally, `h`, `j`, `k`, `l` keys will work exactly as Left, Down, Up and Right arrow keys (without
+Ctrl).
 
 To create a new wallet, select `[ + Add wallet ]` line in the tree, so that a special widget appears
 to the right. There you can either create a completely new wallet by specifying its name and a

--- a/docs/usage-tui.md
+++ b/docs/usage-tui.md
@@ -44,6 +44,14 @@ All widgets that have a lot of text (e.g. About and Logs) can be scrolled with m
 On the `Wallet` tab you can see all your wallets with their accounts and addresses organized in a
 tree. To the right of the tree you can see details of the selected wallet, account or address.
 
+The tree can be navigated in several ways. First of all, you can select any entry by clicking it
+with mouse. You can also change the current selection with the keyboard. Up and Down keys will go to
+the previous and the next item respectively, including the `[ + Add wallet ]` button. Right key will
+go to the first child of the current item and Left key will go to the parent. Ctrl-Up and Ctrl-Down
+can be used to switch between items of the same type &mdash; e.g. go to the next or previous wallet,
+if a wallet is currently selected. Finally, `h`, `j`, `k`, `l` keys will work exactly as arrow keys
+(without Ctrl).
+
 To create a new wallet, select `[ + Add wallet ]` line in the tree, so that a special widget appears
 to the right. There you can either create a completely new wallet by specifying its name and a
 passphrase, or restore an existing one. When a new wallet is created, Ariadne will print you its

--- a/ui/vty/src/Ariadne/UI/Vty/Keyboard.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Keyboard.hs
@@ -22,6 +22,8 @@ data KeyboardEvent
   | KeyRight
   | KeyUp
   | KeyDown
+  | KeyCtrlUp
+  | KeyCtrlDown
   | KeyPageUp
   | KeyPageDown
   | KeyHome
@@ -67,8 +69,10 @@ vtyToKey = \case
 
     EvKey KLeft        _        -> KeyLeft
     EvKey KRight       _        -> KeyRight
-    EvKey KUp          _        -> KeyUp
-    EvKey KDown        _        -> KeyDown
+    EvKey KUp          []       -> KeyUp
+    EvKey KDown        []       -> KeyDown
+    EvKey KUp          [MCtrl]  -> KeyCtrlUp
+    EvKey KDown        [MCtrl]  -> KeyCtrlDown
     EvKey KPageUp      _        -> KeyPageUp
     EvKey KPageDown    _        -> KeyPageDown
     EvKey KHome        _        -> KeyHome

--- a/ui/vty/src/Ariadne/UI/Vty/Keyboard.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Keyboard.hs
@@ -69,10 +69,10 @@ vtyToKey = \case
 
     EvKey KLeft        _        -> KeyLeft
     EvKey KRight       _        -> KeyRight
-    EvKey KUp          []       -> KeyUp
-    EvKey KDown        []       -> KeyDown
     EvKey KUp          [MCtrl]  -> KeyCtrlUp
     EvKey KDown        [MCtrl]  -> KeyCtrlDown
+    EvKey KUp          _        -> KeyUp
+    EvKey KDown        _        -> KeyDown
     EvKey KPageUp      _        -> KeyPageUp
     EvKey KPageDown    _        -> KeyPageDown
     EvKey KHome        _        -> KeyHome

--- a/ui/vty/src/Ariadne/UI/Vty/Scrolling.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Scrolling.hs
@@ -28,6 +28,8 @@ keyToScrollingAction :: KeyboardEvent -> Maybe ScrollingAction
 keyToScrollingAction = \case
   KeyUp       -> Just ScrollingLineUp
   KeyDown     -> Just ScrollingLineDown
+  KeyCtrlUp   -> Just ScrollingLineUp
+  KeyCtrlDown -> Just ScrollingLineDown
   KeyPageUp   -> Just ScrollingPgUp
   KeyPageDown -> Just ScrollingPgDown
   KeyHome     -> Just ScrollingHome

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Tree.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Tree.hs
@@ -226,7 +226,7 @@ handleTreeWidgetEvent UiLangFace{..} = \case
       _ -> [x]
   TreeNavigationNextWallet -> defaultPath $ \p@(x :| _) -> if maxBound == x then toList p else [succ x]
 
-  TreeNavigationParent -> defaultPath $ NE.init
+  TreeNavigationParent -> defaultPath $ \p -> if length p == 1 then p else NE.init p
   TreeNavigationFirstChild -> defaultPath $ (++ [0]) . toList
 
   TreeNavigationPrevItem -> whenJustM (modifiedPath False) putSelect

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Tree.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Tree.hs
@@ -176,27 +176,27 @@ data TreeWidgetEvent
   = TreeUpdateEvent [UiTree] (Maybe UiTreeSelection)
   | TreeMouseDownEvent B.Location
   | TreeScrollingEvent ScrollingAction
-  | TreeNavigationUp
-  | TreeNavigationDown
-  | TreeNavigationLeft
-  | TreeNavigationRight
-  | TreeNavigationPrev
-  | TreeNavigationNext
+  | TreeNavigationPrevWallet
+  | TreeNavigationNextWallet
+  | TreeNavigationParent
+  | TreeNavigationFirstChild
+  | TreeNavigationPrevItem
+  | TreeNavigationNextItem
 
 keyToTreeEvent
   :: KeyboardEvent
   -> Maybe TreeWidgetEvent
 keyToTreeEvent = \case
-  KeyCtrlUp -> Just TreeNavigationUp
-  KeyCtrlDown -> Just TreeNavigationDown
-  KeyUp -> Just TreeNavigationPrev
-  KeyDown -> Just TreeNavigationNext
-  KeyLeft -> Just TreeNavigationLeft
-  KeyRight -> Just TreeNavigationRight
-  KeyChar 'h' -> Just TreeNavigationLeft
-  KeyChar 'j' -> Just TreeNavigationNext
-  KeyChar 'k' -> Just TreeNavigationPrev
-  KeyChar 'l' -> Just TreeNavigationRight
+  KeyCtrlUp -> Just TreeNavigationPrevWallet
+  KeyCtrlDown -> Just TreeNavigationNextWallet
+  KeyUp -> Just TreeNavigationPrevItem
+  KeyDown -> Just TreeNavigationNextItem
+  KeyLeft -> Just TreeNavigationParent
+  KeyRight -> Just TreeNavigationFirstChild
+  KeyChar 'h' -> Just TreeNavigationParent
+  KeyChar 'j' -> Just TreeNavigationNextItem
+  KeyChar 'k' -> Just TreeNavigationPrevItem
+  KeyChar 'l' -> Just TreeNavigationFirstChild
   _ -> Nothing
 
 handleTreeWidgetEvent
@@ -218,18 +218,22 @@ handleTreeWidgetEvent UiLangFace{..} = \case
   TreeScrollingEvent action -> do
     lift $ handleScrollingEvent widgetName action
     treeScrollBySelectionL .= False
-  TreeNavigationUp -> defaultPath $ applyToLast (\x -> if minBound == x then x else pred x)
-  TreeNavigationDown -> defaultPath $ applyToLast (\x -> if maxBound == x then x else succ x)
-  TreeNavigationLeft -> defaultPath $ NE.init
-  TreeNavigationRight -> defaultPath $ (++ [0]) . toList
 
-  TreeNavigationPrev -> whenJustM (modifiedPath False) putSelect
-  TreeNavigationNext -> whenJustM (modifiedPath True) putSelect
+  -- Wallet index is always the head of path
+  TreeNavigationPrevWallet -> defaultPath $ \p@(x :| xs) ->
+    case xs of
+      [] -> if minBound == x then toList p else [pred x]
+      _ -> [x]
+  TreeNavigationNextWallet -> defaultPath $ \p@(x :| _) -> if maxBound == x then toList p else [succ x]
+
+  TreeNavigationParent -> defaultPath $ NE.init
+  TreeNavigationFirstChild -> defaultPath $ (++ [0]) . toList
+
+  TreeNavigationPrevItem -> whenJustM (modifiedPath False) putSelect
+  TreeNavigationNextItem -> whenJustM (modifiedPath True) putSelect
 
   where
     putSelect = void . liftIO . langPutUiCommand . UiSelect
-    applyToLast :: (Word -> Word) -> NE.NonEmpty Word -> [Word]
-    applyToLast f xs = NE.init xs ++ [f (NE.last xs)]
     defaultPath f = get <&> treeItems <&> (find treeItemSelected >=> treeItemPath >=> nonEmpty) <&> maybe [0] f >>= putSelect
 
     modifiedPath forward = runMaybeT $ do

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Tree.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Tree.hs
@@ -226,7 +226,7 @@ handleTreeWidgetEvent UiLangFace{..} = \case
       _ -> [x]
   TreeNavigationNextWallet -> defaultPath $ \p@(x :| _) -> if maxBound == x then toList p else [succ x]
 
-  TreeNavigationParent -> defaultPath $ \p -> if length p == 1 then p else NE.init p
+  TreeNavigationParent -> defaultPath $ \p -> if length p == 1 then toList p else NE.init p
   TreeNavigationFirstChild -> defaultPath $ (++ [0]) . toList
 
   TreeNavigationPrevItem -> whenJustM (modifiedPath False) putSelect


### PR DESCRIPTION
Up and Down now scroll through all items, old behavior is preserved in
Ctrl-Up and Ctrl-Down.

---

There are two disputable decisions in this PR:

- I made `KeyUp` and `KeyDown` events fire only when no modifier is presed. Previously REPL, for example, would treat Up and Ctrl-Up the same way, now it will react only to Up. Is that OK?
- I changed `j` and `k` to work like new Up and Down, not like new Ctrl-Up and Ctrl-Down (the old behavior).