### PR TITLE
[AD-229] Use componentm for components creation

### DIFF
--- a/ariadne/cardano/ariadne-cardano.cabal
+++ b/ariadne/cardano/ariadne-cardano.cabal
@@ -43,6 +43,7 @@ library
     , cardano-sl-util
     , Cabal
     , MissingH
+    , componentm
     , conduit
     , contravariant
     , constraints
@@ -95,13 +96,14 @@ library
     , unliftio-core
     , monad-control
     , transformers-base
+    , vinyl
     , yaml
   exposed-modules:
-      Ariadne.Update.Backend
       Ariadne.Cardano.Knit
       Ariadne.Cardano.Backend
       Ariadne.Cardano.Face
       Ariadne.Cardano.Orphans
+
       Ariadne.Config.Wallet
       Ariadne.Config.Ariadne
       Ariadne.Config.CLI
@@ -110,6 +112,11 @@ library
       Ariadne.Config.Update
       Ariadne.Config.DhallUtil
       Ariadne.Config.TH
+
+      Ariadne.MainTemplate
+
+      Ariadne.Update.Backend
+
       Ariadne.Wallet.Knit
       Ariadne.Wallet.Backend
       Ariadne.Wallet.Backend.AddressDiscovery

--- a/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
@@ -3,6 +3,7 @@ module Ariadne.Cardano.Backend (createCardanoBackend) where
 import Universum
 
 import Control.Concurrent.STM.TVar (TVar)
+import Control.Monad.Component (ComponentM, buildComponent_)
 import Control.Monad.Trans.Reader (withReaderT)
 import qualified Data.ByteString as BS
 import Data.Constraint (Dict(..))
@@ -44,8 +45,8 @@ createCardanoBackend ::
        CardanoConfig
     -> BListenerHandle
     -> (TVar UserSecret -> IO ())
-    -> IO (CardanoFace, (CardanoEvent -> IO ()) -> IO ())
-createCardanoBackend cardanoConfig bHandle addUs = do
+    -> ComponentM (CardanoFace, (CardanoEvent -> IO ()) -> IO ())
+createCardanoBackend cardanoConfig bHandle addUs = buildComponent_ "Cardano" $ do
   cardanoContextVar <- newEmptyMVar
   diffusionVar <- newEmptyMVar
   let confOpts = ccConfigurationOptions cardanoConfig

--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -1,0 +1,133 @@
+-- | Template of the code that is supposed to be in 'Main.hs'.
+
+module Ariadne.MainTemplate
+       ( MainSettings (..)
+       , defaultMain
+       ) where
+
+import Universum
+
+import Control.Concurrent.Async (race_, withAsync)
+import Control.Monad.Component (ComponentM, runComponentM)
+import Data.Version (Version)
+import Data.Vinyl.Core (Rec(..), (<+>))
+import Data.Vinyl.TypeLevel (type (++))
+import IiExtras (runNat)
+import Text.PrettyPrint.ANSI.Leijen (Doc)
+
+import Ariadne.Cardano.Backend (createCardanoBackend)
+import Ariadne.Cardano.Face (CardanoEvent, CardanoFace(..))
+import Ariadne.Config.Ariadne (AriadneConfig(..))
+import Ariadne.Config.CLI (getConfig)
+import Ariadne.Config.History (HistoryConfig(..))
+import Ariadne.Knit.Backend (Components, KnitFace, createKnitBackend)
+import Ariadne.TaskManager.Backend
+import Ariadne.Update.Backend
+import Ariadne.UX.CommandHistory
+import Ariadne.Wallet.Backend
+import Ariadne.Wallet.Face (WalletEvent)
+
+import qualified Ariadne.Cardano.Knit as Knit
+import qualified Ariadne.TaskManager.Knit as Knit
+import qualified Ariadne.Wallet.Knit as Knit
+import qualified Knit
+
+type NonUiComponents = '[Knit.Core, Knit.Cardano, Knit.Wallet, Knit.TaskManager]
+
+type family AllComponents (uiComponents :: [*]) :: [*] where
+   AllComponents uiComponents = uiComponents ++ NonUiComponents
+
+-- | Everything needed for the 'main' function.
+data MainSettings (uiComponents :: [*]) uiFace uiLangFace = MainSettings
+    { msCommitHash :: !String
+    -- ^ Commit hash of current revision. Should be passed to
+    -- 'defaultMain' instead of being obtained there, because it
+    -- involves TH and we want to run it only when we build
+    -- executables, not when we build the library.
+    , msCreateUI :: !(CommandHistory -> ComponentM (uiFace, uiLangFace -> IO ()))
+    , msPutWalletEventToUI :: !(uiFace -> WalletEvent -> IO ())
+    , msPutCardanoEventToUI :: !(uiFace -> CardanoEvent -> IO ())
+    , msPutUpdateEventToUI :: !(Maybe (uiFace -> Version -> Text -> IO ()))
+    -- ^ Make UI process an update event if it's supported by UI. If
+    -- it's not supported, this field can be 'Nothing'.
+    , msKnitFaceToUI ::
+        !(uiFace -> KnitFace (AllComponents uiComponents) -> uiLangFace)
+    , msUiExecContext ::
+        !(uiFace ->
+        Rec (Knit.ComponentExecContext IO (AllComponents uiComponents)) uiComponents)
+    }
+
+-- | Default implementation of the 'main' function.
+defaultMain
+    :: Components (AllComponents uiComponents)
+    => MainSettings uiComponents uiFace uiLangFace -> IO ()
+defaultMain settings = do
+    ariadneConfig <- getConfig (msCommitHash settings)
+    runComponentM "ariadne" (initializeEverything settings ariadneConfig) id
+
+initializeEverything
+    :: forall uiComponents uiFace uiLangFace.
+       Components (AllComponents uiComponents)
+    => MainSettings uiComponents uiFace uiLangFace
+    -> AriadneConfig
+    -> ComponentM (IO ())
+initializeEverything MainSettings {..}
+                     AriadneConfig { acCardano = cardanoConfig
+                                   , acWallet = walletConfig
+                                   , acUpdate = updateConfig
+                                   , acHistory = historyConfig
+                                   } = do
+  history <- openCommandHistory $ hcPath historyConfig
+
+  (uiFace, mkUiAction) <- msCreateUI history
+  (bHandle, addUs, mkWallet) <-
+      createWalletBackend walletConfig (msPutWalletEventToUI uiFace)
+  (cardanoFace, mkCardanoAction) <- createCardanoBackend cardanoConfig bHandle addUs
+  let CardanoFace { cardanoRunCardanoMode = runCardanoMode
+                  } = cardanoFace
+  taskManagerFace <- createTaskManagerFace
+
+  let
+    mkWalletFace :: (Doc -> IO ()) -> WalletFace
+    walletInitAction :: IO ()
+    (mkWalletFace, walletInitAction) =
+      mkWallet cardanoFace
+
+    knitExecContext ::
+        (Doc -> IO ()) -> Knit.ExecContext IO (AllComponents uiComponents)
+    knitExecContext putCommandOutput =
+       msUiExecContext uiFace <+>
+       Knit.CoreExecCtx (putCommandOutput . Knit.ppValue) :&
+       Knit.CardanoExecCtx (runNat runCardanoMode) :&
+       Knit.WalletExecCtx walletFace :&
+       Knit.TaskManagerExecCtx taskManagerFace :&
+       RNil
+      where
+        walletFace = mkWalletFace putCommandOutput
+
+    knitFace :: KnitFace (AllComponents uiComponents)
+    knitFace = createKnitBackend knitExecContext taskManagerFace
+
+    uiAction, cardanoAction :: IO ()
+    uiAction = mkUiAction (msKnitFaceToUI uiFace knitFace)
+    cardanoAction = mkCardanoAction (msPutCardanoEventToUI uiFace)
+
+    raceWithUpdateCheckAction :: IO () -> IO ()
+    raceWithUpdateCheckAction action =
+      case msPutUpdateEventToUI of
+        Nothing -> action
+        Just putUpdateEventToUI ->
+          let updateCheck =
+                runUpdateCheck updateConfig (putUpdateEventToUI uiFace)
+          in action `race_` updateCheck
+
+    initAction :: IO ()
+    initAction = walletInitAction
+
+    serviceAction :: IO ()
+    serviceAction =
+      raceWithUpdateCheckAction $
+      uiAction `race_`
+      cardanoAction
+
+  return $ withAsync initAction $ \_ -> serviceAction

--- a/ariadne/core/ariadne-core.cabal
+++ b/ariadne/core/ariadne-core.cabal
@@ -22,6 +22,7 @@ library
     , ansi-wl-pprint
     , async
     , containers
+    , componentm
     , formatting
     , knit
     , lens

--- a/ariadne/core/src/Ariadne/Knit/Backend.hs
+++ b/ariadne/core/src/Ariadne/Knit/Backend.hs
@@ -1,5 +1,6 @@
 module Ariadne.Knit.Backend
-  ( KnitFace(..)
+  ( Components
+  , KnitFace(..)
   , createKnitBackend
   ) where
 

--- a/ariadne/core/src/Ariadne/TaskManager/Backend.hs
+++ b/ariadne/core/src/Ariadne/TaskManager/Backend.hs
@@ -4,6 +4,7 @@ import Universum
 
 import Control.Concurrent.Async
 import Control.Lens as L
+import Control.Monad.Component (ComponentM, buildComponent_)
 import Data.Map as Map
 import IiExtras
 
@@ -22,8 +23,8 @@ data TaskMap v = TaskMap
   }
 makeLenses 'TaskMap
 
-createTaskManagerFace :: forall v. IO (TaskManagerFace v)
-createTaskManagerFace = do
+createTaskManagerFace :: forall v. ComponentM (TaskManagerFace v)
+createTaskManagerFace = buildComponent_ "TaskManager" $ do
   idGen <- newTaskIdGenerator
   taskMapVar <- newIORef (TaskMap Map.empty Map.empty)
   let

--- a/ariadne/core/src/Ariadne/UX/CommandHistory.hs
+++ b/ariadne/core/src/Ariadne/UX/CommandHistory.hs
@@ -9,8 +9,9 @@ module Ariadne.UX.CommandHistory
 
 import Universum
 
-import Database.SQLite.Simple
+import Control.Monad.Component (ComponentM, buildComponent_)
 import qualified Data.Text as T
+import Database.SQLite.Simple
 
 data Row = Row Int T.Text deriving (Show)
 instance FromRow Row where
@@ -26,8 +27,8 @@ data CommandHistory =
     , currentPrefix :: IORef Text
     }
 
-openCommandHistory :: FilePath -> IO CommandHistory
-openCommandHistory historyFile = do
+openCommandHistory :: FilePath -> ComponentM CommandHistory
+openCommandHistory historyFile = buildComponent_ "Command history" $ do
     currentPrefix <- newIORef ""
     currentCommandId <- newIORef 0
     withConnection historyFile $
@@ -73,7 +74,7 @@ changeCommand ch direction = do
           Next -> do
             resetCurrentCommandId ch
             return $ Just prefix
-    
+
 setPrefix :: CommandHistory -> Text -> IO ()
 setPrefix ch (T.strip -> prefix) = do
     resetCurrentCommandId ch

--- a/stack.yaml
+++ b/stack.yaml
@@ -254,6 +254,8 @@ extra-deps:
 - vinyl-0.8.1.1
 - named-0.1.0.0
 - base-noprelude-4.10.1.0 # due to lootbox
+- componentm-0.0.0.2
+- teardown-0.5.0.0
 
 ## Ariadne Qt GUI specific
 - hoppy-runtime-0.5.0

--- a/ui/cli-app/Main.hs
+++ b/ui/cli-app/Main.hs
@@ -2,72 +2,27 @@ module Main where
 
 import Universum
 
-import Control.Concurrent.Async
 import IiExtras
-import Text.PrettyPrint.ANSI.Leijen (Doc)
 
-import Ariadne.Cardano.Backend
-import Ariadne.Cardano.Face (CardanoFace(..))
-import Ariadne.Config.Ariadne (AriadneConfig(..))
-import Ariadne.Config.CLI (getConfig)
 import Ariadne.Config.TH (getCommitHash)
-import Ariadne.Knit.Backend
-import Ariadne.TaskManager.Backend
+import Ariadne.MainTemplate (MainSettings(..), defaultMain)
 import Ariadne.UI.Cli
-import Ariadne.Update.Backend
-import Ariadne.Wallet.Backend
-
-import qualified Ariadne.Cardano.Knit as Knit
-import qualified Ariadne.TaskManager.Knit as Knit
-import qualified Ariadne.Wallet.Knit as Knit
-import qualified Knit
+import Ariadne.UI.Cli.Face (UiLangFace)
 
 import Glue
 
-type Components = '[Knit.Core, Knit.Cardano, Knit.Wallet, Knit.TaskManager]
+type UiComponents = '[]
 
 main :: IO ()
-main = do
-  ariadneConfig <- getConfig $(getCommitHash)
-  let cardanoConfig = acCardano ariadneConfig
-      walletConfig = acWallet ariadneConfig
-      updateConfig = acUpdate ariadneConfig
-
-  (uiFace, mkUiAction) <- createAriadneUI
-  (bHandle, addUs, mkWallet) <- createWalletBackend walletConfig (putWalletEventToUI uiFace)
-  (cardanoFace, mkCardanoAction) <- createCardanoBackend cardanoConfig bHandle addUs
-  let CardanoFace { cardanoRunCardanoMode = runCardanoMode
-                  } = cardanoFace
-  taskManagerFace <- createTaskManagerFace
-
-  let
-    mkWalletFace :: (Doc -> IO ()) -> WalletFace
-    walletInitAction :: IO ()
-    (mkWalletFace, walletInitAction) =
-      mkWallet cardanoFace
-
-    knitExecContext :: (Doc -> IO ()) -> Knit.ExecContext IO Components
-    knitExecContext putCommandOutput =
-      Knit.CoreExecCtx (putCommandOutput . Knit.ppValue) :&
-      Knit.CardanoExecCtx (runNat runCardanoMode) :&
-      Knit.WalletExecCtx walletFace :&
-      Knit.TaskManagerExecCtx taskManagerFace :&
-      RNil
-      where
-        walletFace = mkWalletFace putCommandOutput
-
-    knitFace = createKnitBackend knitExecContext taskManagerFace
-
-    uiAction, cardanoAction, updateCheckAction :: IO ()
-    uiAction = mkUiAction (knitFaceToUI uiFace knitFace)
-    cardanoAction = mkCardanoAction (putCardanoEventToUI uiFace)
-
-    updateCheckAction = runUpdateCheck updateConfig (putUpdateEventToUI uiFace)
-
-    initAction :: IO ()
-    initAction = walletInitAction
-
-    serviceAction :: IO ()
-    serviceAction = uiAction `race_` cardanoAction `race_` updateCheckAction
-
-  withAsync initAction $ \_ -> serviceAction
+main = defaultMain mainSettings
+  where
+    mainSettings :: MainSettings UiComponents UiFace UiLangFace
+    mainSettings = MainSettings
+        { msCommitHash = $(getCommitHash)
+        , msCreateUI = const createAriadneUI
+        , msPutWalletEventToUI = putWalletEventToUI
+        , msPutCardanoEventToUI = putCardanoEventToUI
+        , msPutUpdateEventToUI = Just putUpdateEventToUI
+        , msKnitFaceToUI = knitFaceToUI
+        , msUiExecContext = const RNil
+        }

--- a/ui/cli-app/ariadne-cli-app.cabal
+++ b/ui/cli-app/ariadne-cli-app.cabal
@@ -25,6 +25,7 @@ executable ariadne-cli
     , ariadne-core
     , async
     , base >=4.7 && <5
+    , componentm
     , ii-extras
     , knit
     , text

--- a/ui/cli-lib/ariadne-cli-lib.cabal
+++ b/ui/cli-lib/ariadne-cli-lib.cabal
@@ -20,6 +20,7 @@ library
   build-depends:
       ansi-wl-pprint
     , base >=4.7 && <5
+    , componentm
     , haskeline
     , loc
     , text

--- a/ui/cli-lib/src/Ariadne/UI/Cli.hs
+++ b/ui/cli-lib/src/Ariadne/UI/Cli.hs
@@ -5,6 +5,7 @@ module Ariadne.UI.Cli
 
 import Universum
 
+import Control.Monad.Component (ComponentM, buildComponent_)
 import Data.Text (strip, unlines)
 
 import qualified System.Console.Haskeline as Haskeline
@@ -16,8 +17,8 @@ type Repl = Haskeline.InputT IO
 type UiAction = UiLangFace -> IO ()
 type PrintAction = Text -> IO ()
 
-createAriadneUI :: IO (UiFace, UiAction)
-createAriadneUI = do
+createAriadneUI :: ComponentM (UiFace, UiAction)
+createAriadneUI = buildComponent_ "UI-CLI" $ do
     printActionVar :: MVar PrintAction <- newEmptyMVar
     let uiFace = mkUiFace printActionVar
     return (uiFace, runUI printActionVar uiFace)

--- a/ui/qt-app/ariadne-qt-app.cabal
+++ b/ui/qt-app/ariadne-qt-app.cabal
@@ -25,6 +25,7 @@ executable ariadne-qt
     , ariadne-qt-lib
     , async
     , base >=4.7 && <5
+    , componentm
     , containers
     , double-conversion
     , ii-extras

--- a/ui/qt-lib/ariadne-qt-lib.cabal
+++ b/ui/qt-lib/ariadne-qt-lib.cabal
@@ -31,6 +31,7 @@ library
     , text
     , ansi-wl-pprint
     , containers
+    , componentm
     , hoppy-runtime
     , loc
     , qtah

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -6,6 +6,7 @@ module Ariadne.UI.Qt
 import Universum
 
 import Control.Concurrent
+import Control.Monad.Component (ComponentM, buildComponent_)
 import Control.Monad.Extra (loopM)
 
 import Ariadne.UI.Qt.Face (UiEvent(..), UiFace(..), UiHistoryFace, UiLangFace)
@@ -29,11 +30,13 @@ type UiAction = UiLangFace -> IO ()
 
 type UiEventBQueue = TBQueue UiEvent
 
-createAriadneUI :: UiHistoryFace -> IO (UiFace, UiAction)
-createAriadneUI historyFace = do
+createAriadneUI :: UiHistoryFace -> ComponentM (UiFace, UiAction)
+createAriadneUI historyFace = buildComponent_ "UI-Qt" $ do
   eventQueue <- mkEventBQueue
   dispatcherIORef :: IORef (Maybe QObject.QObject) <- newIORef Nothing
-  return (mkUiFace eventQueue dispatcherIORef, runUIEventLoop eventQueue dispatcherIORef historyFace)
+  return
+    ( mkUiFace eventQueue dispatcherIORef
+    , runUIEventLoop eventQueue dispatcherIORef historyFace)
 
 fonts :: [Text]
 fonts =

--- a/ui/vty-app/Main.hs
+++ b/ui/vty-app/Main.hs
@@ -2,89 +2,43 @@ module Main where
 
 import Universum
 
-import Control.Concurrent.Async
+import Control.Monad.Component (ComponentM)
 import IiExtras
-import Text.PrettyPrint.ANSI.Leijen (Doc)
 
-import Ariadne.Cardano.Backend
-import Ariadne.Cardano.Face (CardanoFace(..))
-import Ariadne.Config.Ariadne (AriadneConfig(..))
-import Ariadne.Config.CLI (getConfig)
-import Ariadne.Config.History (HistoryConfig(..))
 import Ariadne.Config.TH (getCommitHash)
-import Ariadne.Knit.Backend
-import Ariadne.TaskManager.Backend
+import Ariadne.MainTemplate (MainSettings(..), defaultMain)
 import Ariadne.UI.Vty
 import Ariadne.UI.Vty.Face
-import Ariadne.Update.Backend
 import Ariadne.UX.CommandHistory
-import Ariadne.Wallet.Backend
 
-import qualified Ariadne.Cardano.Knit as Knit
-import qualified Ariadne.TaskManager.Knit as Knit
 import qualified Ariadne.UI.Vty.Knit as Knit
-import qualified Ariadne.Wallet.Knit as Knit
-import qualified Knit
 
 import Glue
 
-type Components = '[Knit.Core, Knit.Cardano, Knit.Wallet, Knit.TaskManager, Knit.UI]
+type UiComponents = '[Knit.UI]
 
 main :: IO ()
-main = do
-  ariadneConfig <- getConfig $(getCommitHash)
-  let cardanoConfig = acCardano ariadneConfig
-      walletConfig = acWallet ariadneConfig
-      updateConfig = acUpdate ariadneConfig
-      historyConfig = acHistory ariadneConfig
+main = defaultMain mainSettings
+  where
+    mainSettings :: MainSettings UiComponents UiFace UiLangFace
+    mainSettings = MainSettings
+        { msCommitHash = $(getCommitHash)
+        , msCreateUI = createUI
+        , msPutWalletEventToUI = putWalletEventToUI
+        , msPutCardanoEventToUI = putCardanoEventToUI
+        , msPutUpdateEventToUI = Just putUpdateEventToUI
+        , msKnitFaceToUI = knitFaceToUI
+        , msUiExecContext = \uiFace -> Knit.UiExecCtx uiFace :& RNil
+        }
 
-  history <- openCommandHistory $ hcPath historyConfig
-  let historyFace = historyToUI history
-
-  let
-    features = UiFeatures
-      { featureStatus = True
-      , featureExport = False
-      , featureAccounts = True
-      , featureFullRestore = True
-      , featureSecretKeyName = "Mnemonic"
-      }
-  (uiFace, mkUiAction) <- createAriadneUI features historyFace
-  (bHandle, addUs, mkWallet) <- createWalletBackend walletConfig (putWalletEventToUI uiFace)
-  (cardanoFace, mkCardanoAction) <- createCardanoBackend cardanoConfig bHandle addUs
-  let CardanoFace { cardanoRunCardanoMode = runCardanoMode
-                  } = cardanoFace
-  taskManagerFace <- createTaskManagerFace
-
-  let
-    mkWalletFace :: (Doc -> IO ()) -> WalletFace
-    walletInitAction :: IO ()
-    (mkWalletFace, walletInitAction) =
-      mkWallet cardanoFace
-
-    knitExecContext :: (Doc -> IO ()) -> Knit.ExecContext IO Components
-    knitExecContext putCommandOutput =
-      Knit.CoreExecCtx (putCommandOutput . Knit.ppValue) :&
-      Knit.CardanoExecCtx (runNat runCardanoMode) :&
-      Knit.WalletExecCtx walletFace :&
-      Knit.TaskManagerExecCtx taskManagerFace :&
-      Knit.UiExecCtx uiFace :&
-      RNil
-      where
-        walletFace = mkWalletFace putCommandOutput
-
-    knitFace = createKnitBackend knitExecContext taskManagerFace
-
-    uiAction, cardanoAction, updateCheckAction :: IO ()
-    uiAction = mkUiAction (knitFaceToUI uiFace knitFace)
-    cardanoAction = mkCardanoAction (putCardanoEventToUI uiFace)
-
-    updateCheckAction = runUpdateCheck updateConfig (putUpdateEventToUI uiFace)
-
-    initAction :: IO ()
-    initAction = walletInitAction
-
-    serviceAction :: IO ()
-    serviceAction = uiAction `race_` cardanoAction `race_` updateCheckAction
-
-  withAsync initAction $ \_ -> serviceAction
+    createUI :: CommandHistory -> ComponentM (UiFace, UiLangFace -> IO ())
+    createUI history =
+        let historyFace = historyToUI history
+            features = UiFeatures
+                { featureStatus = True
+                , featureExport = False
+                , featureAccounts = True
+                , featureFullRestore = True
+                , featureSecretKeyName = "Mnemonic"
+                }
+        in createAriadneUI features historyFace

--- a/ui/vty-app/ariadne-vty-app.cabal
+++ b/ui/vty-app/ariadne-vty-app.cabal
@@ -25,6 +25,7 @@ executable ariadne
     , ariadne-vty-lib
     , async
     , base >=4.7 && <5
+    , componentm
     , containers
     , double-conversion
     , ii-extras

--- a/ui/vty-lib/ariadne-vty-lib.cabal
+++ b/ui/vty-lib/ariadne-vty-lib.cabal
@@ -22,6 +22,7 @@ library
     , ansi-terminal
     , base >=4.7 && <5
     , brick
+    , componentm
     , containers
     , directory
     , Hclip

--- a/ui/vty-lib/src/Ariadne/UI/Vty.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty.hs
@@ -7,6 +7,7 @@ import Universum
 
 import qualified Brick as B
 import Brick.BChan
+import Control.Monad.Component (ComponentM, buildComponent_)
 import qualified Graphics.Vty as V
 
 import Ariadne.UI.Vty.App
@@ -18,8 +19,8 @@ type UiAction = UiLangFace -> IO ()
 --
 -- * a record of methods for interacting with the UI from other threads
 -- * the IO action to run in the UI thread
-createAriadneUI :: UiFeatures -> UiHistoryFace -> IO (UiFace, UiAction)
-createAriadneUI features historyFace = do
+createAriadneUI :: UiFeatures -> UiHistoryFace -> ComponentM (UiFace, UiAction)
+createAriadneUI features historyFace = buildComponent_ "UI-Vty" $ do
   eventChan <- mkEventChan
   let uiFace = mkUiFace eventChan
 


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-229

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [x] Adressed HLint warnings and hints
- [x] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
`componentm` has some generally useful features, but the main reason
for us to use it is that it should make it much easier to use `bracket`
style initialization of components. However, this commit doesn't add
cleanup actions, it only refactors existing code. Cleanup actions will
be added later. So only `buildComponent_` is used now, but `buildComponent`
will also be used.
Common functionality from `Main.hs` modules was moved into a new module called
`MainTemplate` because I didn't want to make the same changes in three places.

