### PR TITLE
[AD-356] Clear request results when switching between wallets/accounts

### DIFF
--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -281,6 +281,9 @@ data UiWalletInfo = UiWalletInfo
   , uwiAccounts :: ![UiAccountInfo]
   }
 
+instance Eq UiWalletInfo where
+  a == b = uwiWalletIdx a == uwiWalletIdx b
+
 data UiAccountInfo = UiAccountInfo
   { uaciLabel :: !(Maybe Text)
   , uaciWalletIdx :: !Word
@@ -289,12 +292,22 @@ data UiAccountInfo = UiAccountInfo
   , uaciAddresses :: ![UiAddressInfo]
   }
 
+instance Eq UiAccountInfo where
+  a == b =
+    uaciWalletIdx a == uaciWalletIdx b &&
+    uaciPath a == uaciPath b
+
 data UiAddressInfo = UiAddressInfo
   { uadiWalletIdx :: !Word
   , uadiPath :: !TreePath
   , uadiAddress :: !Text
   , uadiBalance :: !(Maybe Text)
   }
+
+instance Eq UiAddressInfo where
+  a == b =
+    uadiWalletIdx a == uadiWalletIdx b &&
+    uadiPath a == uadiPath b
 
 -- | Info for currently selected tree item
 data UiSelectionInfo

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
@@ -163,6 +163,10 @@ handleAddWalletWidgetEvent
   :: UiEvent
   -> WidgetEventM AddWalletWidgetState p ()
 handleAddWalletWidgetEvent = \case
+  UiWalletEvent UiWalletUpdate{..} 
+    | isJust wuSelectionInfo -> do
+        addWalletNewResultL .= NewResultNone
+        addWalletRestoreResultL .= RestoreResultNone
   UiCommandResult commandId (UiNewWalletCommandResult result) -> do
     use addWalletNewResultL >>= \case
       NewResultWaiting commandId' | commandId == commandId' ->


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-356

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
Previously, results of actions were retained during switching between wallets/accounts.
