### PR TITLE
[AD-280] Exclude empty account/address lists from focus ring

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
@@ -98,13 +98,7 @@ initAccountWidget langFace =
       WidgetEventListSelected idx -> performCopyAddress idx
       _ -> return ()
 
-    setWidgetFocusList
-      [ WidgetNameAccountName
-      , WidgetNameAccountRenameButton
-      , WidgetNameAccountSend
-      , WidgetNameAccountAddressGenerateButton
-      , WidgetNameAccountAddressList
-      ]
+    withWidgetState updateFocusList
 
 ----------------------------------------------------------------------------
 -- View
@@ -202,6 +196,7 @@ handleAccountWidgetEvent = \case
         accountNameL .= fromMaybe "" uaciLabel
         accountBalanceL .= uaciBalance
         accountAddressesL .= map (\UiAddressInfo{..} -> AccountAddress uadiAddress uadiBalance) uaciAddresses
+        updateFocusList
       _ -> return ()
   UiCommandResult commandId (UiRenameCommandResult result) -> do
     accountRenameResultL %= \case
@@ -223,6 +218,17 @@ handleAccountWidgetEvent = \case
 ----------------------------------------------------------------------------
 -- Actions
 ----------------------------------------------------------------------------
+
+updateFocusList :: Monad m => StateT AccountWidgetState (StateT (WidgetInfo AccountWidgetState p) m) ()
+updateFocusList = do
+  addresses <- use accountAddressesL
+  lift $ setWidgetFocusList $
+    [ WidgetNameAccountName
+    , WidgetNameAccountRenameButton
+    , WidgetNameAccountSend
+    , WidgetNameAccountAddressGenerateButton
+    ] ++
+    (if null addresses then [] else [WidgetNameAccountAddressList])
 
 performRename :: WidgetEventM AccountWidgetState p ()
 performRename = do

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Wallet.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Wallet.hs
@@ -102,14 +102,7 @@ initWalletWidget langFace =
         Just $ widgetParentGetter
         (\WalletWidgetState{..} -> map walletAccountIdx $ filter walletAccountSelected $ walletAccounts)
 
-    setWidgetFocusList
-      [ WidgetNameWalletName
-      , WidgetNameWalletRenameButton
-      , WidgetNameWalletAccountList
-      , WidgetNameWalletNewAccountName
-      , WidgetNameWalletNewAccountButton
-      , WidgetNameWalletSend
-      ]
+    withWidgetState updateFocusList
 
 ----------------------------------------------------------------------------
 -- View
@@ -184,6 +177,7 @@ handleWalletWidgetEvent = \case
         walletAccountsL .= map
           (\(idx, UiAccountInfo{..}) -> WalletAccount idx (fromMaybe "" uaciLabel) uaciBalance False)
           (zip [0..] uwiAccounts)
+        updateFocusList
       _ -> return ()
   UiCommandResult commandId (UiRenameCommandResult result) -> do
     walletRenameResultL %= \case
@@ -209,6 +203,19 @@ handleWalletWidgetEvent = \case
 ----------------------------------------------------------------------------
 -- Actions
 ----------------------------------------------------------------------------
+
+updateFocusList :: Monad m => StateT WalletWidgetState (StateT (WidgetInfo WalletWidgetState p) m) ()
+updateFocusList = do
+  accounts <- use walletAccountsL
+  lift $ setWidgetFocusList $
+    [ WidgetNameWalletName
+    , WidgetNameWalletRenameButton
+    ] ++
+    (if null accounts then [] else [WidgetNameWalletAccountList]) ++
+    [ WidgetNameWalletNewAccountName
+    , WidgetNameWalletNewAccountButton
+    , WidgetNameWalletSend
+    ]
 
 performRename :: WidgetEventM WalletWidgetState p ()
 performRename = do


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-280

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
`Wallet`/`Account` widgets now have dynamic focus list too.
`updateFocusList` signature is still quite unfortunate, but I'm not ready for another refactoring yet :D