### PR TITLE
[AD-328] Decrease number of configurable fields in CLI

### DIFF
--- a/ariadne/cardano/ariadne-cardano.cabal
+++ b/ariadne/cardano/ariadne-cardano.cabal
@@ -191,7 +191,6 @@ library
   ghc-options: -Wall -Wcompat -Werror
                -Wincomplete-uni-patterns -Wincomplete-record-updates
                -Wredundant-constraints
-               -Wno-unused-top-binds
 
   build-tools: cpphs >= 1.19
 

--- a/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
@@ -2,7 +2,6 @@ module Ariadne.Cardano.Backend (createCardanoBackend) where
 
 import Universum
 
-import Ariadne.Config.Cardano (CardanoConfig(..))
 import Control.Concurrent.STM.TVar (TVar)
 import Control.Monad.Trans.Reader (withReaderT)
 import Data.Constraint (Dict(..))
@@ -26,12 +25,13 @@ import Pos.Txp (txpGlobalSettings)
 import Pos.Update.Worker (updateTriggerWorker)
 import Pos.Util (logException, sleep)
 import Pos.Util.CompileInfo (retrieveCompileTimeInfo, withCompileInfo)
-import Pos.Util.UserSecret (UserSecret, userSecret, usVss)
+import Pos.Util.UserSecret (UserSecret, usVss, userSecret)
 import System.Wlog
   (consoleActionB, maybeLogsDirB, removeAllHandlers, setupLogging, showTidB,
   showTimeB, usingLoggerName)
 
 import Ariadne.Cardano.Face
+import Ariadne.Config.Cardano (CardanoConfig(..), cardanoConfigToCommonNodeArgs)
 
 createCardanoBackend ::
        CardanoConfig
@@ -39,19 +39,19 @@ createCardanoBackend ::
     -> (TVar UserSecret -> IO ())
     -> IO (CardanoFace, (CardanoEvent -> IO ()) -> IO ())
 createCardanoBackend cardanoConfig bHandle addUs = do
-  let commonArgs = getCardanoConfig cardanoConfig
+  let commonNodeArgs = cardanoConfigToCommonNodeArgs cardanoConfig
   cardanoContextVar <- newEmptyMVar
   diffusionVar <- newEmptyMVar
   runProduction $
       withCompileInfo $(retrieveCompileTimeInfo) $
-      withConfigurations (CLI.configurationOptions . CLI.commonArgs $ commonArgs) $ \_ntpConf ->
+      withConfigurations (CLI.configurationOptions . CLI.commonArgs $ commonNodeArgs) $ \_ntpConf ->
       return (CardanoFace
           { cardanoRunCardanoMode = Nat (runCardanoMode cardanoContextVar)
           , cardanoConfigurations = Dict
           , cardanoCompileInfo = Dict
           , cardanoGetDiffusion = getDiffusion diffusionVar
           }
-          , runCardanoNode bHandle addUs cardanoContextVar diffusionVar commonArgs)
+          , runCardanoNode bHandle addUs cardanoContextVar diffusionVar commonNodeArgs)
 
 runCardanoMode :: MVar CardanoContext -> (CardanoMode ~> IO)
 runCardanoMode cardanoContextVar (CardanoMode act) = do

--- a/ariadne/cardano/src/Ariadne/Cardano/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Face.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+
 module Ariadne.Cardano.Face
        ( BListenerHandle (..)
        , CardanoContext (..)

--- a/ariadne/cardano/src/Ariadne/Config/Ariadne.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Ariadne.hs
@@ -1,6 +1,11 @@
 module Ariadne.Config.Ariadne
-  ( defaultAriadneConfig
-  , AriadneConfig (..)) where
+       ( defaultAriadneConfig
+       , AriadneConfig (..)
+       , acCardanoL
+       , acWalletL
+       , acUpdateL
+       , acHistoryL
+       ) where
 
 import Universum
 
@@ -9,11 +14,13 @@ import Ariadne.Config.DhallUtil (parseField)
 import Ariadne.Config.History
 import Ariadne.Config.Update
 import Ariadne.Config.Wallet
+import Control.Lens (makeLensesWith)
 import qualified Data.HashMap.Strict.InsOrd as Map
 import qualified Dhall as D
 import Dhall.Core (Expr(..))
 import Dhall.Parser (Src(..))
 import Dhall.TypeCheck (X)
+import IiExtras (postfixLFields)
 
 -- default Ariadne config with Cardano mainnet config
 defaultAriadneConfig :: AriadneConfig
@@ -42,6 +49,8 @@ data AriadneConfig = AriadneConfig
   , acUpdate :: UpdateConfig
   , acHistory :: HistoryConfig
   } deriving (Eq, Show)
+
+makeLensesWith postfixLFields ''AriadneConfig
 
 instance D.Interpret AriadneConfig where
   autoWith _ = D.Type extractOut expectedOut

--- a/ariadne/cardano/src/Ariadne/Config/CLI.hs
+++ b/ariadne/cardano/src/Ariadne/Config/CLI.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+
 module Ariadne.Config.CLI
     ( getConfig
     -- * Exported for testing

--- a/ariadne/cardano/src/Ariadne/Config/CLI.hs
+++ b/ariadne/cardano/src/Ariadne/Config/CLI.hs
@@ -24,9 +24,8 @@ import Pos.Client.CLI.Options (CommonArgs(..))
 import Pos.Core.Slotting (Timestamp(..))
 import Pos.Infra.Network.CLI (NetworkConfigOpts(..))
 import Pos.Infra.Network.Types (NodeName(..))
-import Pos.Infra.Statistics (EkgParams(..), StatsdParams(..))
-import Pos.Infra.Util.TimeWarp
-  (NetworkAddress, addrParser, addrParserNoWildcard)
+import Pos.Infra.Statistics (EkgParams(..))
+import Pos.Infra.Util.TimeWarp (NetworkAddress, addrParser)
 import Pos.Launcher
 import Serokell.Data.Memory.Units (Byte, fromBytes)
 import Serokell.Util.OptParse (fromParsec)
@@ -34,7 +33,6 @@ import Serokell.Util.Parse (byte)
 import System.Directory
   (XdgDirectory(..), doesFileExist, getCurrentDirectory, getXdgDirectory)
 import System.FilePath (isAbsolute, takeDirectory, (</>))
-import qualified Text.Read as R (readEither)
 
 import Ariadne.Config.Ariadne (AriadneConfig(..), defaultAriadneConfig)
 import Ariadne.Config.Cardano (CardanoConfig(..), cardanoFieldModifier)
@@ -54,19 +52,13 @@ data CLI_WalletConfig = CLI_WalletConfig
 
 data CLI_NetworkConfigOpts = CLI_NetworkConfigOpts
     { cli_ncoTopology        :: !(Maybe FilePath)
-    , cli_ncoKademlia        :: !(Maybe FilePath)
     , cli_ncoSelf            :: !(Maybe NodeName)
     , cli_ncoPort            :: !(Maybe Word16)
-    , cli_ncoPolicies        :: !(Maybe FilePath)
-    , cli_ncoBindAddress     :: !(Maybe NetworkAddress)
-    , cli_ncoExternalAddress :: !(Maybe NetworkAddress)
     } deriving (Eq, Show, Generic)
 
 data CLI_CommonArgs = CLI_CommonArgs
     { cli_logConfig            :: !(Maybe FilePath)
     , cli_logPrefix            :: !(Maybe FilePath)
-    , cli_reportServers        :: !(Maybe [Text])
-    , cli_updateServers        :: !(Maybe [Text])
     , cli_configurationOptions :: !CLI_ConfigurationOptions
     } deriving (Eq, Show, Generic)
 
@@ -82,34 +74,15 @@ data CLI_ConfigurationOptions = CLI_ConfigurationOptions
 data CLI_CommonNodeArgs = CLI_CommonNodeArgs
     { cli_dbPath                 :: !(Maybe FilePath)
     , cli_rebuildDB              :: !(Maybe Bool)
-    , cli_devGenesisSecretI      :: !(Maybe Int)
     , cli_keyfilePath            :: !(Maybe FilePath)
     , cli_networkConfigOpts      :: !CLI_NetworkConfigOpts
-    , cli_jlPath                 :: !(Maybe FilePath)
     , cli_commonArgs             :: !CLI_CommonArgs
-    , cli_updateLatestPath       :: !(Maybe FilePath)
-    , cli_updateWithPackage      :: !(Maybe Bool)
-    , cli_route53Params          :: !(Maybe NetworkAddress)
     , cli_enableMetrics          :: !(Maybe Bool)
     , cli_ekgParams              :: !(Maybe EkgParams)
-    , cli_statsdParams           :: !CLI_StatsdParams
-    , cli_cnaDumpGenesisDataPath :: !(Maybe FilePath)
-    , cli_cnaDumpConfiguration   :: !(Maybe Bool)
     } deriving (Eq, Show, Generic)
-
-data CLI_StatsdParams = CLI_StatsdParams
-    { cli_statsdHost     :: !(Maybe Text)
-    , cli_statsdPort     :: !(Maybe Int)
-    , cli_statsdInterval :: !(Maybe Int)
-    , cli_statsdDebug    :: !(Maybe Bool)
-    , cli_statsdPrefix   :: !(Maybe Text)
-    , cli_statsdSuffix   :: !(Maybe Text)
-    } deriving (Eq, Show, Generic)
-
 
 makeLensesWith postfixLFields ''CLI_CommonArgs
 makeLensesWith postfixLFields ''CLI_NetworkConfigOpts
-makeLensesWith postfixLFields ''CLI_StatsdParams
 makeLensesWith postfixLFields ''CLI_ConfigurationOptions
 makeLensesWith postfixLFields ''CLI_AriadneConfig
 makeLensesWith postfixLFields ''CLI_CardanoConfig
@@ -118,7 +91,6 @@ makeLensesWith postfixLFields ''CLI_WalletConfig
 
 makeLensesWith postfixLFields ''NetworkConfigOpts
 makeLensesWith postfixLFields ''CommonArgs
-makeLensesWith postfixLFields ''StatsdParams
 makeLensesWith postfixLFields ''ConfigurationOptions
 makeLensesWith postfixLFields ''CommonNodeArgs
 makeLensesWith postfixLFields ''AriadneConfig
@@ -130,12 +102,22 @@ mergeConfigs :: CLI_AriadneConfig -> AriadneConfig -> AriadneConfig
 mergeConfigs overrideAc defaultAc = mergedAriadneConfig
   where
     -- TODO: AD-175 Overridable update configuration
-    mergedAriadneConfig = AriadneConfig mergedCardanoConfig mergedWalletConfig (defaultAc ^. acUpdateL) mergedHistoryConfig
+    mergedAriadneConfig = AriadneConfig
+        { acCardano = mergedCardanoConfig
+        , acWallet = mergedWalletConfig
+        , acUpdate = defaultAc ^. acUpdateL
+        , acHistory = defaultAc ^. acHistoryL
+        }
 
-    mergedWalletConfig = WalletConfig $ merge (overrideAc ^. cli_acWalletL . cli_wcEntropySizeL) (defaultAc ^. acWalletL . wcEntropySizeL)
+    -- Merge Wallet config
+    overrideWc = overrideAc ^. cli_acWalletL
+    defaultWc = defaultAc ^. acWalletL
+    mergedWalletConfig = WalletConfig
+        { wcEntropySize = merge
+            (overrideWc ^. cli_wcEntropySizeL) (defaultWc ^. wcEntropySizeL)
+        }
 
-    mergedHistoryConfig = defaultAc ^. acHistoryL
-
+    -- Merge Cardano config
     overrideCna = overrideAc ^. cli_acCardanoL . cli_getCardanoConfigL
     defaultCna = defaultAc ^. acCardanoL . getCardanoConfigL
 
@@ -148,42 +130,25 @@ mergeConfigs overrideAc defaultAc = mergedAriadneConfig
     overrideCo = overrideCa ^. cli_configurationOptionsL
     defaultCo = defaultCa ^. configurationOptionsL
 
-    overrideSp = overrideCna ^. cli_statsdParamsL
-    mbDefaultSp = defaultCna ^. statsdParamsL
-
-    mergedCardanoConfig = CardanoConfig CommonNodeArgs
+    mergedCardanoConfig = CardanoConfig $ defaultCna
         { dbPath = (overrideCna ^. cli_dbPathL) <|> (defaultCna ^. dbPathL)
         , rebuildDB = merge (overrideCna ^. cli_rebuildDBL) (defaultCna ^. rebuildDBL)
-        , devGenesisSecretI = (overrideCna ^. cli_devGenesisSecretIL) <|> (defaultCna ^. devGenesisSecretIL)
         , keyfilePath = merge (overrideCna ^. cli_keyfilePathL) (defaultCna ^. keyfilePathL)
         , networkConfigOpts = mergedNetworkConfigOpts
-        , jlPath = (overrideCna ^. cli_jlPathL) <|> (defaultCna ^. jlPathL)
         , commonArgs = mergedCommonArgs
-        , updateLatestPath = merge (overrideCna ^. cli_updateLatestPathL) (defaultCna ^. updateLatestPathL)
-        , updateWithPackage = merge (overrideCna ^. cli_updateWithPackageL) (defaultCna ^. updateWithPackageL)
-        , route53Params = (overrideCna ^. cli_route53ParamsL) <|> (defaultCna ^. route53ParamsL)
         , enableMetrics = merge (overrideCna ^. cli_enableMetricsL) (defaultCna ^. enableMetricsL)
         , ekgParams = (overrideCna ^. cli_ekgParamsL) <|> (defaultCna ^. ekgParamsL)
-        , statsdParams = mergedStatsdParams
-        , cnaDumpGenesisDataPath = (overrideCna ^. cli_cnaDumpGenesisDataPathL) <|> (defaultCna ^. cnaDumpGenesisDataPathL)
-        , cnaDumpConfiguration = merge (overrideCna ^. cli_cnaDumpConfigurationL) (defaultCna ^. cnaDumpConfigurationL)
         }
 
-    mergedNetworkConfigOpts = NetworkConfigOpts
+    mergedNetworkConfigOpts = defaultNco
         { ncoTopology  = (overrideNco ^. cli_ncoTopologyL) <|> (defaultNco ^. ncoTopologyL)
-        , ncoKademlia = (overrideNco ^. cli_ncoKademliaL) <|> (defaultNco ^. ncoKademliaL)
         , ncoSelf = (overrideNco ^. cli_ncoSelfL) <|> (defaultNco ^. ncoSelfL)
         , ncoPort = merge (overrideNco ^. cli_ncoPortL) (defaultNco ^. ncoPortL)
-        , ncoPolicies = (overrideNco ^. cli_ncoPoliciesL) <|> (defaultNco ^. ncoPoliciesL)
-        , ncoBindAddress = (overrideNco ^. cli_ncoBindAddressL) <|> (defaultNco ^. ncoBindAddressL)
-        , ncoExternalAddress = (overrideNco ^. cli_ncoExternalAddressL) <|> (defaultNco ^. ncoExternalAddressL)
         }
 
-    mergedCommonArgs = CommonArgs
+    mergedCommonArgs = defaultCa
         { logConfig = (overrideCa ^. cli_logConfigL) <|> (defaultCa ^. logConfigL)
         , logPrefix = (overrideCa ^. cli_logPrefixL) <|> (defaultCa ^. logPrefixL)
-        , reportServers = merge (overrideCa ^. cli_reportServersL) (defaultCa ^. reportServersL)
-        , updateServers = merge (overrideCa ^. cli_updateServersL) (defaultCa ^. updateServersL)
         , configurationOptions = mergedConfigurationOptions
         }
 
@@ -193,15 +158,6 @@ mergeConfigs overrideAc defaultAc = mergedAriadneConfig
         , cfoSystemStart = (overrideCo ^. cli_cfoSystemStartL) <|> (defaultCo ^. cfoSystemStartL)
         , cfoSeed = (overrideCo ^. cli_cfoSeedL) <|> (defaultCo ^. cfoSeedL)
         }
-
-    mergedStatsdParams = fmap (\defaultSp -> StatsdParams
-            { statsdHost = merge (overrideSp ^. cli_statsdHostL) (defaultSp ^. statsdHostL)
-            , statsdPort = merge (overrideSp ^. cli_statsdPortL) (defaultSp ^. statsdPortL)
-            , statsdInterval = merge (overrideSp ^. cli_statsdIntervalL) (defaultSp ^. statsdIntervalL)
-            , statsdDebug = merge (overrideSp ^. cli_statsdDebugL) (defaultSp ^. statsdDebugL)
-            , statsdPrefix = merge (overrideSp ^. cli_statsdPrefixL) (defaultSp ^. statsdPrefixL)
-            , statsdSuffix = merge (overrideSp ^. cli_statsdSuffixL) (defaultSp ^. statsdSuffixL)
-            }) mbDefaultSp
 
 merge :: Maybe a -> a -> a
 merge = flip fromMaybe
@@ -326,57 +282,19 @@ cliCommonNodeArgsParser = do
     , help "If node's database already exists, discard its contents \
     \and create a new one from scratch."
     ]
-  cli_devGenesisSecretI <- optional $ option auto $ mconcat
-    [ long $ toOptionNameCardano "devGenesisSecretI"
-    , metavar "INT"
-    , help "Used genesis secret key index."
-    ]
   cli_keyfilePath <- optional $ strOption $ mconcat
     [ long $ toOptionNameCardano "keyfilePath"
     , metavar "FILEPATH"
     , help "Path to file with secret key (we use it for Daedalus)."
     ]
   cli_networkConfigOpts <- cliNetworkConfigOption
-  cli_jlPath <- optional $ strOption $ mconcat
-    [ long $ toOptionNameCardano "jlPath"
-    , metavar "FILEPATH"
-    , help "Path to JSON log file."
-    ]
   cli_commonArgs <- cliCommonArgsParser
-  cli_updateLatestPath <- optional $ strOption $ mconcat
-    [ long $ toOptionNameCardano "updateLatestPath"
-    , metavar "FILEPATH"
-    , help "Path to update installer file, \
-    \which should be downloaded by Update System."
-    ]
-  cli_updateWithPackage <- optional $ option auto $ mconcat
-    [ long $ toOptionNameCardano "updateWithPackage"
-    , metavar "BOOL"
-    , help "Enable updating via installer."
-    ]
-  cli_route53Params <- optional $ option (fromParsec addrParser) $ mconcat
-    [ long $ toOptionNameCardano "route53Params"
-    , metavar "IP:PORT"
-    , help "Host and port for the Route53 DNS health check."
-    ]
   cli_enableMetrics <- optional $ option auto $ mconcat
     [ long $ toOptionNameCardano "enableMetrics"
     , metavar "BOOL"
     , help "Enable metrics (EKG, statsd)"
     ]
   cli_ekgParams <- optional cliEkgParamsOption
-  cli_statsdParams <- cliStatsdParamsOption
-
-  cli_cnaDumpGenesisDataPath <- optional $ strOption $ mconcat
-    [ long $ toOptionNameCardano "cnaDumpGenesisDataPath"
-    , metavar "FILEPATH"
-    , help "Dump genesis data in canonical JSON format to this file."
-    ]
-  cli_cnaDumpConfiguration <- optional $ option auto $ mconcat
-    [ long $ toOptionNameCardano "cnaDumpConfiguration"
-    , metavar "BOOL"
-    , help "Dump configuration and exit."
-    ]
 
   pure CLI_CommonNodeArgs{..}
 
@@ -395,58 +313,12 @@ cliEkgServerOption = option (fromParsec addrParser) $ mconcat
   , help "Host and port for the EKG server"
   ]
 
-cliStatsdParamsOption :: Opt.Parser CLI_StatsdParams
-cliStatsdParamsOption = do
-  addr <- optional cliStatsdServerOption
-  interval <- optional $ option auto $ mconcat
-    [ long $ toOptionNameCardano "statsdInterval"
-    , metavar "MILLISECONDS"
-    , help "Polling interval for statsd (milliseconds)"
-    ]
-  debug <- optional $ option auto $ mconcat
-    [ long $ toOptionNameCardano "statsdDebug"
-    , metavar "BOOL"
-    , help "Enable statsd debug mode"
-    ]
-  prefix <- optional $ strOption $ mconcat
-    [ long $ toOptionNameCardano "statsdPrefix"
-    , metavar "TEXT"
-    , help "Prefix for statsd"
-    ]
-  suffix <- optional $ strOption $ mconcat
-    [ long $ toOptionNameCardano "statsdSuffix"
-    , metavar "TEXT"
-    , help "Suffix for statsd"
-    ]
-  pure CLI_StatsdParams
-    { -- The network address parser only accepts ByteStrings which are
-      -- UTF8 encoded
-      cli_statsdHost = decodeUtf8 . fst <$> addr
-    , cli_statsdPort = fromIntegral . snd <$> addr
-    , cli_statsdInterval = interval
-    , cli_statsdDebug = debug
-    , cli_statsdPrefix = prefix
-    , cli_statsdSuffix = suffix
-    }
-
-cliStatsdServerOption :: Opt.Parser NetworkAddress
-cliStatsdServerOption = Opt.option (fromParsec addrParserNoWildcard) $ mconcat
-  [ long $ toOptionNameCardano "statsdAddr"
-  , metavar "IP:PORT"
-  , help "Host and port for the statsd server"
-  ]
-
 cliNetworkConfigOption :: Opt.Parser CLI_NetworkConfigOpts
 cliNetworkConfigOption = do
   cli_ncoTopology <- optional $ strOption $ mconcat
     [ long $ toOptionNameCardano "ncoTopology"
     , metavar "FILEPATH"
     , help "Path to a YAML file containing the network topology"
-    ]
-  cli_ncoKademlia <- optional $ strOption $ mconcat
-    [ long $ toOptionNameCardano "ncoKademlia"
-    , metavar "FILEPATH"
-    , help "Path to a YAML file containing the kademlia configuration"
     ]
   cli_ncoSelf <- optional $ strOption $ mconcat
     [ long $ toOptionNameCardano "ncoSelf"
@@ -458,32 +330,7 @@ cliNetworkConfigOption = do
     , metavar "PORT"
     , help "Port number for IP address to node ID translation"
     ]
-  cli_ncoPolicies <- optional $ strOption $ mconcat
-    [ long $ toOptionNameCardano "ncoPolicies"
-    , metavar "FILEPATH"
-    , help "Path to a YAML file containing the network policies"
-    ]
-  cli_ncoExternalAddress <- cliExternalNetworkAddressOption
-  cli_ncoBindAddress <- cliListenNetworkAddressOption
   pure CLI_NetworkConfigOpts {..}
-
-cliExternalNetworkAddressOption :: Opt.Parser (Maybe NetworkAddress)
-cliExternalNetworkAddressOption = optional $ option (fromParsec addrParserNoWildcard) $ mconcat
-  [ long $ toOptionNameCardano "ncoExternalAddress"
-  , metavar "IP:PORT"
-  , help "IP and port of external address. \
-  \Please make sure these IP and port (on which node is running) are accessible \
-  \otherwise proper work of CSL isn't guaranteed. \
-  \0.0.0.0 is not accepted as a valid host."
-  ]
-
-cliListenNetworkAddressOption :: Opt.Parser (Maybe NetworkAddress)
-cliListenNetworkAddressOption = optional $ option (fromParsec addrParserNoWildcard) $ mconcat
-  [ long $ toOptionNameCardano "ncoBindAddress"
-  , metavar "IP:PORT"
-  , help "IP and port on which to bind and listen. Please make sure these IP \
-    \and port are accessible, otherwise proper work of CSL isn't guaranteed."
-  ]
 
 cliConfigurationOptionsParser :: Opt.Parser CLI_ConfigurationOptions
 cliConfigurationOptionsParser = do
@@ -524,16 +371,6 @@ cliCommonArgsParser = do
     , metavar "FILEPATH"
     , help "Prefix to logger output path."
     ]
-  cli_reportServers <- optional $ option listParser $ mconcat
-    [ long $ toOptionNameCardano "reportServers"
-    , metavar "[URI]"
-    , help "Reporting servers to send crash/error logs on. Expected formatting: '[\"serv-uri-1\", \"serv-uri-2\"]'"
-    ]
-  cli_updateServers <- optional $ option listParser $ mconcat
-    [ long $ toOptionNameCardano "updateServers"
-    , metavar "[URI]"
-    , help "Servers to download updates from. Expected formatting: '[\"serv-uri-1\", \"serv-uri-2\"]'"
-    ]
 
   cli_configurationOptions <- cliConfigurationOptionsParser
   pure CLI_CommonArgs {..}
@@ -543,6 +380,3 @@ toOptionNameCardano = ("cardano:" <>) . toString . cardanoFieldModifier
 
 toOptionNameWallet :: D.Text -> String
 toOptionNameWallet =  ("wallet:" <>) . toString . walletFieldModifier
-
-listParser :: Opt.ReadM [Text]
-listParser =  Opt.eitherReader (R.readEither @[Text])

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -44,6 +44,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet (
     -- ** Composite lenses
   , hdAccountRootId
   , hdAddressRootId
+  , hdAddressChain
   , hdAddressAccountId
     -- * Unknown identifiers
   , UnknownHdRoot(..)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
@@ -49,7 +49,7 @@ unsafeMkWord31 n =
 {-# INLINE unsafeMkWord31 #-}
 
 word31ToWord32 :: Word31 -> Word32
-word31ToWord32 (Word31 n) = n
+word31ToWord32 = getWord31
 
 {-------------------------------------------------------------------------------
   Instances

--- a/ariadne/cardano/test/Spec.hs
+++ b/ariadne/cardano/test/Spec.hs
@@ -2,14 +2,6 @@
 
 import Universum
 
-import Ariadne.Cardano.Orphans ()
-import Ariadne.Config.Ariadne (AriadneConfig(..), defaultAriadneConfig)
-import Ariadne.Config.Cardano (CardanoConfig(..))
-import Ariadne.Config.CLI (mergeConfigs, opts)
-import Ariadne.Config.DhallUtil (fromDhall, toDhall)
-import Ariadne.Config.History (HistoryConfig(..))
-import Ariadne.Config.Update (UpdateConfig(..))
-import Ariadne.Config.Wallet (WalletConfig(..))
 import Control.Lens (makeLensesWith)
 import IiExtras (postfixLFields)
 import qualified Options.Applicative as Opt
@@ -17,8 +9,8 @@ import Pos.Client.CLI.NodeOptions (CommonNodeArgs(..))
 import Pos.Client.CLI.Options (CommonArgs(..))
 import Pos.Infra.Network.CLI (NetworkConfigOpts(..))
 import Pos.Infra.Network.Types (NodeName(..))
-import Pos.Infra.Statistics (EkgParams(..), StatsdParams(..))
-import Pos.Launcher
+import Pos.Infra.Statistics (EkgParams(..))
+import Pos.Launcher (ConfigurationOptions(..))
 import Serokell.Data.Memory.Units (fromBytes)
 import Test.Ariadne.Cardano.Arbitrary ()
 import Test.Ariadne.Knit (knitSpec)
@@ -26,6 +18,13 @@ import Test.Hspec (Expectation, Spec, describe, hspec, it, shouldBe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (Property)
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
+
+import Ariadne.Cardano.Orphans ()
+import Ariadne.Config.Ariadne (AriadneConfig(..), defaultAriadneConfig)
+import Ariadne.Config.Cardano (CardanoConfig(..))
+import Ariadne.Config.CLI (mergeConfigs, opts)
+import Ariadne.Config.DhallUtil (fromDhall, toDhall)
+import Ariadne.Config.Wallet (WalletConfig(..))
 
 makeLensesWith postfixLFields ''CommonNodeArgs
 makeLensesWith postfixLFields ''AriadneConfig
@@ -38,7 +37,7 @@ main = hspec $ do
 
 configSpec :: Spec
 configSpec = describe "Ariadne.Config" $ do
-  it "CLI can override any field" overrideConfigUnitTest
+  it "CLI can override a certain set of fields" overrideConfigUnitTest
   prop "handles any CardanoConfig" propHandleCardanoConfig
 
 propHandleCardanoConfig :: CardanoConfig -> Property
@@ -51,7 +50,7 @@ overrideConfigUnitTest = actual `shouldBe` Just expectedAriadneConfig
   where
     opts' = opts "doesNotMatter"
     actual =
-        (`mergeConfigs` ariadneConfigSample) . view _3 <$>
+        (`mergeConfigs` defaultAriadneConfig) . view _3 <$>
         Opt.getParseResult (Opt.execParserPure Opt.defaultPrefs opts' cliArgs)
 
 cliArgs :: [String]
@@ -59,103 +58,57 @@ cliArgs =
   [ "--config", "doesNotMatter"
   , "--cardano:db-path", "new-db-path"
   , "--cardano:rebuild-db", "True"
-  , "--cardano:genesis-secret", "111"
   , "--cardano:keyfile", "new-keyfile"
   , "--cardano:topology", "new-topology"
-  , "--cardano:kademlia", "new-kademlia"
   , "--cardano:node-id", "new-node-id"
   , "--cardano:default-port", "4444"
-  , "--cardano:policies", "new-policies"
-  , "--cardano:address", "255.255.255.255:8888"
-  , "--cardano:listen", "255.255.255.254:8888"
-  , "--cardano:json-log", "new-json-log"
   , "--cardano:log-config", "new-log-config"
   , "--cardano:log-prefix", "new-log-prefix"
-  , "--cardano:report-servers", "[\"new-report-server-1\", \"new-report-server-2\"]"
-  , "--cardano:update-servers", "[\"new-update-server-1\", \"new-update-server-2\"]"
   , "--cardano:configuration-file", "new-configuration-file"
   , "--cardano:configuration-key", "new-configuration-key"
   , "--cardano:system-start", "89"
   , "--cardano:configuration-seed", "9"
-  , "--cardano:update-latest-path", "new-update-latest-path"
-  , "--cardano:update-with-package", "True"
-  , "--cardano:route53-health-check", "255.255.255.253:8888"
   , "--cardano:metrics", "True"
   , "--cardano:ekg-params", "255.255.255.252:8888"
-  , "--cardano:statsd-server", "255.255.255.251:8888"
-  , "--cardano:statsd-interval", "1000"
-  , "--cardano:statsd-debug", "True"
-  , "--cardano:statsd-prefix", "new-statsd-prefix"
-  , "--cardano:statsd-suffix", "new-statsd-suffix"
-  , "--cardano:dump-genesis-data-to", "new-dump-genesis-data-to"
-  , "--cardano:dump-configuration", "True"
   , "--wallet:entropy-size", "32"
   ]
 
 
 expectedAriadneConfig :: AriadneConfig
-expectedAriadneConfig = AriadneConfig
-  { acCardano = CardanoConfig
-    { getCardanoConfig = CommonNodeArgs
+expectedAriadneConfig = defaultAriadneConfig
+  { acCardano = defaultCardanoConfig
+    { getCardanoConfig = defaultCommonNodeArgs
         { dbPath = Just "new-db-path"
         , rebuildDB = True
-        , devGenesisSecretI = Just 111
         , keyfilePath = "new-keyfile"
-        , networkConfigOpts = NetworkConfigOpts
+        , networkConfigOpts = defaultNetworkConfigOpts
             { ncoTopology = Just "new-topology"
-            , ncoKademlia = Just "new-kademlia"
             , ncoSelf = Just (NodeName "new-node-id")
             , ncoPort = 4444
-            , ncoPolicies = Just "new-policies"
-            , ncoBindAddress = Just ("255.255.255.254",8888)
-            , ncoExternalAddress = Just ("255.255.255.255",8888)
             }
-        , jlPath = Just "new-json-log"
-        , commonArgs = CommonArgs
+        , commonArgs = defaultCommonArgs
           { logConfig = Just "new-log-config"
           , logPrefix = Just "new-log-prefix"
-          , reportServers = ["new-report-server-1", "new-report-server-2"]
-          , updateServers = ["new-update-server-1", "new-update-server-2"]
           , configurationOptions = ConfigurationOptions
-            {cfoFilePath = "new-configuration-file"
+            { cfoFilePath = "new-configuration-file"
             , cfoKey = "new-configuration-key"
-            , cfoSystemStart = Just 89000000, cfoSeed = Just 9
+            , cfoSystemStart = Just 89000000
+            , cfoSeed = Just 9
             }
           }
-        , updateLatestPath = "new-update-latest-path"
-        , updateWithPackage = True
-        , route53Params = Just ("255.255.255.253",8888)
         , enableMetrics = True
-        , ekgParams = Just (EkgParams {ekgHost = "255.255.255.252", ekgPort = 8888})
-        , statsdParams = Just StatsdParams
-          {statsdHost = "255.255.255.251"
-          , statsdPort = 8888
-          , statsdInterval = 1000
-          , statsdDebug = True
-          , statsdPrefix = "new-statsd-prefix"
-          , statsdSuffix = "new-statsd-suffix"
-          }
-        , cnaDumpGenesisDataPath = Just "new-dump-genesis-data-to"
-        , cnaDumpConfiguration = True
+        , ekgParams = Just
+          (EkgParams {ekgHost = "255.255.255.252", ekgPort = 8888})
         }
     }
-  , acWallet = WalletConfig {wcEntropySize = fromBytes 32}
-  , acUpdate = UpdateConfig
-      { ucVersionCheckUrl = "https://serokell.io/ariadne/version"
-      , ucUpdateUrl = "https://serokell.io/ariadne/"
-      , ucCheckDelay = 3600
-      }
-  , acHistory = HistoryConfig {hcPath = "ariadne_history.db"}
+  , acWallet = defaultWalletConfig
+    { wcEntropySize = fromBytes 32
+    }
   }
-
-ariadneConfigSample :: AriadneConfig
-ariadneConfigSample = defaultAriadneConfig & (acCardanoL . getCardanoConfigL . statsdParamsL) .~ statsdSample
   where
-    statsdSample = Just StatsdParams
-      { statsdHost     = "host"
-      , statsdPort     = 2020
-      , statsdInterval = 1010
-      , statsdDebug    = False
-      , statsdPrefix   = "prefix"
-      , statsdSuffix   = "suffix"
-      }
+    defaultCardanoConfig = acCardano defaultAriadneConfig
+    defaultCommonNodeArgs = getCardanoConfig defaultCardanoConfig
+    defaultCommonArgs = commonArgs defaultCommonNodeArgs
+    defaultNetworkConfigOpts = networkConfigOpts defaultCommonNodeArgs
+
+    defaultWalletConfig = acWallet defaultAriadneConfig

--- a/ariadne/cardano/test/Spec.hs
+++ b/ariadne/cardano/test/Spec.hs
@@ -6,8 +6,6 @@ import Control.Lens (makeLensesWith)
 import IiExtras (postfixLFields)
 import qualified Options.Applicative as Opt
 import Pos.Client.CLI.NodeOptions (CommonNodeArgs(..))
-import Pos.Client.CLI.Options (CommonArgs(..))
-import Pos.Infra.Network.CLI (NetworkConfigOpts(..))
 import Pos.Infra.Network.Types (NodeName(..))
 import Pos.Infra.Statistics (EkgParams(..))
 import Pos.Launcher (ConfigurationOptions(..))
@@ -77,38 +75,28 @@ cliArgs =
 expectedAriadneConfig :: AriadneConfig
 expectedAriadneConfig = defaultAriadneConfig
   { acCardano = defaultCardanoConfig
-    { getCardanoConfig = defaultCommonNodeArgs
-        { dbPath = Just "new-db-path"
-        , rebuildDB = True
-        , keyfilePath = "new-keyfile"
-        , networkConfigOpts = defaultNetworkConfigOpts
-            { ncoTopology = Just "new-topology"
-            , ncoSelf = Just (NodeName "new-node-id")
-            , ncoPort = 4444
-            }
-        , commonArgs = defaultCommonArgs
-          { logConfig = Just "new-log-config"
-          , logPrefix = Just "new-log-prefix"
-          , configurationOptions = ConfigurationOptions
-            { cfoFilePath = "new-configuration-file"
-            , cfoKey = "new-configuration-key"
-            , cfoSystemStart = Just 89000000
-            , cfoSeed = Just 9
-            }
+      { ccDbPath = Just "new-db-path"
+      , ccRebuildDB = True
+      , ccKeyfilePath = "new-keyfile"
+      , ccNetworkTopology = Just "new-topology"
+      , ccNetworkNodeId = Just (NodeName "new-node-id")
+      , ccNetworkPort = 4444
+      , ccLogConfig = Just "new-log-config"
+      , ccLogPrefix = Just "new-log-prefix"
+      , ccConfigurationOptions = ConfigurationOptions
+          { cfoFilePath = "new-configuration-file"
+          , cfoKey = "new-configuration-key"
+          , cfoSystemStart = Just 89000000
+          , cfoSeed = Just 9
           }
-        , enableMetrics = True
-        , ekgParams = Just
-          (EkgParams {ekgHost = "255.255.255.252", ekgPort = 8888})
-        }
-    }
+      , ccEnableMetrics = True
+      , ccEkgParams = Just
+        (EkgParams {ekgHost = "255.255.255.252", ekgPort = 8888})
+      }
   , acWallet = defaultWalletConfig
     { wcEntropySize = fromBytes 32
     }
   }
   where
     defaultCardanoConfig = acCardano defaultAriadneConfig
-    defaultCommonNodeArgs = getCardanoConfig defaultCardanoConfig
-    defaultCommonArgs = commonArgs defaultCommonNodeArgs
-    defaultNetworkConfigOpts = networkConfigOpts defaultCommonNodeArgs
-
     defaultWalletConfig = acWallet defaultAriadneConfig

--- a/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
@@ -6,14 +6,11 @@ import Universum
 import Ariadne.Config.Cardano (CardanoConfig(..))
 import Data.Text (pack)
 import Data.Time.Units (fromMicroseconds)
-import Pos.Client.CLI.NodeOptions (CommonNodeArgs(..))
-import Pos.Client.CLI.Options (CommonArgs(..))
 import Pos.Core.Slotting (Timestamp(..))
-import Pos.Infra.Network.CLI (NetworkConfigOpts(..))
 import Pos.Infra.Network.Types (NodeName(..))
-import Pos.Infra.Statistics (EkgParams(..), StatsdParams(..))
+import Pos.Infra.Statistics (EkgParams(..))
 import Pos.Infra.Util.TimeWarp (NetworkAddress)
-import Pos.Launcher
+import Pos.Launcher (ConfigurationOptions(..))
 import Test.QuickCheck (Gen, suchThat)
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
 import Test.QuickCheck.Gen (choose, elements, listOf, oneof)
@@ -21,56 +18,19 @@ import Test.QuickCheck.Gen (choose, elements, listOf, oneof)
 import qualified Data.ByteString.Char8 as B8
 
 instance Arbitrary CardanoConfig where
-  arbitrary = CardanoConfig <$> genCommonNodeArgs
-
-genCommonNodeArgs :: Gen CommonNodeArgs
-genCommonNodeArgs = do
-    dbPath <- genMaybe genValidString
-    rebuildDB <- arbitrary
-    devGenesisSecretI <- arbitrary
-    keyfilePath <- genValidString
-    networkConfigOpts <- genNetworkConfigOpts
-    jlPath <- genMaybe genValidString
-    commonArgs <- genCommonArgs
-    updateLatestPath <- genValidString
-    updateWithPackage <- arbitrary
-    route53Params <- genMaybe genNetworkAddress
-    enableMetrics <- arbitrary
-    ekgParams <- genMaybe genEkgParams
-    statsdParams <- genMaybe genStatsdParams
-    cnaDumpGenesisDataPath <- genMaybe genValidString
-    cnaDumpConfiguration <- arbitrary
-    return CommonNodeArgs {..}
-
-genStatsdParams :: Gen StatsdParams
-genStatsdParams = do
-    statsdHost <- genValidText
-    statsdPort <- (arbitrary :: Gen Int) `suchThat` (> 0)
-    statsdInterval <- arbitrary
-    statsdDebug <- arbitrary
-    statsdPrefix <- genValidText
-    statsdSuffix <- genValidText
-    return StatsdParams {..}
-
-genNetworkConfigOpts :: Gen NetworkConfigOpts
-genNetworkConfigOpts = do
-    ncoTopology <- genMaybe genValidString
-    ncoKademlia <- genMaybe genValidString
-    ncoSelf <- genMaybe $ NodeName <$> genValidText
-    ncoPort <- arbitrary
-    ncoPolicies <- genMaybe genValidString
-    ncoBindAddress <- genMaybe genNetworkAddress
-    ncoExternalAddress <- genMaybe genNetworkAddress
-    return NetworkConfigOpts {..}
-
-genCommonArgs :: Gen CommonArgs
-genCommonArgs = do
-    logConfig <- genMaybe genValidString
-    logPrefix <- genMaybe genValidString
-    reportServers <- listOf genValidText
-    updateServers <- listOf genValidText
-    configurationOptions <- genConfigurationOptions
-    return CommonArgs {..}
+    arbitrary = do
+        ccDbPath <- genMaybe genValidString
+        ccRebuildDB <- arbitrary
+        ccKeyfilePath <- genValidString
+        ccNetworkTopology <- genMaybe genValidString
+        ccNetworkNodeId <- genMaybe $ NodeName <$> genValidText
+        ccNetworkPort <- arbitrary
+        ccLogConfig <- genMaybe genValidString
+        ccLogPrefix <- genMaybe genValidString
+        ccConfigurationOptions <- genConfigurationOptions
+        ccEnableMetrics <- arbitrary
+        ccEkgParams <- genMaybe genEkgParams
+        return CardanoConfig {..}
 
 genEkgParams :: Gen EkgParams
 genEkgParams = do

--- a/ariadne/core/ariadne-core.cabal
+++ b/ariadne/core/ariadne-core.cabal
@@ -81,6 +81,5 @@ library
   ghc-options: -Wall -Wcompat -Werror
                -Wincomplete-uni-patterns -Wincomplete-record-updates
                -Wredundant-constraints
-               -Wno-unused-top-binds
 
   build-tools: cpphs >= 1.19

--- a/config/cardano.dhall
+++ b/config/cardano.dhall
@@ -1,35 +1,17 @@
-{ common-args = 
-    { configuration-options = 
-        { configuration-file = ["./cardano/cardano-config.yaml"] : Optional Text
-        , configuration-key = ["mainnet_full"] : Optional Text
-        , configuration-seed = [] : Optional Integer
-        , system-start = [] : Optional Natural 
-        }
-    , log-config = ["./cardano/log-config.yaml"] : Optional Text
-    , log-prefix = ["@DATA/logs/mainnet"] : Optional Text
-    , report-servers = [] : List Text
-    , update-servers = [] : List Text 
+{ configuration-options =
+    { configuration-file = ["./cardano/cardano-config.yaml"] : Optional Text
+    , configuration-key = ["mainnet_full"] : Optional Text
+    , configuration-seed = [] : Optional Integer
+    , system-start = [] : Optional Natural
     }
+, log-config = ["./cardano/log-config.yaml"] : Optional Text
+, log-prefix = ["@DATA/logs/mainnet"] : Optional Text
 , rebuild-db = False
 , db-path = ["@DATA/db-mainnet"] : Optional Text
-, dump-configuration = False
-, dump-genesis-data-to = [] : Optional Text
 , ekg-params = [] : Optional { IP : Text, PORT : Natural }
-, genesis-secret = [] : Optional Integer
-, json-log = [] : Optional Text
 , keyfile = ["@DATA/secret-mainnet.key"] : Optional Text
 , metrics = False
-, network-config = 
-    { address = [] : Optional { IP : Text, PORT : Natural }
-    , default-port = [+3000] : Optional Natural
-    , kademlia = [] : Optional Text
-    , listen = [] : Optional { IP : Text, PORT : Natural }
-    , node-id = ["node0"] : Optional Text
-    , policies = [] : Optional Text
-    , topology = ["./cardano/topology.yaml"] : Optional Text 
-    }
-, route53-health-check = [] : Optional { IP : Text, PORT : Natural }
-, statsd-params = [] : Optional { statsd-debug : Optional Bool, statsd-interval : Optional Integer, statsd-prefix : Optional Text, statsd-server : { IP : Text, PORT : Natural }, statsd-suffix : Optional Text }
-, update-latest-path = [] : Optional Text
-, update-with-package = False
+, default-port = [+3000] : Optional Natural
+, node-id = ["node0"] : Optional Text
+, topology = ["./cardano/topology.yaml"] : Optional Text
 }

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 let
   overlay = import ''${builtins.fetchGit "ssh://git@github.com/serokell/serokell-overlay"}/pkgs'';
-  nixpkgs = import (builtins.fetchTarball "https://github.com/serokell/nixpkgs/archive/master.tar.gz") {
+  nixpkgs = import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/master.tar.gz") {
     overlays = [ overlay ];
   };
 in


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-328

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [x] Adressed HLint warnings and hints
- [x] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
Some configurable fields are very unlikely to be of interest for anybody, so we remove the ability to configure them to simplify code.
`AriadneConfig` was a `newtype` over `cardano-sl`'s `CommonNodeArgs`, now it's not. The reasons are:
1. Some fields are out of interest.
2. Flat structure is easier to work with.
3. Some other modifications will be necessary for AD-205 most likely.

Also I allowed myself to remove `unused-top-binds` suppression from `.cabal` files, to make it easier to remove stuff that it no longer needed (it was a problem for me while I was working on this issue).


