### PR TITLE
[AD-245] Remove addresses from the tree

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -398,18 +398,13 @@ select WalletFace{..} walletSelRef runCardanoMode mWalletRef wsPath = do
         Just (accIdx :| acPath) -> do
 
           -- validate account
-          account <- maybeThrow
+          _account <- maybeThrow
             (AccountDoesNotExist $ pretty accIdx)
             (wallet ^? wdAccounts . ix (fromIntegral accIdx))
 
           case nonEmpty acPath of
             Nothing -> return ()
-            Just (addrIdx :| []) -> do
-              -- validate address
-              void $ maybeThrow
-                (AddressDoesNotExist $ pretty addrIdx)
-                (account ^? adAddresses . ix (fromIntegral addrIdx))
-            Just (_ :| _) -> throwM SelectIsTooDeep
+            Just _ -> throwM SelectIsTooDeep
 
       atomicWriteIORef walletSelRef $ Just $
         WalletSelection { wsPath, wsWalletIndex }

--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -402,9 +402,7 @@ select WalletFace{..} walletSelRef runCardanoMode mWalletRef wsPath = do
             (AccountDoesNotExist $ pretty accIdx)
             (wallet ^? wdAccounts . ix (fromIntegral accIdx))
 
-          case nonEmpty acPath of
-            Nothing -> return ()
-            Just _ -> throwM SelectIsTooDeep
+          unless (null acPath) $ throwM SelectIsTooDeep
 
       atomicWriteIORef walletSelRef $ Just $
         WalletSelection { wsPath, wsWalletIndex }

--- a/ui/vty/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/App.hs
@@ -394,15 +394,6 @@ handleAppEvent langFace ev =
           zoom appStateTreeL $ handleTreeWidgetEvent langFace $
             TreeMouseDownEvent coords
           return AppInProgress
-        BrickPane -> do
-          appStateFocusL .= AppFocusPane
-          uses appStateTreeL treeWidgetSelection >>= \case
-            TreeSelectionAccount ->
-              zoom appStateAccountL $ handleAccountWidgetEvent langFace $
-                AccountMouseDownEvent coords
-            _ ->
-              return ()
-          return AppInProgress
         BrickReplOutput -> do
           appStateFocusL .= AppFocusReplOutput
           return AppInProgress

--- a/ui/vty/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Face.hs
@@ -197,7 +197,6 @@ data UiTreeSelection =
 data UiWalletInfoType
   = UiWalletInfoWallet
   | UiWalletInfoAccount [Word32]
-  | UiWalletInfoAddress [Word32]
 
 data UiWalletInfo
   = UiWalletInfo
@@ -205,4 +204,5 @@ data UiWalletInfo
     , wpiLabel :: !(Maybe Text)
     , wpiWalletIdx :: !Word
     , wpiPath :: !TreePath
+    , wpiAddresses :: ![(Word32, Text)]
     }

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
@@ -90,13 +90,9 @@ drawAccountDetail attr _selAttr info AccountWidgetState{..} = V.vertCat $
 data AccountWidgetEvent
   = AccountUpdateEvent (Maybe UiWalletInfo)
   | AccountBalanceCommandResult UiCommandId UiBalanceCommandResult
-  | AccountMouseDownEvent B.Location
-  | AccountCopySelectionEvent
 
 keyToAccountEvent :: KeyboardEvent -> Maybe AccountWidgetEvent
-keyToAccountEvent = \case
-  KeyEnter -> Just AccountCopySelectionEvent
-  _ -> Nothing
+keyToAccountEvent _ = Nothing
 
 handleAccountFocus
   :: Bool
@@ -134,11 +130,6 @@ handleAccountWidgetEvent UiLangFace{..} ev = do
                 put $ Balance balance
               UiBalanceCommandFailure err -> do
                 put $ FailedBalance err
-    AccountMouseDownEvent coords -> when (isCopyButtonClick coords) $
-      void $ putExpr UiCopySelection
-    AccountCopySelectionEvent ->
-      zoom (walletItemInfoL . _Just) $
-        void $ putExpr UiCopySelection
   where
     setInfo info = do
       balancePromise <- refreshBalance
@@ -155,9 +146,3 @@ handleAccountWidgetEvent UiLangFace{..} ev = do
 
       Right commandId <- putExpr UiBalance
       return $ WaitingBalance commandId
-
-copyButtonText :: Text
-copyButtonText = "[ Copy ]"
-
-isCopyButtonClick :: B.Location -> Bool
-isCopyButtonClick (B.Location (col,row)) = row == 2 && col >= 0 && col <= length copyButtonText

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
@@ -26,19 +26,19 @@ import Ariadne.UI.Vty.UI
 data BalancePromise = WaitingBalance UiCommandId | FailedBalance Text | Balance Text
 makePrisms ''BalancePromise
 
-data WalletInfo
-  = WalletAccountInfo
+data AccountInfo
+  = AccountInfo
     { label :: !Text
     , derivationPath :: ![Word32]
     , addresses :: ![(Word32, Text)]
     , balance :: !BalancePromise
     }
 
-makeLensesWith postfixLFields ''WalletInfo
+makeLensesWith postfixLFields ''AccountInfo
 
 data AccountWidgetState =
   AccountWidgetState
-    { walletItemInfo :: !(Maybe WalletInfo)
+    { walletItemInfo :: !(Maybe AccountInfo)
     , walletInitialized :: !Bool
     }
 
@@ -75,7 +75,7 @@ drawAccountWidget _hasFocus widgetState@AccountWidgetState{..} =
         B.emptyResult
           & B.imageL .~ imgOrLoading
 
-drawAccountDetail :: V.Attr -> V.Attr -> WalletInfo -> AccountWidgetState -> V.Image
+drawAccountDetail :: V.Attr -> V.Attr -> AccountInfo -> AccountWidgetState -> V.Image
 drawAccountDetail attr _selAttr info AccountWidgetState{..} = V.vertCat $
   [ V.text' attr $ "Account name:     " <> info ^. labelL
   , V.text' attr $ "Total balance:    " <> case info ^. balanceL of
@@ -122,7 +122,7 @@ handleAccountWidgetEvent UiLangFace{..} ev = do
     AccountUpdateEvent itemInfo -> do
       walletInitializedL .= True
       whenJust itemInfo $ \UiWalletInfo{..} -> let label = fromMaybe "" wpiLabel in case wpiType of
-        Just (UiWalletInfoAccount dp) -> setInfo (WalletAccountInfo label dp wpiAddresses)
+        Just (UiWalletInfoAccount dp) -> setInfo (AccountInfo label dp wpiAddresses)
         _ -> walletItemInfoL .= Nothing
     AccountBalanceCommandResult commandId result -> do
       zoom (walletItemInfoL . _Just . balanceL) $ do


### PR DESCRIPTION
Now wallet tree displays only two levels: wallets and accounts. Wallet
pane displays all addresses for the selected account. A possibility to
select an address is removed.