### PR TITLE
[AD-349] Do 'ApplyBlock' update only if it can change something

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
@@ -29,10 +29,10 @@ module Ariadne.Wallet.Cardano.Kernel (
 
 import Universum hiding (State, init)
 
+import Control.Concurrent.STM.TVar (readTVar)
 import Control.Lens.TH
 import qualified Data.Map.Strict as Map
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Control.Concurrent.STM.TVar (readTVar)
 
 import Formatting (build, sformat)
 
@@ -63,8 +63,8 @@ import Pos.Core (AddressHash, Coin, Timestamp(..), TxAux(..))
 
 import Pos.Core.Chrono (OldestFirst(..))
 import Pos.Crypto (EncryptedSecretKey, PublicKey)
-import Pos.Util.UserSecret (UserSecret, usWallets)
 import Pos.Txp (Utxo)
+import Pos.Util.UserSecret (UserSecret, usWallets)
 
 {-------------------------------------------------------------------------------
   Passive wallet
@@ -211,7 +211,8 @@ applyBlock pw@PassiveWallet{..} b
         let blockMeta = BlockMeta . InDb $ Map.empty
 
         -- apply block to all Accounts in all Wallets
-        void $ update' _wallets $ ApplyBlock (blocksByAccount, blockMeta)
+        unless (null blocksByAccount) $
+            update' _wallets $ ApplyBlock (blocksByAccount, blockMeta)
 
 -- | Apply multiple blocks, one at a time, to all wallets in the PassiveWallet
 --


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-349

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [x] Adressed HLint warnings and hints
- [x] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
If `blocksByAccount` is empty, `ApplyBlock` will not do anything.
However, these events will be in the DB log of events. We don't want
to store useless events.
