### PR TITLE
[AD-135] Make BIP-32 functions more granular and reusable

### DIFF
--- a/ariadne/ariadne.cabal
+++ b/ariadne/ariadne.cabal
@@ -131,6 +131,7 @@ library
 
       Ariadne.Wallet.Cardano.Kernel
       Ariadne.Wallet.Cardano.Kernel.Actions
+      Ariadne.Wallet.Cardano.Kernel.Bip32
       Ariadne.Wallet.Cardano.Kernel.Bip44
       Ariadne.Wallet.Cardano.Kernel.DB.AcidState
       Ariadne.Wallet.Cardano.Kernel.DB.BlockMeta

--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -49,8 +49,6 @@ import Ariadne.Config.Wallet (WalletConfig(..))
 import Ariadne.Wallet.Cardano.Kernel.Bip32
 import Ariadne.Wallet.Cardano.Kernel.Bip44
   (Bip44DerivationPath(..), encodeBip44DerivationPath)
-import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
-  (HdAccountIx(..), HdAddressChain(..), HdAddressIx(..))
 import Ariadne.Wallet.Face
 
 data NoWalletSelection = NoWalletSelection
@@ -511,20 +509,17 @@ deriveBip44KeyPair ::
        IsBootstrapEraAddr
     -> PassPhrase
     -> EncryptedSecretKey
-    -> HdAccountIx
-    -> HdAddressChain
-    -> HdAddressIx
+    -> Bip44DerivationPath
     -> Maybe (Address, EncryptedSecretKey)
-deriveBip44KeyPair era pp rootSK hdAccountIx hdAddressChain hdAddressIx =
+deriveBip44KeyPair era pp rootSK bip44DerPath =
     toPair <$>
     deriveHDSecretKeyByPath (ShouldCheckPassphrase True) pp rootSK derPath
   where
-    bip44DerPath = Bip44DerivationPath hdAccountIx hdAddressChain hdAddressIx
     derPath :: [Word32]
     derPath = encodeBip44DerivationPath bip44DerPath
     toPair :: EncryptedSecretKey -> (Address, EncryptedSecretKey)
     toPair addrSK =
-        ( makePubKeyHdwAddress'
+        ( makePubKeyHdwAddressUsingPath
               era
               derPath
               ! #root (encToPublic rootSK)

--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -35,17 +35,18 @@ import qualified Data.Vector as V
 import Formatting (bprint, int, (%))
 import IiExtras
 import Loot.Crypto.Bip39 (entropyToMnemonic, mnemonicToSeed)
+import Named ((!))
 import Numeric.Natural (Natural)
 import Serokell.Data.Memory.Units (Byte)
 
 import Pos.Client.KeyStorage (getSecretDefault, modifySecretDefault)
-import Pos.Core.Common
-  (IsBootstrapEraAddr(..), deriveLvl2KeyPair, makePubKeyHdwAddress)
+import Pos.Core.Common (IsBootstrapEraAddr(..), deriveLvl2KeyPair)
 import Pos.Crypto
 import Pos.Util (eitherToThrow, maybeThrow)
 import Pos.Util.UserSecret
 
 import Ariadne.Config.Wallet (WalletConfig(..))
+import Ariadne.Wallet.Cardano.Kernel.Bip32
 import Ariadne.Wallet.Cardano.Kernel.Bip44
   (Bip44DerivationPath(..), encodeBip44DerivationPath)
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
@@ -503,7 +504,7 @@ findFirstUnique lastIdx paths = head
   where
     pathsSet = V.foldr S.insert S.empty paths
 
--- ^ This function derives a 3-level address using account index, change index
+-- | This function derives a 3-level address using account index, change index
 --   and address index. The input key should be the master key (not the key
 --   that was derived from purpose and coin type)
 deriveBip44KeyPair ::
@@ -514,25 +515,18 @@ deriveBip44KeyPair ::
     -> HdAddressChain
     -> HdAddressIx
     -> Maybe (Address, EncryptedSecretKey)
-deriveBip44KeyPair era pp sk hdAccountIx hdAddressChain hdAddressIx =
-    derivePathKeyPair era pp sk $
-        encodeBip44DerivationPath $
-            Bip44DerivationPath hdAccountIx hdAddressChain hdAddressIx
-
--- ^ This function derives a key (and an address) following an arbitrary derivation path.
-derivePathKeyPair ::
-       IsBootstrapEraAddr
-    -> PassPhrase
-    -> EncryptedSecretKey
-    -> [Word32]
-    -> Maybe (Address, EncryptedSecretKey)
-derivePathKeyPair era pp sk derPath = do
-    addrKey <- mAddrKey
-    let hdPP = deriveHDPassphrase $ encToPublic sk
-        hdPayload = packHDAddressAttr hdPP derPath
-    return (makePubKeyHdwAddress era hdPayload (encToPublic addrKey), addrKey)
+deriveBip44KeyPair era pp rootSK hdAccountIx hdAddressChain hdAddressIx =
+    toPair <$>
+    deriveHDSecretKeyByPath (ShouldCheckPassphrase True) pp rootSK derPath
   where
-    mAddrKey = foldM
-        (\sk' (check, idx) -> deriveHDSecretKey (ShouldCheckPassphrase check) pp sk' idx)
-        sk
-        (zip (True:repeat False) derPath) -- check passphrase only once
+    bip44DerPath = Bip44DerivationPath hdAccountIx hdAddressChain hdAddressIx
+    derPath :: [Word32]
+    derPath = encodeBip44DerivationPath bip44DerPath
+    toPair :: EncryptedSecretKey -> (Address, EncryptedSecretKey)
+    toPair addrSK =
+        ( makePubKeyHdwAddress'
+              era
+              derPath
+              ! #root (encToPublic rootSK)
+              ! #address (encToPublic addrSK)
+        , addrSK)

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
@@ -1,0 +1,42 @@
+-- | Helpers to work with BIP-32 implementation in Cardano.
+
+module Ariadne.Wallet.Cardano.Kernel.Bip32
+       ( deriveHDSecretKeyByPath
+       , makePubKeyHdwAddress'
+       ) where
+
+import Universum
+
+import Named (Named(..))
+
+import Pos.Core.Common (Address, IsBootstrapEraAddr(..), makePubKeyHdwAddress)
+import Pos.Crypto.HD
+  (ShouldCheckPassphrase(..), deriveHDPassphrase, deriveHDSecretKey,
+  packHDAddressAttr)
+import Pos.Crypto.Signing (EncryptedSecretKey, PassPhrase, PublicKey)
+
+-- | Like 'deriveHDSecretKey' from Cardano, but can derive not only
+-- direct descendant.
+deriveHDSecretKeyByPath
+    :: ShouldCheckPassphrase
+    -> PassPhrase
+    -> EncryptedSecretKey
+    -> [Word32]
+    -> Maybe EncryptedSecretKey
+deriveHDSecretKeyByPath shouldCheck pp sk derPath =
+    foldM
+        (\sk' (check, idx) -> deriveHDSecretKey check pp sk' idx)
+        sk
+        -- check passphrase at most once
+        (zip (shouldCheck : repeat (ShouldCheckPassphrase False)) derPath)
+
+-- | Like 'makePubKeyHdwAddress', but also creates HDPassphrase internally.
+makePubKeyHdwAddress' ::
+       IsBootstrapEraAddr
+    -> [Word32]
+    -> PublicKey `Named` "root" -> PublicKey `Named` "address" -> Address
+makePubKeyHdwAddress' era derPath (Named rootPK) (Named addrPK) =
+    makePubKeyHdwAddress era hdPayload addrPK
+  where
+    hdPP = deriveHDPassphrase rootPK
+    hdPayload = packHDAddressAttr hdPP derPath

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
@@ -2,7 +2,7 @@
 
 module Ariadne.Wallet.Cardano.Kernel.Bip32
        ( deriveHDSecretKeyByPath
-       , makePubKeyHdwAddress'
+       , makePubKeyHdwAddressUsingPath
        ) where
 
 import Universum
@@ -30,12 +30,13 @@ deriveHDSecretKeyByPath shouldCheck pp sk derPath =
         -- check passphrase at most once
         (zip (shouldCheck : repeat (ShouldCheckPassphrase False)) derPath)
 
--- | Like 'makePubKeyHdwAddress', but also creates HDPassphrase internally.
-makePubKeyHdwAddress' ::
+-- | Like 'makePubKeyHdwAddress', but also creates HDPassphrase
+-- internally using derivation path and root public key.
+makePubKeyHdwAddressUsingPath ::
        IsBootstrapEraAddr
     -> [Word32]
     -> PublicKey `Named` "root" -> PublicKey `Named` "address" -> Address
-makePubKeyHdwAddress' era derPath (Named rootPK) (Named addrPK) =
+makePubKeyHdwAddressUsingPath era derPath (Named rootPK) (Named addrPK) =
     makePubKeyHdwAddress era hdPayload addrPK
   where
     hdPP = deriveHDPassphrase rootPK


### PR DESCRIPTION
1. Part of BIP-32 logic was moved from KeyStorage.hs to a new module,
   so that it logic can be easier used from other places.
2. Previously there was a function to derive a key by path and construct
   an address (all at once). I split it into two functions basically.