### PR TITLE
[AD-288] Fix account names in Wallet widget

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Wallet.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Wallet.hs
@@ -182,7 +182,7 @@ handleWalletWidgetEvent = \case
         walletNameL .= fromMaybe "" uwiLabel
         walletBalanceL .= uwiBalance
         walletAccountsL .= map
-          (\(idx, UiAccountInfo{..}) -> WalletAccount idx (fromMaybe "" uwiLabel) uwiBalance False)
+          (\(idx, UiAccountInfo{..}) -> WalletAccount idx (fromMaybe "" uaciLabel) uaciBalance False)
           (zip [0..] uwiAccounts)
       _ -> return ()
   UiCommandResult commandId (UiRenameCommandResult result) -> do


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-288

**Checklist:**

- [ ] ~Updated docs if necessary~ (not applicable)
- [ ] ~Adressed HLint warnings and hints~ (not yet)
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits

**Description:**
Show account names instead of wallet name to fix this bug: https://i.imgur.com/XtOyL4t.png