### PR TITLE
[AD-273] Delete whole subtree when something is deleted.

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -517,7 +517,7 @@ removeSelection acidDb WalletFace{..} walletSelRef runCardanoMode = do
     -- Throw "Nothing selected" here?
     Just selection -> case selection of
       WSRoot hdrId -> do
-        update acidDb (DeleteHdRoot hdrId)
+        throwLeftIO $ update acidDb (DeleteHdRoot hdrId)
         runCardanoMode $ modifySecretDefault (usWallets %= Map.delete (fromRootId hdrId))
         return Nothing
       WSAccount accId -> do
@@ -528,7 +528,6 @@ removeSelection acidDb WalletFace{..} walletSelRef runCardanoMode = do
   where
     fromRootId :: HdRootId -> AddressHash PublicKey
     fromRootId (HdRootId (InDb x)) = x
-
 
 renameSelection
   :: AcidState DB

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
@@ -343,11 +343,11 @@ updateHdAccountName :: HdAccountId
 updateHdAccountName accId name = runUpdate' . zoom dbHdWallets $
     HD.updateHdAccountName accId name
 
-deleteHdRoot :: HdRootId -> Update DB ()
-deleteHdRoot rootId = runUpdateNoErrors . zoom dbHdWallets $
+deleteHdRoot :: HdRootId -> Update DB (Either HD.DeleteHdRootError ())
+deleteHdRoot rootId = runUpdate' . zoom dbHdWallets $
     HD.deleteHdRoot rootId
 
-deleteHdAccount :: HdAccountId -> Update DB (Either UnknownHdRoot ())
+deleteHdAccount :: HdAccountId -> Update DB (Either HD.DeleteHdAccountError ())
 deleteHdAccount accId = runUpdate' . zoom dbHdWallets $
     HD.deleteHdAccount accId
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Delete.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Delete.hs
@@ -1,24 +1,66 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 -- | DELETE operatiosn on HD wallets
 module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Delete (
-    deleteHdRoot
+    DeleteHdAccountError(..)
+  , DeleteHdRootError(..)
+  , deleteHdRoot
   , deleteHdAccount
   ) where
 
 import Universum
 
-import Control.Lens (at, (.=))
-
+import Data.SafeCopy (base, deriveSafeCopySimple)
+import Control.Lens ((%=))
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
 import Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState
+import Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet
 
 {-------------------------------------------------------------------------------
   DELETE
 -------------------------------------------------------------------------------}
 
--- | Delete a wallet
-deleteHdRoot :: HdRootId -> Update' HdWallets e ()
-deleteHdRoot rootId = zoom hdWalletsRoots $ at rootId .= Nothing
+-- | Delete a wallet with the whole subtree (addresses and accounts). 
+deleteHdRoot :: HdRootId -> Update' HdWallets DeleteHdRootError ()
+deleteHdRoot rootId = do 
+  zoomHdRootId DeleteUnknownHdRoot rootId $ return ()
+  hdWalletsAddresses %= deleteIxAll rootId 
+  hdWalletsAccounts  %= deleteIxAll rootId 
+  hdWalletsRoots     %= deleteIxAll rootId 
 
--- | Delete an account
-deleteHdAccount :: HdAccountId -> Update' HdWallets UnknownHdRoot ()
-deleteHdAccount accId = zoom hdWalletsAccounts $ at accId .= Nothing
+-- | Delete an account with its addresses.
+deleteHdAccount :: HdAccountId -> Update' HdWallets DeleteHdAccountError ()
+deleteHdAccount accId = do
+  zoomHdAccountId DeleteUnknownHdAccount accId $ return ()
+  hdWalletsAddresses %= deleteIxAll accId 
+  hdWalletsAccounts  %= deleteIxAll accId 
+
+
+{-------------------------------------------------------------------------------
+  Errors
+-------------------------------------------------------------------------------}
+
+-- | Errors thrown by 'deleteHdWallet'
+data DeleteHdRootError =
+    -- | We don't have a wallet with the specified ID
+    DeleteUnknownHdRoot UnknownHdRoot
+    deriving (Eq, Show)
+
+-- | Errors thrown by 'deleteHdAccount'
+data DeleteHdAccountError =
+    -- | The specified account could not be found
+    DeleteUnknownHdAccount UnknownHdAccount 
+    deriving (Eq, Show)
+
+instance Exception DeleteHdRootError where
+  displayException (DeleteUnknownHdRoot (UnknownHdRoot rootId)) =
+    toString $ "The wallet '" <> pretty rootId <> "' does not exist."
+
+instance Exception DeleteHdAccountError where
+  displayException (DeleteUnknownHdAccount (UnknownHdAccount accountId)) =
+    toString $ "The account '" <> pretty accountId <> "' does not exist."
+  displayException (DeleteUnknownHdAccount (UnknownHdAccountRoot rootId)) = 
+    toString $ "The corresponding wallet '" <> pretty rootId <> "' does not exist."
+
+deriveSafeCopySimple 1 'base ''DeleteHdRootError
+deriveSafeCopySimple 1 'base ''DeleteHdAccountError

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
@@ -10,6 +10,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet (
   , IxSet
   , Indexable
     -- * Building 'Indexable' instances
+  , deleteIxAll  
   , ixFun
   , ixList
     -- * Queries
@@ -169,6 +170,12 @@ updateIxManyM pk f (WrapIxSet s) = do
     mappedValues <- traverse (Lens.coerced f) originalValues
     pure $ WrapIxSet $
       foldr IxSet.insert (foldr IxSet.delete s originalValues) mappedValues
+
+-- | Delete all values with the given key. 
+
+deleteIxAll :: (Indexable a, IsIndexOf ix a) => ix -> IxSet a -> IxSet a
+deleteIxAll ix (WrapIxSet ixSet) =
+    WrapIxSet (IxSet.getGT ix ixSet `IxSet.union` IxSet.getLT ix ixSet)
 
 {-------------------------------------------------------------------------------
   Construction


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-273

**Checklist:**

- [ ] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
- [ ] Adressed HLint warnings and hints
- [x] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**

For example, in case of wallet's deletion, accounts and addresses will be also deleted.
Deleteing of the whole subtree happens atomically.
I use "deleteIxAll" function to delete unused addresses and accouns directly.
But this function des nothing if the key is not presented in IxSet (invalid HdRootId/HdAccountId),
that is why i check it in the beginning and throw exception in case of invalid id.