### PR TITLE
Rename .wallet-db to wallet-db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ secret-mainnet.key.lock
 ariadne_history
 ariadne_history.db
 db-mainnet
-.wallet-db/
+wallet-db/
 config/cardano-configuration.yaml
 config/mainnet-genesis.json
 

--- a/ariadne/cardano/src/Ariadne/Config/Wallet.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Wallet.hs
@@ -25,7 +25,7 @@ defaultWalletConfig :: FilePath -> WalletConfig
 defaultWalletConfig dataDir = WalletConfig
     { wcEntropySize = 16
     , wcKeyfilePath = dataDir </> "secret-mainnet.key"
-    , wcAcidDBPath  = dataDir </> ".wallet-db"
+    , wcAcidDBPath  = dataDir </> "wallet-db"
     }
 
 parseFieldWallet ::

--- a/ariadne/cardano/test/Spec.hs
+++ b/ariadne/cardano/test/Spec.hs
@@ -108,7 +108,7 @@ cliArgs =
   , "--cardano:ekg-params", "255.255.255.252:8888"
   , "--wallet:entropy-size", "32"
   , "--wallet:keyfile", "new-secret-mainnet.key"
-  , "--wallet:wallet-db-path", ".new-wallet-db"
+  , "--wallet:wallet-db-path", "new-wallet-db"
   ]
 
 
@@ -134,7 +134,7 @@ expectedAriadneConfig = defaultAriadneCfg
   , acWallet = defaultWalletConfig
     { wcEntropySize = fromBytes 32
     , wcKeyfilePath = "new-secret-mainnet.key"
-    , wcAcidDBPath  = ".new-wallet-db"
+    , wcAcidDBPath  = "new-wallet-db"
     }
   }
   where

--- a/config/wallet.dhall
+++ b/config/wallet.dhall
@@ -1,5 +1,5 @@
 {
     entropy-size = +16
   , keyfile = "@DATA/secret-mainnet.key" : Text
-  , wallet-db-path = "@DATA/.wallet-db"
+  , wallet-db-path = "@DATA/wallet-db"
 }


### PR DESCRIPTION
Rename `.wallet-db` to `wallet-db` since this directory is now in XDG data dir, where there is no point in hiding it.

Please note that #288 should be merged first.