### PR TITLE
[AD-270] Check keyfile for unknown keys on startup

### DIFF
--- a/ariadne/cardano/package.yaml
+++ b/ariadne/cardano/package.yaml
@@ -48,6 +48,7 @@ library:
     - file-embed
     - filelock
     - filepath
+    - fmt
     - formatting
     - http-client
     - http-client-tls

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Consistency.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Consistency.hs
@@ -1,0 +1,62 @@
+-- | This module contains functions that are needed
+-- to check consistency of wallets and key storage.
+
+module Ariadne.Wallet.Cardano.Kernel.Consistency
+       ( getUnknownKeys
+       , getUnknownWallets
+       ) where
+
+import Data.List ((\\))
+import qualified Data.Map as Map
+import Fmt (blockListF, (+|), (|+))
+
+import Ariadne.Wallet.Cardano.Kernel (PassiveWallet, getWalletSnapshot)
+import Ariadne.Wallet.Cardano.Kernel.DB.AcidState (dbHdWallets)
+import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
+  (HdRoot, HdRootId, WalletName, hdRootId, hdRootName)
+import Ariadne.Wallet.Cardano.Kernel.Keystore (Keystore)
+import Ariadne.Wallet.Cardano.Kernel.Types (WalletId(..))
+
+import qualified Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Read as HDRead
+import qualified Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet as IxSet
+import qualified Ariadne.Wallet.Cardano.Kernel.Keystore as Keystore
+
+-- | Checks keystore for unknown keys and return list of them.
+getUnknownKeys :: MonadIO m => PassiveWallet -> Keystore -> m [HdRootId]
+getUnknownKeys pwallet keystore = do
+  (keystoreRootIds,walletRootIds,_) <- getRootIdsFromWalletAndKeyfile pwallet keystore
+  return $ (keystoreRootIds \\ walletRootIds)
+
+-- | Returns list of wallets without corresponding key in keystore.
+getUnknownWallets
+  :: MonadIO m => PassiveWallet -> Keystore -> m ([WalletName], [HdRootId])
+getUnknownWallets pwallet keystore = do
+  (keystoreRootIds,walletRootIds, wallets) <- getRootIdsFromWalletAndKeyfile pwallet keystore
+  let rootIDsWithMissedSecretKeys = walletRootIds \\ keystoreRootIds
+  let eitherWalletsWithMissedSecretKeys =
+        mapM (flip IxSet.getTheOnly wallets) rootIDsWithMissedSecretKeys
+  let walletNamesWithMissedSecretKeys = case eitherWalletsWithMissedSecretKeys of
+        Right wallet -> view hdRootName <$> wallet
+        Left  (brokenRootId, brokenWallets) ->
+                 error $ "There are more (or less) than one wallet with the same HdRootId: \n \
+                         \Broken RootId: " +|brokenRootId|+ "\n" <>
+                         "Names of wallets with this id: " <>
+                         blockListF (view hdRootName <$> IxSet.toList brokenWallets)
+  return (walletNamesWithMissedSecretKeys,rootIDsWithMissedSecretKeys)
+
+-- | helper function. It returns list of HdRootIds from keystore and from wallets database.
+-- And also ixset of all HdRoots
+getRootIdsFromWalletAndKeyfile
+  :: MonadIO m
+  => PassiveWallet
+  -> Keystore
+  ->  m ([HdRootId], [HdRootId], IxSet.IxSet HdRoot)
+getRootIdsFromWalletAndKeyfile pwallet keystore = do
+  snapshot <- liftIO $ getWalletSnapshot pwallet
+  let wallets = HDRead.readAllHdRoots (snapshot ^. dbHdWallets)
+  let walletRootIds = view hdRootId <$> IxSet.toList wallets
+  (keystoreRootIds) <- liftIO $ Map.keys <$> Keystore.toMap keystore
+  return (getHdRootId <$> keystoreRootIds, walletRootIds, wallets)
+  where
+    getHdRootId :: WalletId -> HdRootId
+    getHdRootId (WalletIdHdSeq rootId) = rootId

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Wallets.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Wallets.hs
@@ -3,6 +3,7 @@ module Ariadne.Wallet.Cardano.Kernel.Wallets
        , updateHdWalletName
        , updateHdWalletAssurance
        , deleteHdWallet
+       , removeKeysFromKeystore
        , HasNonemptyPassphrase(..)
        , mkHasPP
        , CreateWithAddress(..)
@@ -189,6 +190,13 @@ deleteHdWallet pw rootId = do
             -- STEP 2: Purge the key from the keystore.
             Keystore.delete (WalletIdHdSeq rootId) (pw ^. walletKeystore)
             return $ Right ()
+
+removeKeysFromKeystore :: PassiveWallet
+                       -> [HD.HdRootId]
+                       -> IO ()
+removeKeysFromKeystore pw rootIds =
+  let keystore = pw ^. walletKeystore
+  in mapM_ (\rootId -> Keystore.delete (WalletIdHdSeq rootId) keystore) rootIds
 
 {-------------------------------------------------------------------------------
   Wallet update

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
@@ -98,6 +98,11 @@ data PassiveWalletLayer m = PassiveWalletLayer
           :: Kernel.HdRootId
           -> m (Either Kernel.UnknownHdRoot (IxSet Kernel.HdAddress))
 
+    -- | keystore
+    , pwlRemoveUnknownKeys
+          :: [Kernel.HdRootId]
+          -> m ()
+
     -- | core API
     , pwlApplyBlocks
           :: OldestFirst NE Blund
@@ -118,6 +123,12 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , pwlLookupKeystore
           :: Kernel.HdRootId
           -> m (Maybe EncryptedSecretKey)
+
+    -- | Check keyfile.
+    , pwlGetUnknownKeys
+          :: m [Kernel.HdRootId]
+    , pwlGetWalletsWithoutSecretKeys
+          :: m ([Kernel.WalletName], [Kernel.HdRootId])
     }
 
 data ActiveWalletLayer m = ActiveWalletLayer

--- a/ariadne/cardano/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Face.hs
@@ -95,6 +95,8 @@ data ConfirmationType
   | ConfrimRemoveWallet WalletName
   | ConfirmRemoveAccount AccountName
   | ConfirmSend [ConfirmSendInfo]    -- ^ lists of outputs' info
+  | ConfirmDelUnknownKeys Text       -- ^ Unknown RootIDs from Keyfile
+  | ConfirmDelBrokenWallets Text     -- ^ Names of wallets with missing secret keys in keyfile
 
 data ConfirmSendInfo =
   ConfirmSendInfo

--- a/ariadne/core/src/Ariadne/UIConfig.hs
+++ b/ariadne/core/src/Ariadne/UIConfig.hs
@@ -17,12 +17,24 @@ module Ariadne.UIConfig
        , deleteSureMkMessage
        , deleteSureMessage
        , deleteRetypeMkMessage
+       , expandingMessageRemovingKeys
+       , expandingMessageRemovingWallets
        , sendHeaderMessage
        , sendDefinitiveMessage
        , sendListMessage
        , passwordHeaderMessage
        , passwordUseOneMessage
        , passwordLabelMessage
+       , rmUnkownKeysHeaderMessage
+       , rmUnknownKeysIntroMessage
+       , rmUnknownKeysSureMessage
+       , rmUnknownKeysRetypeConfirm
+       , rmUnknownKeysRetypeMkMessage
+       , rmBrokenWalletsHeaderMessage
+       , rmBrokenWalletsIntroMkMessage
+       , rmBrokenWalletDelSureMessage
+       , rmBrokenWltRetypeMkMessage
+       , rmBrokenRetypeConfirm
        ) where
 
 import Formatting
@@ -97,6 +109,47 @@ deleteRetypeMkMessage :: Format Text (delItem -> Text) -> delItem -> Text
 deleteRetypeMkMessage itemTypeFormat itemType = sformat
     ("Type " % itemTypeFormat % " name to confirm deletion") itemType
 
+rmUnkownKeysHeaderMessage :: Text
+rmUnkownKeysHeaderMessage = "Remove unknown keys"
+
+rmUnknownKeysSureMessage :: Text
+rmUnknownKeysSureMessage = "Make sure that you don't need keys from keyfile \
+    \(It is not a backup, for example). Those keys will be deleted."
+
+rmUnknownKeysIntroMessage :: Text
+rmUnknownKeysIntroMessage= "There are keys that don't \
+    \correspond to any known wallet.\nDo you want to delete them?"
+
+rmUnknownKeysRetypeMkMessage :: Text -> Text
+rmUnknownKeysRetypeMkMessage typeMsg = "Please, write " <> typeMsg <> " if you are sure."
+
+rmUnknownKeysRetypeConfirm :: Text
+rmUnknownKeysRetypeConfirm = "\"Yes\""
+
+expandingMessageRemovingKeys :: Text
+expandingMessageRemovingKeys = "List of unknown secret keys"
+
+rmBrokenWalletsHeaderMessage :: Text
+rmBrokenWalletsHeaderMessage = "Remove wallets with missing secret keys"
+
+rmBrokenWalletsIntroMkMessage :: Text
+rmBrokenWalletsIntroMkMessage = "There are wallets without corresponding secret key \
+    \in keyfile. Without secret keys you can do almost nothing with such wallets. \
+    \Do you want to delete them?"
+
+rmBrokenWalletDelSureMessage :: Text
+rmBrokenWalletDelSureMessage = "Make sure that you don't have secret keys or can restore \
+    \wallets from mnemonic."
+
+rmBrokenWltRetypeMkMessage :: Text -> Text
+rmBrokenWltRetypeMkMessage typeMsg = "Please, write " <> typeMsg <> " if you are sure."
+
+rmBrokenRetypeConfirm :: Text
+rmBrokenRetypeConfirm = "\"Yes\""
+
+expandingMessageRemovingWallets :: Text
+expandingMessageRemovingWallets = "List of wallets with missing secret keys"
+
 sendHeaderMessage :: Text
 sendHeaderMessage = "Confirm Transaction"
 
@@ -116,3 +169,4 @@ passwordUseOneMessage = "Activate to use a password."
 
 passwordLabelMessage :: Text
 passwordLabelMessage = "Password"
+

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -302,6 +302,10 @@ walletEventToUI = \case
       ConfirmRemoveAccount accountName ->
           UiConfirmRemove $ UiDelAccount $ Just $ unAccountName accountName
       ConfirmSend confsendInfo -> UiConfirmSend $ map toUiConfirmSendInfo confsendInfo
+      ConfirmDelUnknownKeys unknownKeys -> UiConfirmRemove $ UiDelUnknownKeys unknownKeys
+      ConfirmDelBrokenWallets walletsWithMissingKeys
+        -> UiConfirmRemove $ UiDelBrokenWallets walletsWithMissingKeys
+
 
 toUiConfirmSendInfo :: ConfirmSendInfo -> UiConfirmSendInfo
 toUiConfirmSendInfo ConfirmSendInfo{..} = UiConfirmSendInfo {..}

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -180,6 +180,8 @@ data UiConfirmSendInfo =
 data UiDeletingItem
   = UiDelWallet (Maybe Text)
   | UiDelAccount (Maybe Text)
+  | UiDelUnknownKeys Text
+  | UiDelBrokenWallets Text
   deriving Eq
 
 -- | Ui event to handle backend exceptions

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Delete.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Delete.hs
@@ -8,6 +8,7 @@ import Formatting
 
 import Graphics.UI.Qtah.Signal (connect_)
 
+import Graphics.UI.Qtah.Core.Types (QtArrowType(..))
 import qualified Graphics.UI.Qtah.Widgets.QAbstractButton as QAbstractButton
 import qualified Graphics.UI.Qtah.Widgets.QBoxLayout as QBoxLayout
 import qualified Graphics.UI.Qtah.Widgets.QCheckBox as QCheckBox
@@ -16,12 +17,16 @@ import qualified Graphics.UI.Qtah.Widgets.QHBoxLayout as QHBoxLayout
 import qualified Graphics.UI.Qtah.Widgets.QLabel as QLabel
 import qualified Graphics.UI.Qtah.Widgets.QLineEdit as QLineEdit
 import qualified Graphics.UI.Qtah.Widgets.QPushButton as QPushButton
+import qualified Graphics.UI.Qtah.Widgets.QScrollArea as QScrollArea
+import qualified Graphics.UI.Qtah.Widgets.QSizePolicy as QSizePolicy
+import qualified Graphics.UI.Qtah.Widgets.QToolButton as QToolButton
+import qualified Graphics.UI.Qtah.Widgets.QVBoxLayout as QVBoxLayout
 import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
 
-import Ariadne.UIConfig
 import Ariadne.UI.Qt.Face
 import Ariadne.UI.Qt.UI
 import Ariadne.UI.Qt.Widgets.Dialogs.Util
+import Ariadne.UIConfig
 
 data DeletionResult = DoDelete | Cancel deriving Eq
 
@@ -32,34 +37,76 @@ data Delete =
     , retypeWidget :: QWidget.QWidget
     , retypeName :: QLineEdit.QLineEdit
     , deleteButton :: QPushButton.QPushButton
+    , deleteUnknownObjects :: Maybe (QToolButton.QToolButton,QScrollArea.QScrollArea)
     , itemType :: UiDeletingItem
     }
+
+data MessagesOnDelWidget =
+  MessagesOnDelWidget
+    { header          :: !String
+    , intro           :: !String
+    , isSureMessage   :: !Text
+    , reTypeMessage   :: !String
+    , expandingMessge :: !Text
+    , confirmMsg      :: !Text
+    }
+
+makeMessages :: UiDeletingItem -> MessagesOnDelWidget
+makeMessages (UiDelUnknownKeys _) =
+  let header  = toString rmUnkownKeysHeaderMessage
+      intro = toString $ rmUnknownKeysIntroMessage
+      expandingMessge = expandingMessageRemovingKeys
+      isSureMessage = rmUnknownKeysSureMessage
+      reTypeMessage = toString $
+        rmUnknownKeysRetypeMkMessage ("<b>" <> rmUnknownKeysRetypeConfirm <> "</b>")
+      confirmMsg = rmUnknownKeysRetypeConfirm
+  in MessagesOnDelWidget{..}
+makeMessages (UiDelBrokenWallets _) =
+  let header  = toString rmBrokenWalletsHeaderMessage
+      intro = toString $ rmBrokenWalletsIntroMkMessage
+      expandingMessge = expandingMessageRemovingWallets
+      isSureMessage = rmBrokenWalletDelSureMessage
+      reTypeMessage = toString $
+        rmBrokenWltRetypeMkMessage ("<b>" <> rmBrokenRetypeConfirm <> "</b>")
+      confirmMsg = rmBrokenRetypeConfirm
+  in MessagesOnDelWidget{..}
+makeMessages itemType =
+  let header = toString . T.toUpper $ deleteHeaderMkMessage itemTypeFormat itemType
+      itemName = fromMaybe "this" $ itemTypeName itemType
+      intro = toString $
+        deleteIntroMkMessage itemTypeFormat ("<b>" <> itemName <> "</b>") itemType
+      expandingMessge = ""
+      isSureMessage = deleteSureMkMessage itemTypeFormat itemType
+      reTypeMessage = toString $ deleteRetypeMkMessage itemTypeFormat itemType
+      confirmMsg = itemName
+  in MessagesOnDelWidget{..}
 
 initDelete :: UiDeletingItem -> IO Delete
 initDelete itemType = do
   delete <- QDialog.new
   layout <- createLayout delete
+  let MessagesOnDelWidget{..} = makeMessages itemType
 
-  let headerString = toString . T.toUpper $ deleteHeaderMkMessage itemTypeFormat itemType
-      itemName = fromMaybe "this" $ itemTypeName itemType
+  QWidget.setWindowTitle delete header
 
-  QWidget.setWindowTitle delete headerString
+  headerWidget <- QLabel.newWithText header
+  addHeader layout headerWidget
 
-  header <- QLabel.newWithText headerString
-  addHeader layout header
-
-  warningLabel <- QLabel.newWithText . toString $
-      deleteIntroMkMessage itemTypeFormat ("<b>" <> itemName <> "</b>") itemType
+  warningLabel <- QLabel.newWithText intro
   QBoxLayout.addWidget layout warningLabel
 
-  isSure <- createCheckBox layout CheckboxOnLeft $
-      deleteSureMkMessage itemTypeFormat itemType
+  deleteUnknownObjects <- case itemType of
+    (UiDelUnknownKeys rootKeysText) ->
+      showDeletingObjects rootKeysText expandingMessge layout
+    (UiDelBrokenWallets brokenWalletNames) ->
+      showDeletingObjects brokenWalletNames expandingMessge layout
+    _ -> return Nothing
+  isSure <- createCheckBox layout CheckboxOnLeft $ isSureMessage
 
   (retypeWidget, retypeLayout) <- createSubWidget
   addSeparator retypeLayout
 
-  retypeLabel <- QLabel.newWithText . toString $
-      deleteRetypeMkMessage itemTypeFormat itemType
+  retypeLabel <- QLabel.newWithText reTypeMessage
   retypeName <- QLineEdit.new
   addRow retypeLayout retypeLabel retypeName
 
@@ -80,6 +127,10 @@ initDelete itemType = do
 
   let del = Delete{..}
 
+  case deleteUnknownObjects of
+    (Just (unknownObjectsExpand,_)) -> connect_ unknownObjectsExpand QAbstractButton.toggledSignal $
+                                   unknownObjectsToggled del
+    _ -> pass
   connect_ isSure QAbstractButton.toggledSignal $ isSureToggled del
   connect_ retypeName QLineEdit.textChangedSignal $ \_ -> revalidate del
   connect_ cancelButton QAbstractButton.clickedSignal $ \_ -> QDialog.reject delete
@@ -111,11 +162,15 @@ isValid Delete{..} = do
         UiDelWallet maybeName -> case maybeName of
           Nothing -> True
           Just itemName -> delItemName == itemName
+        UiDelUnknownKeys _ -> (T.toTitle delItemName) == "Yes"
+        UiDelBrokenWallets _ -> (T.toTitle delItemName) == "Yes"
   return $ delIsSure && isNameChecked
 
-isDelWallet :: UiDeletingItem -> Bool
-isDelWallet = \case
+shouldCheck :: UiDeletingItem -> Bool
+shouldCheck = \case
   UiDelWallet _ -> True
+  UiDelUnknownKeys _ -> True
+  UiDelBrokenWallets _  -> True
   _ -> False
 
 revalidate :: Delete -> IO ()
@@ -125,15 +180,45 @@ itemTypeFormat :: Format r (UiDeletingItem -> r)
 itemTypeFormat = later $ \case
   UiDelWallet _ -> "wallet"
   UiDelAccount _ -> "account"
+  UiDelUnknownKeys _ -> "keys"
+  UiDelBrokenWallets _ -> "wallets"
 
 itemTypeName :: UiDeletingItem -> Maybe Text
 itemTypeName = \case
   UiDelWallet name -> name
   UiDelAccount name -> name
+  UiDelUnknownKeys _ -> Just "DelUnknownKeys"
+  UiDelBrokenWallets _ -> Just "DelBrokenWallets"
 
 isSureToggled :: Delete -> Bool -> IO ()
 isSureToggled del@Delete{..} checked = do
   revalidate del
-  when (isDelWallet itemType && isJust (itemTypeName itemType)) $ do
+  when (shouldCheck itemType && isJust (itemTypeName itemType)) $ do
     QWidget.setVisible retypeWidget checked
     QWidget.adjustSize delete
+
+unknownObjectsToggled :: Delete -> Bool -> IO ()
+unknownObjectsToggled Delete{..} expanded = case deleteUnknownObjects of
+  Just (unknownObjectsExpand,unknownObjectsScroll) -> do
+    QToolButton.setArrowType unknownObjectsExpand $ bool RightArrow DownArrow expanded
+    QWidget.setVisible unknownObjectsScroll expanded
+    QWidget.adjustSize delete
+  _ -> pass
+
+showDeletingObjects
+  :: Text
+  -> Text
+  -> QVBoxLayout.QVBoxLayout
+  -> IO (Maybe (QToolButton.QToolButton, QScrollArea.QScrollArea))
+showDeletingObjects listOfDeletingObjects expandingLabel layout = do
+  deletingObjectsExpand <- createToolButton layout expandingLabel
+  QToolButton.setArrowType deletingObjectsExpand RightArrow
+  unknownObjects <- QLabel.newWithText $ toString listOfDeletingObjects
+  unknownObjectsScroll <- QScrollArea.new
+  QScrollArea.setWidget unknownObjectsScroll unknownObjects
+  QWidget.setMaximumSizeRaw unknownObjectsScroll 1200 75
+  QWidget.setSizePolicyRaw unknownObjectsScroll QSizePolicy.Preferred QSizePolicy.Fixed
+  QBoxLayout.addWidget layout unknownObjectsScroll
+  QWidget.hide unknownObjectsScroll
+  QAbstractButton.setCheckable deletingObjectsExpand True
+  return $ Just (deletingObjectsExpand,unknownObjectsScroll)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
@@ -10,6 +10,8 @@ module Ariadne.UI.Qt.Widgets.Dialogs.Util
        , createCheckBoxWithLabel
        , createPasswordField
        , createRowLayout
+       , createToolButton
+       , createToolButtonWithLabel
        , onEventType
        ) where
 
@@ -33,6 +35,7 @@ import qualified Graphics.UI.Qtah.Widgets.QLabel as QLabel
 import qualified Graphics.UI.Qtah.Widgets.QLayout as QLayout
 import qualified Graphics.UI.Qtah.Widgets.QLineEdit as QLineEdit
 import qualified Graphics.UI.Qtah.Widgets.QPushButton as QPushButton
+import qualified Graphics.UI.Qtah.Widgets.QToolButton as QToolButton
 import qualified Graphics.UI.Qtah.Widgets.QVBoxLayout as QVBoxLayout
 import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
 
@@ -144,6 +147,34 @@ createCheckBox layout checkBoxPos labelText = do
   QBoxLayout.addLayout layout checkBoxLayout
 
   return checkBox
+
+createToolButtonWithLabel :: Text -> IO (QToolButton.QToolButton, QLabel.QLabel)
+createToolButtonWithLabel labelText = do
+  toolButton <- QToolButton.new
+  QWidget.setSizePolicyRaw toolButton Maximum Maximum
+  toolButtonLabel <- QLabel.newWithText $ toString labelText
+  QLabel.setWordWrap toolButtonLabel True
+
+  void $ Event.onEvent toolButtonLabel $
+    \(ev :: QMouseEvent.QMouseEvent) -> do
+      eventType <- QEvent.eventType ev
+      if eventType == QEvent.MouseButtonRelease
+        then QAbstractButton.toggle toolButton $> True
+        else return False
+  return (toolButton, toolButtonLabel)
+
+createToolButton
+  :: QVBoxLayout.QVBoxLayout
+  -> Text
+  -> IO QToolButton.QToolButton
+createToolButton layout labelText = do
+  (toolButton, toolButtonLabel) <- createToolButtonWithLabel labelText
+  QWidget.setMinimumSizeRaw toolButtonLabel 600 30
+  toolButtonLayout <- QHBoxLayout.new
+  QBoxLayout.addWidget toolButtonLayout toolButton
+  QBoxLayout.addWidget toolButtonLayout toolButtonLabel
+  QBoxLayout.addLayout layout toolButtonLayout
+  return toolButton
 
 createPasswordField :: Text -> IO (QHBoxLayout.QHBoxLayout, QLineEdit.QLineEdit)
 createPasswordField placeholder = do

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletTree.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletTree.hs
@@ -92,7 +92,7 @@ addWalletClicked UiLangFace{..} _uiWalletFace WalletTree{..} _checked =
 data WalletTreeEvent
   = WalletTreeNewWalletCommandResult UiCommandId UiNewWalletCommandResult
   | WalletTreeRestoreWalletCommandResult UiCommandId UiRestoreWalletCommandResult
-  | WalletTreeConfirmMnemonic (MVar Bool) [Text] 
+  | WalletTreeConfirmMnemonic (MVar Bool) [Text]
 
 handleWalletTreeEvent
   :: UiLangFace
@@ -111,7 +111,7 @@ handleWalletTreeEvent UiLangFace{..} ev = do
         void $ QMessageBox.information treeView ("Success" :: String) ("Wallet restored" :: String)
       UiRestoreWalletCommandFailure err -> do
         void $ QMessageBox.critical treeView ("Error" :: String) $ toString err
-    WalletTreeConfirmMnemonic resultVar mnemonic -> do 
+    WalletTreeConfirmMnemonic resultVar mnemonic -> do
       liftIO $ runConfirmMnemonic mnemonic >>= \case
         ConfirmMnemonicSuccess -> putMVar resultVar True
         ConfirmMnemonicFailure -> do

--- a/ui/vty-app/Glue.hs
+++ b/ui/vty-app/Glue.hs
@@ -307,6 +307,9 @@ walletEventToUI = \case
       ConfirmRemoveAccount accountName ->
         UiConfirmRemove $ UiDelAccount $ Just $ unAccountName accountName
       ConfirmSend confsendInfo -> UiConfirmSend $ map toUiConfirmSendInfo confsendInfo
+      ConfirmDelUnknownKeys unknownKeys -> UiConfirmRemove $ UiDelUnknownKeys unknownKeys
+      ConfirmDelBrokenWallets walletsWithMissingKeys
+        -> UiConfirmRemove $ UiDelBrokenWallets walletsWithMissingKeys
 
 toUiConfirmSendInfo :: ConfirmSendInfo -> UiConfirmSendInfo
 toUiConfirmSendInfo ConfirmSendInfo{..} = UiConfirmSendInfo {..}

--- a/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
@@ -155,9 +155,9 @@ resetAppFocus = do
     NoModal -> appFocusList <$> get
     PasswordMode -> return [WidgetNamePassword]
     ConfirmationMode confirmationType -> case confirmationType of
-      UiConfirmMnemonic _ -> return [WidgetNameConfirmMnemonic]
-      UiConfirmRemove _   -> return [WidgetNameConfirmRemove]
-      UiConfirmSend _     -> return [WidgetNameConfirmSend]
+      UiConfirmMnemonic _   -> return [WidgetNameConfirmMnemonic]
+      UiConfirmRemove _     -> return [WidgetNameConfirmRemove]
+      UiConfirmSend _       -> return [WidgetNameConfirmSend]
 
 setAppFocus :: Monad m => WidgetName -> StateT AppState m ()
 setAppFocus focus = do
@@ -310,7 +310,7 @@ handleAppEvent brickEvent = do
               UiConfirmMnemonic _ -> [WidgetNameConfirmMnemonic]
               UiConfirmRemove _   -> [WidgetNameConfirmRemove]
               UiConfirmSend _     -> [WidgetNameConfirmSend]
-      
+
       when (modalName `isPrefixOf` name) $ case button of
         V.BScrollUp -> void $ runHandler $ handleWidgetScroll ScrollingLineUp name
         V.BScrollDown -> void $ runHandler $ handleWidgetScroll ScrollingLineDown name

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -199,6 +199,8 @@ data UiConfirmSendInfo =
 data UiDeletingItem
   = UiDelWallet (Maybe Text)
   | UiDelAccount (Maybe Text)
+  | UiDelUnknownKeys Text
+  | UiDelBrokenWallets Text
   deriving Eq
 
 ----------------------------------------------------------------------------

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
@@ -141,6 +141,7 @@ data WidgetNamePart
 
   | WidgetNameConfirmRemove
   | WidgetNameConfirmRemoveCheck
+  | WidgetNameConfirmRemoveKeysExpand
   | WidgetNameConfirmRemoveName
   | WidgetNameConfirmRemoveContinue
   | WidgetNameConfirmRemoveCancel

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
@@ -27,6 +27,7 @@ data AddWalletWidgetState =
     , addWalletNewResult :: !NewResult
 
     , addWalletRestoreName :: !Text
+    , addWalletRestoreFullFieldName :: !Text
     , addWalletRestoreMnemonic :: !Text
     , addWalletRestorePass :: !Text
     , addWalletRestoreResult :: !RestoreResult
@@ -62,6 +63,7 @@ initAddWalletWidget langFace features =
       , addWalletNewResult = NewResultNone
 
       , addWalletRestoreName = ""
+      , addWalletRestoreFullFieldName = "Full restoration (find all used addresses)"
       , addWalletRestoreMnemonic = ""
       , addWalletRestorePass = ""
       , addWalletRestoreResult = RestoreResultNone

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Dialog/Utils.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Dialog/Utils.hs
@@ -3,6 +3,9 @@ module Ariadne.UI.Vty.Widget.Dialog.Utils
        , newDialogState
        , addDialogButton
        , drawInsideDialog
+
+       --- Lenses
+       , dialogLabelL
        ) where
 
 import qualified Brick as B


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-270

**Checklist:**

- [ ] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**

> It's possible that key file has more secret keys than there are wallets in wallet DB. Btw, the opposite is impossible. 

So - now unknown keys are deleted on startup. 