### PR TITLE
[AD-233] Consider accounts argument in 'sendTx'

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -5,6 +5,7 @@ module Ariadne.Wallet.Backend.KeyStorage
          -- * Commands/other functions
          refreshState
        , resolveWalletRef
+       , resolveWalletRefThenRead
        , newAddress
        , newAccount
        , newWallet
@@ -171,6 +172,22 @@ resolveWalletRef walletSelRef walRef db = case walRef of
 
     walletList :: [HdRoot]
     walletList = toList (readAllHdRoots hdWallets)
+
+-- | Like 'resolveWalletRef', but also reads some data from 'DB'
+-- corresponding to the resolved root ID, assuming that the wallet
+-- with this ID definitely exists.
+resolveWalletRefThenRead
+  :: IORef (Maybe WalletSelection)
+  -> WalletReference
+  -> DB
+  -> (HdRootId -> HdQueryErr UnknownHdRoot a)
+  -> IO (HdRootId, a)
+resolveWalletRefThenRead walletSelRef walRef db q = do
+    rootId <- resolveWalletRef walletSelRef walRef db
+    (rootId,) <$> case q rootId (db ^. dbHdWallets) of
+        -- This function's assumption is that it must not happen.
+        Left err -> error $ "resolveWalletRefThenRead: " <> pretty err
+        Right res -> return res
 
 resolveAccountRef
   :: IORef (Maybe WalletSelection)

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -506,6 +506,10 @@ instance Buildable HdAddressId where
     build (HdAddressId parentId chain addressIx)
         = bprint ("HdAddressId: "%build%", "%build%", "%build) parentId chain addressIx
 
+instance Buildable UnknownHdRoot where
+    build (UnknownHdRoot rootId)
+        = bprint ("UnknownHdRoot: "%build) rootId
+
 instance Buildable UnknownHdAccount where
     build (UnknownHdAccountRoot rootId)
         = bprint ("UnknownHdAccountRoot: "%build) rootId

--- a/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
+++ b/ariadne/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
@@ -25,6 +25,8 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet (
   , emptyIxSet
     -- * Conversion
   , toAscList
+    -- * Indexing
+  , (@+)
   ) where
 
 import Universum
@@ -215,3 +217,11 @@ toAscList ::
     => IxSet a
     -> [a]
 toAscList = coerce . IxSet.toAscList (Proxy @(PrimKey a)) . unwrapIxSet
+
+{-------------------------------------------------------------------------------
+  Indexing
+-------------------------------------------------------------------------------}
+
+-- | Creates the subset that has an index in the provided list.
+(@+) :: Indexable a => IxSet a -> [PrimKey a] -> IxSet a
+(WrapIxSet ixSet) @+ indices = WrapIxSet (ixSet IxSet.@+ indices)


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-233

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [ ] Adressed HLint warnings and hints
- [x] Rebased branch on current master and squashed all "Address PR comment" commits

**Description:**
This PR finishes AD-233. Earlier I added an argument with list of accounts to be used as inputs, but this argument was ignored.

Didn't test yet, will do. **Upd**: tested, seems to work.
