### PR TITLE
[AD-323] Knit: remove Ord constraint from Knit backend

### DIFF
--- a/ariadne/src/Ariadne/Knit/Backend.hs
+++ b/ariadne/src/Ariadne/Knit/Backend.hs
@@ -21,7 +21,7 @@ type Components components =
   , AllConstrained (Knit.ComponentLitToValue components) components
   , AllConstrained (Knit.ComponentInflate components) components
   , AllConstrained Knit.ComponentPrinter components
-  , Ord (Knit.Value components)
+  , Eq (Knit.Value components)
   )
 
 createKnitBackend

--- a/knit/src/Knit/DisplayError.hs
+++ b/knit/src/Knit/DisplayError.hs
@@ -86,7 +86,7 @@ ppProcError ProcError{..} = ppArgumentError peArgumentError <$> typeErrorsDoc
         if null peTypeErrors
         then empty
         else "Following type errors occured:" <$>
-             (indent 2 . hcat . map ppTypeError . Set.toList) peTypeErrors
+             (indent 2 . hcat . map ppTypeError) peTypeErrors
 
 ppEvalError :: PrettyPrintValue components => EvalError components -> Doc
 ppEvalError (InvalidArguments name procError) =

--- a/knit/src/Knit/Eval.hs
+++ b/knit/src/Knit/Eval.hs
@@ -38,7 +38,7 @@ evaluate
   :: ( AllConstrained (ComponentCommandExec m components) components
      , AllConstrained (ComponentLitToValue components) components
      , Monad m
-     , Ord (Value components)
+     , Eq (Value components)
      )
   => ExecContext m components
   -> Expr (Some (Elem components) (CommandProc components)) components
@@ -49,7 +49,7 @@ eval
   :: ( AllConstrained (ComponentCommandExec m components) components
      , AllConstrained (ComponentLitToValue components) components
      , Monad m
-     , Ord (Value components)
+     , Eq (Value components)
      )
   => ExecContext m components
   -> Expr (Some (Elem components) (CommandProc components)) components
@@ -63,7 +63,7 @@ evalProcCall
   :: forall m components.
      ( AllConstrained (ComponentCommandExec m components) components
      , Monad m
-     , Ord (Value components)
+     , Eq (Value components)
      )
   => ExecContext m components
   -> ProcCall (Some (Elem components) (CommandProc components)) (Value components)
@@ -86,7 +86,7 @@ componentEvalProcCall
      ( AllConstrained (ComponentCommandExec m components) components
      , Elem components component
      , Monad m
-     , Ord (Value components)
+     , Eq (Value components)
      )
   => ComponentExecContext m components component
   -> ProcCall (CommandProc components component) (Value components)


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
`Encrypted SecretKey` in Disciplina doesn't have `Ord` instance, but we still need to use it in Knit.
`Ord` instance in Knit is used only for putting type errors in `Set`, where simple `List` suffices.