### PR TITLE
[AD-179] applyBlock for address checkpoints

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
@@ -32,6 +32,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Spec (
   , currentAccPendingTxs
   , currentAccBlockMeta
   , currentAddrCheckpoint
+  , currentAddrUtxo
   , currentAddrUtxoBalance
   ) where
 
@@ -174,7 +175,10 @@ currentAccPendingTxs  = currentAccPending . pendingTransactions . fromDb
 currentAddrCheckpoint :: Lens' AddrCheckpoints AddrCheckpoint
 currentAddrCheckpoint = neHead
 
+currentAddrUtxo        :: Lens' AddrCheckpoints Core.Utxo
 currentAddrUtxoBalance :: Lens' AddrCheckpoints Core.Coin
+
+currentAddrUtxo        = currentAddrCheckpoint . addrCheckpointUtxo        . fromDb
 currentAddrUtxoBalance = currentAddrCheckpoint . addrCheckpointUtxoBalance . fromDb
 
 {-------------------------------------------------------------------------------

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
@@ -21,7 +21,8 @@ import Pos.Core.Chrono (OldestFirst(..))
 import Pos.Crypto (hash)
 import Pos.Txp (Utxo)
 
-import Ariadne.Wallet.Cardano.Kernel.PrefilterTx (PrefilteredBlock(..))
+import Ariadne.Wallet.Cardano.Kernel.PrefilterTx
+  (PrefilteredBlock(..), pfbInputs, pfbOutputs)
 
 import Ariadne.Wallet.Cardano.Kernel.DB.BlockMeta
 import Ariadne.Wallet.Cardano.Kernel.DB.InDb
@@ -89,21 +90,23 @@ class UpdatableWalletState state where
 
 -- | Update (utxo,balance) with the given prefiltered block
 updateUtxo :: PrefilteredBlock -> (Utxo, Core.Coin) -> (Utxo, Core.Coin)
-updateUtxo PrefilteredBlock{..} (currentAccUtxo', currentBalance')
+updateUtxo pfb (currentAccUtxo', currentBalance')
     = (utxo', balance')
     where
-        unionUtxo            = Map.union pfbOutputs currentAccUtxo'
-        utxo'                = utxoRemoveInputs unionUtxo pfbInputs
+        inputs               = pfbInputs pfb
+        outputs              = pfbOutputs pfb
+        unionUtxo            = Map.union outputs currentAccUtxo'
+        utxo'                = utxoRemoveInputs unionUtxo inputs
 
-        unionUtxoRestricted  = utxoRestrictToInputs unionUtxo pfbInputs
-        balanceDelta         = balanceI pfbOutputs - balanceI unionUtxoRestricted
+        unionUtxoRestricted  = utxoRestrictToInputs unionUtxo inputs
+        balanceDelta         = balanceI outputs - balanceI unionUtxoRestricted
         currentBalanceI      = Core.coinToInteger currentBalance'
         balance'             = Core.unsafeIntegerToCoin $ currentBalanceI + balanceDelta
 
 -- | Update the pending transactions with the given prefiltered block
 updatePending :: PrefilteredBlock -> PendingTxs -> PendingTxs
-updatePending PrefilteredBlock{..} =
-    Map.filter (\t -> disjoint (txAuxInputSet t) pfbInputs)
+updatePending pfb =
+    Map.filter (\t -> disjoint (txAuxInputSet t) (pfbInputs pfb))
 
 instance UpdatableWalletState AccCheckpoints where
     newPending tx = do

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
@@ -150,5 +150,16 @@ instance UpdatableWalletState AccCheckpoints where
 
 instance UpdatableWalletState AddrCheckpoints where
     newPending _tx = pass
-    applyBlock (_prefBlock, _bMeta) _checkpoints = error "AddrCheckpoints: applyBlock"
+
+    applyBlock (prefBlock, _bMeta) checkpoints
+        = AddrCheckpoint {
+              _addrCheckpointUtxo = InDb utxo''
+            , _addrCheckpointUtxoBalance = InDb balance''
+            } NE.<| checkpoints
+        where
+            utxo'        = checkpoints ^. currentAddrUtxo
+            utxoBalance' = checkpoints ^. currentAddrUtxoBalance
+
+            (utxo'', balance'') = updateUtxo prefBlock (utxo', utxoBalance')
+
     rollback = error "AddrCheckpoints: rollback"


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-179

**Checklist:**

- [x] Adressed HLint warnings and hints _(irrelevant for imported code)_
- [x] Rebased branch on current master and squashed all "Address PR comment" commits

**Description:**

There are multiple essential changes in this PR:

1. `PrefilteredBlock` is now more structured. Previously there used to be just `Set TxIn` and `Utxo`; now the same things are stored in maps indexed by `AddrWithId`.
2. The stuff in `AcidState.hs` now passes around a function that narrows down a `PrefilteredBlock` or `PrefilteredUtxo` to just one address. It's named `narrowP` in `createPrefiltered`.
3. All of the former allows to implement `applyBlock` for address checkpoints. It reuses the exact same code as account checkpoints, but takes as input only the data that is relevant to the address that is being processed ("data" meaning `TxIn`s referring to spendings from this address and new utxo belonging to this address).

Also, some minor cosmetic changes are introduced (like indentation, parentheses, etc). I hope at some point we will adopt `brittany` or perhaps even `hindent`, because the code we imported from IOHK is very inconsistent in terms of style.

Still TODO:

- [x] Implement `Buildable` instance for `PrefilteredBlock`. I ran into some issues due to the fact that the code uses `type` instead of `newtype`, which makes it difficult to avoid orphan instances. This is not urgent and perhaps the commented-out instance can even be deleted for now, as currently this instance is never used.