### PR TITLE
[AD-234] Generate a new address as change

### DIFF
--- a/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -247,7 +247,7 @@ newAddress ::
     -> AccountReference
     -> HdAddressChain
     -> PassPhrase
-    -> IO ()
+    -> IO Address
 newAddress acidDb WalletFace {..} walletSelRef runCardanoMode accRef chain pp = do
   walletDb <- query acidDb Snapshot
   accountId <- resolveAccountRef walletSelRef accRef walletDb
@@ -289,7 +289,7 @@ newAddress acidDb WalletFace {..} walletSelRef runCardanoMode accRef chain pp = 
       , _hdAddressCheckpoints = one emptyAddrCheckpoint
       }
   throwLeftIO $ update acidDb (CreateHdAddress hdAddress)
-  walletRefreshState
+  addr <$ walletRefreshState
     where
       -- Using the sequential indexation as in accounts.
       -- TODO:

--- a/ariadne/src/Ariadne/Wallet/Backend/Mode.hs
+++ b/ariadne/src/Ariadne/Wallet/Backend/Mode.hs
@@ -43,8 +43,8 @@ instance HasConfigurations => MonadTxHistory CardanoMode where
     saveTx = saveTxDefault
 
 instance MonadAddresses CardanoMode where
-    type AddrData CardanoMode = Address
-    getNewAddress = pure
+    type AddrData CardanoMode = IO Address
+    getNewAddress = liftIO
     -- FIXME: do not assume bootstrap era.
     getFakeChangeAddress = pure largestHDAddressBoot
 

--- a/ariadne/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/src/Ariadne/Wallet/Face.hs
@@ -62,7 +62,8 @@ data WalletRestoreType
 
 data WalletFace =
   WalletFace
-    { walletNewAddress :: AccountReference -> HdAddressChain -> PassPhrase -> IO ()
+    { walletNewAddress ::
+        AccountReference -> HdAddressChain -> PassPhrase -> IO Address
     , walletNewAccount :: WalletReference -> Maybe AccountName -> IO ()
     , walletNewWallet :: PassPhrase -> Maybe WalletName -> Maybe Byte -> IO [Text]
     , walletRestore ::

--- a/ariadne/src/Ariadne/Wallet/Knit.hs
+++ b/ariadne/src/Ariadne/Wallet/Knit.hs
@@ -127,8 +127,7 @@ instance (Elem components Wallet, Elem components Core, Elem components Cardano)
             passphrase <- getPassPhraseArg
             pure (accountRef, chain, passphrase)
         , cpRepr = \(accountRef, chain, passphrase) -> CommandAction $ \WalletFace{..} -> do
-            walletNewAddress accountRef chain passphrase
-            return $ toValue ValueUnit
+            toValue . ValueAddress <$> walletNewAddress accountRef chain passphrase
         , cpHelp = "Generate and add a new address to the specified account. When \
                    \no account is specified, uses the selected account."
         }


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-234

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [x] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits

**Description:**

Previously we were reusing one of our addresses as change address,
which is considered bad practice.
Proper approach is to generate a new change address for each transaction.
This logic is handled by the `MonadAddresses` class.
For simplicity an `IO` action which generates a new address is used
as `AddrData`. This action is `walletNewAddress` from `WalletFace` with
proper arguments. `walletNewAddress` was modified to return the address
it generates.

**This PR targets another feature branch!** Should be rebased after #239 is merged.