### PR TITLE
[AD-219] Introduce BIP-44 helpers

### DIFF
--- a/ariadne/ariadne.cabal
+++ b/ariadne/ariadne.cabal
@@ -131,6 +131,7 @@ library
 
       Ariadne.Wallet.Cardano.Kernel
       Ariadne.Wallet.Cardano.Kernel.Actions
+      Ariadne.Wallet.Cardano.Kernel.Bip44
       Ariadne.Wallet.Cardano.Kernel.DB.AcidState
       Ariadne.Wallet.Cardano.Kernel.DB.BlockMeta
       Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
@@ -154,6 +155,7 @@ library
       Ariadne.Wallet.Cardano.Kernel.PrefilterTx
       Ariadne.Wallet.Cardano.Kernel.Submission
       Ariadne.Wallet.Cardano.Kernel.Types
+      Ariadne.Wallet.Cardano.Kernel.Word31
   default-extensions:
       ApplicativeDo
       NoImplicitPrelude

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
@@ -50,7 +50,7 @@ decodeBip44DerivationPath derPathList = do
     guard $ coinType == bip44CoinType
 
     bip44AccountIndex <- HdAccountIx <$> fromHardened accIdx'
-    bip44AddressChain <- join $ mkAddressChain <$> fromNonHardened chainType
+    bip44AddressChain <- mkAddressChain =<< fromNonHardened chainType
     bip44AddressIndex <- HdAddressIx <$> fromNonHardened addrIdx
     pure $ Bip44DerivationPath {..}
   where

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
@@ -1,0 +1,91 @@
+module Ariadne.Wallet.Cardano.Kernel.Bip44
+    ( Bip44DerivationPath (..)
+    , decodeBip44DerivationPath
+    , encodeBip44DerivationPath
+    ) where
+
+import Universum
+
+import Pos.Crypto.HD (firstHardened, firstNonHardened, isHardened)
+
+import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
+  (HdAccountIx(..), HdAddressChain(..), HdAddressIx(..))
+import Ariadne.Wallet.Cardano.Kernel.Word31
+  (Word31, unsafeMkWord31, word31ToWord32)
+
+{-------------------------------------------------------------------------------
+  Constants
+-------------------------------------------------------------------------------}
+
+-- | BIP-44 derivation constant
+bip44Purpose :: Word31
+bip44Purpose = unsafeMkWord31 44
+
+-- | ADA coin index. This is the year when Ada Lovelace was born.
+-- https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+bip44CoinType :: Word31
+bip44CoinType = unsafeMkWord31 1815
+
+{-------------------------------------------------------------------------------
+  BIP-44 conversion functions
+-------------------------------------------------------------------------------}
+
+-- In fact, this is almost HdAddressId, with the exception that
+-- it does not include the corresponding HdRootId.
+data Bip44DerivationPath = Bip44DerivationPath
+    { bip44AccountIndex :: HdAccountIx
+    , bip44AddressChain :: HdAddressChain
+    , bip44AddressIndex :: HdAddressIx
+    } deriving (Eq, Ord, Show)
+
+decodeBip44DerivationPath :: [Word32] -> Maybe Bip44DerivationPath
+decodeBip44DerivationPath derPathList = do
+    -- The bang is needed due to a GHC bug with ApplicativeDo
+    -- (https://ghc.haskell.org/trac/ghc/ticket/14105, fixed in 8.4.1)
+    ![purpose', coinType', accIdx', chainType, addrIdx] <- pure derPathList
+
+    purpose  <- fromHardened purpose'
+    guard $ purpose  == bip44Purpose
+    coinType <- fromHardened coinType'
+    guard $ coinType == bip44CoinType
+
+    bip44AccountIndex <- HdAccountIx <$> fromHardened accIdx'
+    bip44AddressChain <- join $ mkAddressChain <$> fromNonHardened chainType
+    bip44AddressIndex <- HdAddressIx <$> fromNonHardened addrIdx
+    pure $ Bip44DerivationPath {..}
+  where
+    fromNonHardened :: Word32 -> Maybe Word31
+    fromNonHardened idx = do
+        guard $ not $ isHardened idx
+        pure $ unsafeMkWord31 $ idx - firstNonHardened
+
+    fromHardened :: Word32 -> Maybe Word31
+    fromHardened idx = do
+        guard $ isHardened idx
+        pure $ unsafeMkWord31 $ idx - firstHardened
+
+    mkAddressChain :: Word31 -> Maybe HdAddressChain
+    mkAddressChain (word31ToWord32 -> n)
+        | n == 0 = Just HdChainExternal
+        | n == 1 = Just HdChainInternal
+        | otherwise = Nothing
+
+encodeBip44DerivationPath :: Bip44DerivationPath -> [Word32]
+encodeBip44DerivationPath Bip44DerivationPath {..} =
+    [ toHardened bip44Purpose
+    , toHardened bip44CoinType
+    , toHardened $ unwrapHdAccountIx bip44AccountIndex
+    , toNonHardened $ case bip44AddressChain of
+        HdChainExternal -> unsafeMkWord31 0
+        HdChainInternal -> unsafeMkWord31 1
+    , toNonHardened $ unwrapHdAddressIx bip44AddressIndex
+    ]
+  where
+    toNonHardened :: Word31 -> Word32
+    toNonHardened (word31ToWord32 -> n) = firstNonHardened + n
+
+    toHardened :: Word31 -> Word32
+    toHardened (word31ToWord32 -> n) = firstHardened + n
+
+    unwrapHdAccountIx (HdAccountIx accountIdx) = accountIdx
+    unwrapHdAddressIx (HdAddressIx addressIdx) = addressIdx

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -79,6 +79,7 @@ import Ariadne.Wallet.Cardano.Kernel.DB.InDb
 import Ariadne.Wallet.Cardano.Kernel.DB.Spec
 import Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState
 import Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet
+import Ariadne.Wallet.Cardano.Kernel.Word31 (Word31)
 
 {-------------------------------------------------------------------------------
   Supporting types
@@ -91,7 +92,7 @@ newtype WalletName = WalletName Text
 newtype AccountName = AccountName Text
 
 -- | Account index
-newtype HdAccountIx = HdAccountIx Word32
+newtype HdAccountIx = HdAccountIx Word31
   deriving (Eq, Ord, Show)
 
 -- | Whether the chain is an external or an internal one
@@ -99,7 +100,7 @@ data HdAddressChain = HdChainExternal | HdChainInternal
   deriving (Eq, Ord, Show)
 
 -- | Address index
-newtype HdAddressIx = HdAddressIx Word32
+newtype HdAddressIx = HdAddressIx Word31
   deriving (Eq, Ord, Show)
 
 -- | Wallet assurance level

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/PrefilterTx.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/PrefilterTx.hs
@@ -25,6 +25,7 @@ import Pos.Core.Txp (TxIn(..), TxOut(..), TxOutAux(..))
 import Pos.Crypto (EncryptedSecretKey)
 import Pos.Txp.Toil.Types (Utxo)
 
+import Ariadne.Wallet.Cardano.Kernel.Bip44 (Bip44DerivationPath(..))
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
 import Ariadne.Wallet.Cardano.Kernel.DB.InDb (fromDb)
 import Ariadne.Wallet.Cardano.Kernel.DB.Resolved
@@ -186,12 +187,12 @@ prefilter (wid,hdPass) selectAddr rtxs
           toAddressId :: WalletId -> WAddressMeta -> HdAddressId
           toAddressId (WalletIdHdRnd rootId) meta' = addressId
               where
-                  accountIx = _wamAccountIndex meta'
+                  accountIx = bip44AccountIndex $ _wamDerivationPath meta'
                   accountId = HdAccountId rootId accountIx
 
-                  addressChain = _wamAddressChain meta'
+                  addressChain = bip44AddressChain $ _wamDerivationPath meta'
 
-                  addressIx = _wamAddressIndex meta'
+                  addressIx = bip44AddressIndex $ _wamDerivationPath meta'
                   addressId = HdAddressId accountId addressChain addressIx
 
 {-------------------------------------------------------------------------------

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
@@ -1,0 +1,60 @@
+module Ariadne.Wallet.Cardano.Kernel.Word31
+    ( Word31
+    , Word31Exception (..)
+    , unsafeMkWord31
+    , word31ToWord32
+    ) where
+
+import Universum
+
+import Control.Monad.Except (MonadError(throwError))
+import Data.SafeCopy (base, deriveSafeCopySimple)
+import qualified Data.Text.Buildable (Buildable (..))
+import Formatting (bprint, int)
+
+{-------------------------------------------------------------------------------
+  Supporting types
+-------------------------------------------------------------------------------}
+
+newtype Word31 = Word31
+    { getWord31 :: Word32
+    } deriving (Show, Ord, Eq)
+
+newtype Word31Exception = Word31Overflow Word32
+    deriving (Show)
+
+instance Exception Word31Exception where
+    displayException (Word31Overflow n) =
+        "Word31: " <> show n <> " is too large"
+
+maxWord31 :: Word32
+maxWord31 = 0x7FFFFFFF -- 2^31 - 1
+
+instance Bounded Word31 where
+    minBound = Word31 0
+    maxBound = Word31 maxWord31
+
+-- | Makes a 'Word31' but is _|_ if that number exceeds 2^31 - 1
+unsafeMkWord31 :: Word32 -> Word31
+unsafeMkWord31 n =
+    either (error . toText . displayException) (const word31) (checkWord31 word31)
+  where
+    word31 = Word31 n
+{-# INLINE unsafeMkWord31 #-}
+
+checkWord31 :: MonadError Word31Exception m => Word31 -> m ()
+checkWord31 (Word31 n)
+    | n <= maxWord31 = pure ()
+    | otherwise      = throwError $ Word31Overflow n
+
+word31ToWord32 :: Word31 -> Word32
+word31ToWord32 (Word31 n) = n
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+instance Buildable Word31 where
+    build (Word31 n) = bprint int n
+
+deriveSafeCopySimple 1 'base ''Word31

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
@@ -7,7 +7,6 @@ module Ariadne.Wallet.Cardano.Kernel.Word31
 
 import Universum
 
-import Control.Monad.Except (MonadError(throwError))
 import Data.SafeCopy (base, deriveSafeCopySimple)
 import qualified Data.Text.Buildable (Buildable (..))
 import Formatting (bprint, int)

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
@@ -37,15 +37,11 @@ instance Bounded Word31 where
 -- | Makes a 'Word31' but is _|_ if that number exceeds 2^31 - 1
 unsafeMkWord31 :: Word32 -> Word31
 unsafeMkWord31 n =
-    either (error . toText . displayException) (const word31) (checkWord31 word31)
-  where
-    word31 = Word31 n
+    if n <= maxWord31 then
+        Word31 n
+    else
+        bug $ Word31Overflow n
 {-# INLINE unsafeMkWord31 #-}
-
-checkWord31 :: MonadError Word31Exception m => Word31 -> m ()
-checkWord31 (Word31 n)
-    | n <= maxWord31 = pure ()
-    | otherwise      = throwError $ Word31Overflow n
 
 word31ToWord32 :: Word31 -> Word32
 word31ToWord32 (Word31 n) = n


### PR DESCRIPTION
* Introduce `Word31`, a custom type similar to `Coin`, that has `maxBound = 2^31-1`. It lives in `Ariadne.Wallet.Cardano.Kernel.Word31`.
* Put all BIP-44-related conversion into a separate module (`Ariadne.Wallet.Cardano.Kernel.Bip44`) and only expose the necessary stuff outside.
* Modify the rest of the code to comply with the refactoring.