### PR TITLE
[AD-295] Use cached balances in GUI

### DIFF
--- a/ui/qt/app/Glue.hs
+++ b/ui/qt/app/Glue.hs
@@ -94,9 +94,6 @@ knitFaceToUI UiFace{..} KnitFace{..} =
           (Knit.ProcCall Knit.selectCommandName
            (map (Knit.ArgPos . Knit.ExprLit . Knit.toLit . Knit.LitNumber . fromIntegral) ws)
           )
-      UiBalance ->
-        Right $ Knit.ExprProcCall
-          (Knit.ProcCall Knit.balanceCommandName [])
       UiKill commandId ->
         Right $ Knit.ExprProcCall
           (Knit.ProcCall Knit.killCommandName
@@ -128,11 +125,6 @@ knitFaceToUI UiFace{..} KnitFace{..} =
           (Knit.ProcCall Knit.newAddressCommandName [])
 
     resultToUI result = \case
-      UiBalance ->
-        Just . UiBalanceCommandResult . either UiBalanceCommandFailure UiBalanceCommandSuccess $
-          fromResult result >>= fromValue >>= \case
-            Knit.ValueCoin n -> Right $ let (amount, unit) = Knit.showCoin n in amount <> " " <> show unit
-            _ -> Left "Unrecognized return value"
       UiSend _ _ ->
         Just . UiSendCommandResult . either UiSendCommandFailure UiSendCommandSuccess $
           fromResult result >>= fromValue >>= \case

--- a/ui/qt/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt/src/Ariadne/UI/Qt/Face.hs
@@ -7,7 +7,6 @@ module Ariadne.UI.Qt.Face
        , UiEvent (..)
        , UiCommand (..)
        , UiCommandResult (..)
-       , UiBalanceCommandResult (..)
        , UiSendCommandResult (..)
        , UiNewWalletCommandResult (..)
        , UiNewAccountCommandResult (..)
@@ -86,7 +85,6 @@ data UiEvent
 -- | Commands issued by the UI widgets
 data UiCommand
   = UiSelect [Word]
-  | UiBalance
   | UiSend Text Text  -- ^ Address, amount
   | UiNewWallet Text  -- ^ Name
   | UiNewAccount Text  -- ^ Name
@@ -95,15 +93,10 @@ data UiCommand
 
 -- | Results of commands issued by the UI widgets
 data UiCommandResult
-  = UiBalanceCommandResult UiBalanceCommandResult
-  | UiSendCommandResult UiSendCommandResult
+  = UiSendCommandResult UiSendCommandResult
   | UiNewWalletCommandResult UiNewWalletCommandResult
   | UiNewAccountCommandResult UiNewAccountCommandResult
   | UiNewAddressCommandResult UiNewAddressCommandResult
-
-data UiBalanceCommandResult
-  = UiBalanceCommandSuccess Text
-  | UiBalanceCommandFailure Text
 
 data UiSendCommandResult
   = UiSendCommandSuccess Text

--- a/ui/qt/src/Ariadne/UI/Qt/MainWindow.hs
+++ b/ui/qt/src/Ariadne/UI/Qt/MainWindow.hs
@@ -84,8 +84,6 @@ handleMainWindowEvent langFace = \case
   UiCommandEvent commandId result -> do
     magnify replL $ handleReplEvent commandId result
   UiCommandResult commandId commandResult -> case commandResult of
-    UiBalanceCommandResult result ->
-      magnify walletL $ handleWalletEvent langFace $ WalletBalanceCommandResult commandId result
     UiSendCommandResult result ->
       magnify walletL $ handleWalletEvent langFace $ WalletSendCommandResult commandId result
     UiNewWalletCommandResult result ->

--- a/ui/qt/src/Ariadne/UI/Qt/Widgets/Wallet.hs
+++ b/ui/qt/src/Ariadne/UI/Qt/Widgets/Wallet.hs
@@ -143,7 +143,6 @@ currentChanged UiLangFace{..} Wallet{..} selected deselected = do
 
 data WalletEvent
   = WalletUpdateEvent [UiWalletTree] (Maybe UiWalletTreeSelection) (Maybe UiSelectionInfo)
-  | WalletBalanceCommandResult UiCommandId UiBalanceCommandResult
   | WalletSendCommandResult UiCommandId UiSendCommandResult
   | WalletNewWalletCommandResult UiCommandId UiNewWalletCommandResult
   | WalletNewAccountCommandResult UiCommandId UiNewAccountCommandResult
@@ -158,11 +157,9 @@ handleWalletEvent langFace ev = do
   case ev of
     WalletUpdateEvent wallets selection selectionInfo -> do
       lift $ updateModel itemModel selectionModel wallets selection
-      magnify walletInfoL $ handleWalletInfoEvent langFace $
-        WalletInfoSelectionChange selectionInfo
-    WalletBalanceCommandResult commandId result ->
-      magnify walletInfoL $ handleWalletInfoEvent langFace $
-        WalletInfoBalanceCommandResult commandId result
+      whenJust selectionInfo $
+        magnify walletInfoL . handleWalletInfoEvent langFace .
+          WalletInfoSelectionChange
     WalletSendCommandResult commandId result ->
       magnify walletInfoL $ handleWalletInfoEvent langFace $
         WalletInfoSendCommandResult commandId result


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-295

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [x] Adressed HLint warnings and hints
- [x] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
Backend now sends cached balance for each wallet and account, no need to
recalculate it on every selection change.
