### PR TITLE
[AD-336] Permit static values for Configuration, LogConfig, Topology

### DIFF
--- a/ariadne/cardano/src/Ariadne/Config/Cardano.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Cardano.hs
@@ -2,7 +2,9 @@ module Ariadne.Config.Cardano
        ( defaultCardanoConfig
        , cardanoFieldModifier
        , CardanoConfig (..)
-       , cardanoConfigToCommonNodeArgs
+       , mkLoggingParams
+       , getNodeParams
+       , gtSscParams
 
        -- * Lenses
        , ccDbPathL
@@ -31,14 +33,23 @@ import qualified Dhall.Core as Core
 import Dhall.Parser (Src(..))
 import Dhall.TypeCheck (X)
 import IiExtras (postfixLFields)
+import Pos.Behavior (BehaviorConfig(..))
 import Pos.Client.CLI.NodeOptions (CommonNodeArgs(..))
 import Pos.Client.CLI.Options (CommonArgs(..))
+import Pos.Client.CLI.Secrets (prepareUserSecret)
+import Pos.Core.Configuration (HasConfiguration)
 import Pos.Core.Slotting (Timestamp(..))
-import Pos.Infra.Network.CLI (NetworkConfigOpts(..))
+import Pos.Crypto (VssKeyPair(..))
+import Pos.Infra.Network.CLI (NetworkConfigOpts(..), intNetworkConfigOpts)
 import Pos.Infra.Network.Types (NodeName(..))
 import Pos.Infra.Statistics (EkgParams(..))
 import Pos.Infra.Util.TimeWarp (NetworkAddress)
 import Pos.Launcher
+  (BaseParams(..), ConfigurationOptions(..), LoggingParams(..), NodeParams(..))
+import Pos.Ssc (SscParams(..))
+import Pos.Update (UpdateParams(..))
+import Pos.Util.UserSecret (peekUserSecret)
+import System.Wlog (usingLoggerName)
 
 import Ariadne.Cardano.Orphans ()
 import Ariadne.Config.DhallUtil
@@ -66,7 +77,7 @@ data CardanoConfig = CardanoConfig
 makeLensesWith postfixLFields ''CardanoConfig
 
 ----------------------------------------------------------------------------
--- Default values and conversion
+-- Default values
 ----------------------------------------------------------------------------
 
 defaultCommonNodeArgs :: CommonNodeArgs
@@ -108,39 +119,6 @@ defaultCommonNodeArgs =
         , cnaDumpConfiguration = False
         }
 
-cardanoConfigToCommonNodeArgs :: CardanoConfig -> CommonNodeArgs
--- Vanilla pattern-matching is used to be sure nothing is forgotten.
-cardanoConfigToCommonNodeArgs (CardanoConfig
-    ccDbPath
-    ccRebuildDB
-    ccKeyfilePath
-    ccNetworkTopology
-    ccNetworkNodeId
-    ccNetworkPort
-    ccLogConfig
-    ccLogPrefix
-    ccConfigurationOptions
-    ccEnableMetrics
-    ccEkgParams
-                              ) =
-    defaultCommonNodeArgs
-        { dbPath = ccDbPath
-        , rebuildDB = ccRebuildDB
-        , keyfilePath = ccKeyfilePath
-        , networkConfigOpts = (networkConfigOpts defaultCommonNodeArgs)
-            { ncoTopology = ccNetworkTopology
-            , ncoSelf = ccNetworkNodeId
-            , ncoPort = ccNetworkPort
-            }
-        , commonArgs = (commonArgs defaultCommonNodeArgs)
-            { logConfig = ccLogConfig
-            , logPrefix = ccLogPrefix
-            , configurationOptions = ccConfigurationOptions
-            }
-        , enableMetrics = ccEnableMetrics
-        , ekgParams = ccEkgParams
-        }
-
 defaultCardanoConfig :: CardanoConfig
 defaultCardanoConfig =
     CardanoConfig
@@ -162,6 +140,82 @@ defaultCardanoConfig =
     ca :: CommonArgs
     ca = commonArgs defaultCommonNodeArgs
 
+----------------------------------------------------------------------------
+-- Getting NodeParams and SscParams
+----------------------------------------------------------------------------
+
+mkLoggingParams :: CardanoConfig -> LoggingParams
+mkLoggingParams CardanoConfig{..} =
+    LoggingParams
+    { lpHandlerPrefix = ccLogPrefix
+    , lpConfigPath    = ccLogConfig
+    , lpDefaultName   = "ariadne"
+    , lpConsoleLog    = Nothing -- overridden in Backend.hs
+    }
+
+gtSscParams :: VssKeyPair -> BehaviorConfig -> SscParams
+gtSscParams vssSK BehaviorConfig{..} =
+    SscParams
+    { spSscEnabled = True
+    , spVssKeyPair = vssSK
+    , spBehavior = bcSscBehavior
+    }
+
+getNodeParams :: HasConfiguration => CardanoConfig -> IO NodeParams
+-- Vanilla pattern-matching is used to be sure nothing is forgotten.
+getNodeParams conf@(CardanoConfig
+    ccDbPath
+    ccRebuildDB
+    ccKeyfilePath
+    ccNetworkTopology
+    ccNetworkNodeId
+    ccNetworkPort
+    _ccLogConfig  -- is used by mkLoggingParams
+    _ccLogPrefix  -- is used by mkLoggingParams
+    _ccConfigurationOptions  -- should not be used
+    ccEnableMetrics
+    ccEkgParams
+    ) = usingLoggerName ("ariadne" <> "cardano" <> "init") $ do
+
+    let defaultCommonArgs = commonArgs defaultCommonNodeArgs
+
+        nco :: NetworkConfigOpts
+        nco = (networkConfigOpts defaultCommonNodeArgs)
+            { ncoTopology = ccNetworkTopology
+            , ncoSelf = ccNetworkNodeId
+            , ncoPort = ccNetworkPort
+            }
+
+        baseParams :: BaseParams
+        baseParams = BaseParams { bpLoggingParams = mkLoggingParams conf }
+
+    networkConfig <- intNetworkConfigOpts nco
+    -- 'defaultCommonNodeArgs' is passed to 'prepareUserSecret' because we do
+    -- not care what will be put into 'UserSecret'
+    -- (it is essential only for core nodes)
+    (primarySK, userSecret) <-
+        prepareUserSecret defaultCommonNodeArgs =<< peekUserSecret ccKeyfilePath
+    pure NodeParams
+        { npDbPathM = ccDbPath
+        , npRebuildDb = ccRebuildDB
+        , npSecretKey = primarySK
+        , npUserSecret = userSecret
+        , npBaseParams = baseParams
+        , npJLFile = jlPath defaultCommonNodeArgs
+        , npReportServers = reportServers defaultCommonArgs
+        , npUpdateParams = UpdateParams
+            { upUpdatePath    = updateLatestPath defaultCommonNodeArgs
+            , upUpdateWithPkg = updateWithPackage defaultCommonNodeArgs
+            , upUpdateServers = updateServers defaultCommonArgs
+            }
+        , npRoute53Params = route53Params defaultCommonNodeArgs
+        , npEnableMetrics = ccEnableMetrics
+        , npEkgParams = ccEkgParams
+        , npStatsdParams = statsdParams defaultCommonNodeArgs
+        , npAssetLockPath = cnaAssetLockPath defaultCommonNodeArgs
+        , npBehaviorConfig = def
+        , npNetworkConfig = networkConfig
+        }
 
 ----------------------------------------------------------------------------
 -- Dhall

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ packages:
 # Cardano SL itself
 - location:
     git: https://github.com/serokell/cardano-sl.git
-    commit: 3d54e135977407e4b32c651e11402faf17d0c979 # ariadne branch
+    commit: b7660d6f2184646522c803dda59b67b2ae04b591 # ariadne branch
   extra-dep: true
   subdirs:
   - binary


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-336

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [x] Adressed HLint warnings and hints
- [x] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**

_Prehistory_
If `--config` option (which defaults to `xdgConfigPath </> "ariadne-config.dhall"`) points to a non-existing file, the default configuration will be used. It can happen for users who built `ariadne` from source, launched it, but didn't copy/symlink configuration into default location. The default configuration uses filepaths like `"config/cardano/topology.yaml"`. That's not ideal because these files might not exist (it will most likely happen if someone launches `ariadne` not from the root of the repository). Ideally we want `ariadne` to be usable regardless of presence of any configuration files on disk.

There are three configuration files which Cardano uses. One of them is mandatory (configuration). It refers to another file, so in some sense there are four files. Other two are optional, but their default values are defined in `cardano-sl` and we want them to be different.
There are (at least) three possible ways to use static values instead of reading data from files:
1. Modify code in `cardano-sl` to accept a default value. Works only for optional files. If the file is mandatory, it should be made optional first.
2. Copy-paste function which uses a default value and modify it in our code. Works only for optional files. If the file is mandatory, it should be made optional first.
3. Create necessary file, dump data there and use its path. Works even for mandatory files.

_Solution_
I spent quite a lot of time on this issue and somehow ended up using all three approaches.
Default logger config was specified in the `readLoggerConfig` function. This function is trivial, so I just copy-pasted it in our code, so that now default logger config is defined in our code.
Default topology was defined in `Pos.Infra.Network.CLI` and it was rather deep. I used combination of (1) and (2). `intNetworkConfigOpts` now accepts default topology. It's used by `getNodeParams` which I copied in our code.
For `Configuration` I decided to use option (3), because otherwise I would have to copy-paste too much code (and modify it in `ariadne`) or generalize too much code directly in `cardano-sl`.