### PR TITLE
[AD-281] Don't reset focus to first form input when clicking outside input

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/App.hs
@@ -133,7 +133,8 @@ resetAppFocus = get >>= lift . setWidgetFocusList . appFocusList
 
 setAppFocus :: Monad m => WidgetName -> StateT AppState m ()
 setAppFocus focus = do
-  focus' <- uses appWidgetL $ findClosestFocus focus
+  current <- fromMaybe [] <$> uses appFocusRingL B.focusGetCurrent
+  focus' <- uses appWidgetL $ findClosestFocus current focus
   appFocusRingL %= B.focusSetCurrent focus'
 
 updateAppFocusRing :: StateT AppState (B.EventM WidgetName) ()

--- a/ui/vty/src/Ariadne/UI/Vty/Widget.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget.hs
@@ -333,17 +333,18 @@ getFocusRing = B.focusRing . collectFocuses
 --
 -- Goes up along the given path to find closest parent with focus list,
 -- then goes down from there to find the first focusable child.
-findClosestFocus :: WidgetName -> Widget p -> WidgetName
-findClosestFocus [] (Widget WidgetInfo{..})
+findClosestFocus :: WidgetName -> WidgetName -> Widget p -> WidgetName
+findClosestFocus current [] (Widget WidgetInfo{..})
     | n:_ <- catMaybes $ findInChild <$> widgetFocusList = n
     | otherwise = widgetName
   where
     findInChild WidgetNameSelf = Just widgetName
-    findInChild namePart = findClosestFocus [] <$> Map.lookup namePart widgetChildren
-findClosestFocus (np:nps) widget@(Widget WidgetInfo{..})
+    findInChild namePart = findClosestFocus current [] <$> Map.lookup namePart widgetChildren
+findClosestFocus current focus@(np:nps) widget@(Widget WidgetInfo{..})
+  | focus `isPrefixOf` current = current
   | np `elem` widgetFocusList
-  , Just child <- Map.lookup np widgetChildren = findClosestFocus nps child
-  | otherwise = findClosestFocus [] widget
+  , Just child <- Map.lookup np widgetChildren = findClosestFocus current nps child
+  | otherwise = findClosestFocus current [] widget
 
 liftBrick :: B.EventM WidgetName a -> WidgetEventM s p a
 liftBrick = lift . lift . lift


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-281

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
Don't go up the widget hierarchy if clicked widget is the direct ancestor of currently focused widget.
Accidental clicks outside input won't reset focus to first input in a form anymore.