### PR TITLE
Enable MonadFailDesugaring everywhere

### DIFF
--- a/ariadne/ariadne.cabal
+++ b/ariadne/ariadne.cabal
@@ -169,6 +169,7 @@ library
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
+      MonadFailDesugaring
       MultiParamTypeClasses
       MultiWayIf
       NegativeLiterals
@@ -241,6 +242,7 @@ test-suite ariadne-test
         GADTs
         GeneralizedNewtypeDeriving
         LambdaCase
+        MonadFailDesugaring
         MultiParamTypeClasses
         MultiWayIf
         NegativeLiterals

--- a/knit/knit.cabal
+++ b/knit/knit.cabal
@@ -70,6 +70,7 @@ library
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
+      MonadFailDesugaring
       MultiParamTypeClasses
       MultiWayIf
       NegativeLiterals
@@ -127,6 +128,7 @@ test-suite knit-test
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
+      MonadFailDesugaring
       MultiParamTypeClasses
       MultiWayIf
       NegativeLiterals

--- a/ui/qt/ariadne-qt.cabal
+++ b/ui/qt/ariadne-qt.cabal
@@ -65,6 +65,7 @@ library
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
+      MonadFailDesugaring
       MultiParamTypeClasses
       MultiWayIf
       NegativeLiterals
@@ -124,6 +125,7 @@ executable ariadne-qt
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
+      MonadFailDesugaring
       MultiParamTypeClasses
       MultiWayIf
       NegativeLiterals

--- a/ui/vty/ariadne-vty.cabal
+++ b/ui/vty/ariadne-vty.cabal
@@ -77,6 +77,7 @@ library
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
+      MonadFailDesugaring
       MultiParamTypeClasses
       MultiWayIf
       NegativeLiterals
@@ -139,6 +140,7 @@ executable ariadne
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
+      MonadFailDesugaring
       MultiParamTypeClasses
       MultiWayIf
       NegativeLiterals


### PR DESCRIPTION
This will be enabled by default in GHC 8.6, let's make our code ready for it
right now.

For more information see https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail:
> Add a language extension -XMonadFailDesugaring that changes desugaring to
  use MonadFail(fail) instead of Monad(fail) This has the effect that
  typechecking will infer a MonadFail constraint for do blocks with failable
  patterns, just as it is planned to do when the entire thing is done.