### PR TITLE
[AD-282] Allow scrolling viewport past focused widget

### DIFF
--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Account.hs
@@ -148,8 +148,7 @@ drawAccountWidget focus AccountWidgetState{..} = do
 
     labelWidth = 16
 
-    visible namePart = if focus == widgetName ++ [namePart] then B.visible else identity
-    drawChild namePart = visible namePart $ drawWidgetChild focus widget namePart
+    drawChild = drawWidgetChild focus widget
     label = B.padRight (B.Pad 1) . B.txt . fillLeft labelWidth
 
   return $

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/AddWallet.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/AddWallet.hs
@@ -116,8 +116,7 @@ drawAddWalletWidget focus AddWalletWidgetState{..} = do
   widgetName <- getWidgetName
 
   let
-    visible namePart = if focus == widgetName ++ [namePart] then B.visible else identity
-    drawChild namePart = visible namePart $ drawWidgetChild focus widget namePart
+    drawChild = drawWidgetChild focus widget
     label = B.padRight (B.Pad 1) . B.txt . T.takeEnd 13 . (T.append $ T.replicate 13 " ")
     padBottom = B.padBottom (B.Pad 1)
 
@@ -126,7 +125,7 @@ drawAddWalletWidget focus AddWalletWidgetState{..} = do
     B.padAll 1 $
     B.vBox $
     padBottom <$>
-      [ visible WidgetNameAddWalletNewName $ B.txt "Create new wallet"
+      [ B.txt "Create new wallet"
       , label       "Name:" B.<+> drawChild WidgetNameAddWalletNewName
       , label "Passphrase:" B.<+> drawChild WidgetNameAddWalletNewPass
       , label            "" B.<+> drawChild WidgetNameAddWalletNewButton

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Form/Send.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Form/Send.hs
@@ -90,7 +90,6 @@ initSendWidget langFace accountsGetter =
 drawSendWidget :: WidgetName -> (SendWidgetState p) -> WidgetDrawM (SendWidgetState p) p (B.Widget WidgetName)
 drawSendWidget focus SendWidgetState{..} = do
   widget <- ask
-  widgetName <- getWidgetName
 
   let
     padBottom = B.padBottom (B.Pad 1)
@@ -101,8 +100,7 @@ drawSendWidget focus SendWidgetState{..} = do
     labelWidth = 16
     amountWidth = 15
 
-    visible namePart = if focus == widgetName ++ [namePart] then B.visible else identity
-    drawChild namePart = visible namePart $ drawWidgetChild focus widget namePart
+    drawChild = drawWidgetChild focus widget
     label = B.padRight (B.Pad 1) . B.txt . fillLeft labelWidth
 
     drawOutputsHeader = B.hBox

--- a/ui/vty/src/Ariadne/UI/Vty/Widget/Wallet.hs
+++ b/ui/vty/src/Ariadne/UI/Vty/Widget/Wallet.hs
@@ -126,8 +126,7 @@ drawWalletWidget focus WalletWidgetState{..} = do
 
     labelWidth = 16
 
-    visible namePart = if focus == widgetName ++ [namePart] then B.visible else identity
-    drawChild namePart = visible namePart $ drawWidgetChild focus widget namePart
+    drawChild = drawWidgetChild focus widget
     label = B.padRight (B.Pad 1) . B.txt . fillLeft labelWidth
 
   return $


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-282

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
Previously we manually used `Brick.visible` for currently focused widgets, and these "visibility requests" prevented viewports to be scrolled past these focused widgets.

Now we automatically apply `Brick.visible` on focused widgets, _except_ when `widgetIgnoreVisibility` flag is set.
This flag is set every time user scrolls viewport using mouse or `PgUp`/`PgDn`/etc buttons, and reset after every other user interaction, so that the focused widget becomes visible again.

This behaviour is automatic for all concerned widgets, except `Tree`, which is being rendered manually.