### PR TITLE
[AD-318] Introduce base-noprelude and use Universum by default

### DIFF
--- a/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
@@ -1,7 +1,5 @@
 module Ariadne.Cardano.Backend (createCardanoBackend) where
 
-import Universum
-
 import Control.Monad.Component (ComponentM, buildComponent_)
 import Control.Monad.Trans.Reader (withReaderT)
 import Control.Natural ((:~>)(..), type (~>))

--- a/ariadne/cardano/src/Ariadne/Cardano/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Face.hs
@@ -25,8 +25,6 @@ module Ariadne.Cardano.Face
        , decodeTextAddress
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import Control.Monad.Base (MonadBase)
 import Control.Monad.IO.Unlift (MonadUnliftIO)

--- a/ariadne/cardano/src/Ariadne/Cardano/Knit.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Knit.hs
@@ -1,8 +1,6 @@
 module Ariadne.Cardano.Knit where
 
-import Universum hiding (preview)
-
-import Control.Lens hiding (parts)
+import Control.Lens (makePrisms, prism')
 import Control.Natural (type (~>))
 import Data.List as List
 import Data.Scientific

--- a/ariadne/cardano/src/Ariadne/Cardano/Orphans.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Orphans.hs
@@ -1,8 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ariadne.Cardano.Orphans where
 
-import Universum
-
 import Pos.Client.CLI.NodeOptions (CommonNodeArgs(..))
 import Pos.Client.CLI.Options (CommonArgs(..))
 import Pos.Client.Txp.Util (InputSelectionPolicy(..))

--- a/ariadne/cardano/src/Ariadne/Config/Ariadne.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Ariadne.hs
@@ -7,8 +7,6 @@ module Ariadne.Config.Ariadne
        , acHistoryL
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import qualified Data.HashMap.Strict.InsOrd as Map
 import qualified Dhall as D

--- a/ariadne/cardano/src/Ariadne/Config/CLI.hs
+++ b/ariadne/cardano/src/Ariadne/Config/CLI.hs
@@ -7,8 +7,6 @@ module Ariadne.Config.CLI
     , mergeConfigs
     ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith, zoom, (%=))
 import Data.List.Utils (replace)
 import Data.Time.Units (fromMicroseconds)

--- a/ariadne/cardano/src/Ariadne/Config/Cardano.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Cardano.hs
@@ -33,8 +33,6 @@ module Ariadne.Config.Cardano
        , defaultTopology
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import Data.Default (def)
 import Data.FileEmbed (embedFile, makeRelativeToProject)

--- a/ariadne/cardano/src/Ariadne/Config/DhallUtil.hs
+++ b/ariadne/cardano/src/Ariadne/Config/DhallUtil.hs
@@ -16,8 +16,6 @@ module Ariadne.Config.DhallUtil
     , fromDhall)
     where
 
-import Universum
-
 import Data.Functor.Contravariant (Contravariant(..))
 import qualified Data.HashMap.Strict.InsOrd as Map
 import Data.String (fromString)

--- a/ariadne/cardano/src/Ariadne/Config/History.hs
+++ b/ariadne/cardano/src/Ariadne/Config/History.hs
@@ -5,8 +5,6 @@ module Ariadne.Config.History
   , hcPathL
   ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import qualified Data.HashMap.Strict.InsOrd as Map
 import qualified Dhall as D

--- a/ariadne/cardano/src/Ariadne/Config/TH.hs
+++ b/ariadne/cardano/src/Ariadne/Config/TH.hs
@@ -1,7 +1,5 @@
 module Ariadne.Config.TH (getCommitHash) where
 
-import Universum
-
 import Control.Exception.Safe (tryAny)
 import Data.Char (isSpace)
 import Formatting (sformat, string, (%))

--- a/ariadne/cardano/src/Ariadne/Config/Update.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Update.hs
@@ -3,8 +3,6 @@ module Ariadne.Config.Update
   , updateFieldModifier
   , UpdateConfig (..)) where
 
-import Universum
-
 import Ariadne.Config.DhallUtil (interpretInt, parseField)
 import qualified Data.HashMap.Strict.InsOrd as Map
 import qualified Dhall as D

--- a/ariadne/cardano/src/Ariadne/Config/Wallet.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Wallet.hs
@@ -6,8 +6,6 @@ module Ariadne.Config.Wallet
   , walletFieldModifier
   , WalletConfig (..)) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import qualified Data.HashMap.Strict.InsOrd as Map
 import qualified Dhall as D

--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -5,8 +5,6 @@ module Ariadne.MainTemplate
        , defaultMain
        ) where
 
-import Universum
-
 import Control.Concurrent.Async (race_, withAsync)
 import Control.Monad.Component (ComponentM, runComponentM)
 import Control.Natural (($$))

--- a/ariadne/cardano/src/Ariadne/Update/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Update/Backend.hs
@@ -1,7 +1,5 @@
 module Ariadne.Update.Backend where
 
-import Universum
-
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (Exception(..), throwIO, tryAny)
 import qualified Data.ByteString.Lazy.Char8 as BS

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
@@ -4,8 +4,6 @@ module Ariadne.Wallet.Backend
   , createWalletBackend
   ) where
 
-import Universum
-
 import Control.Monad.Component (ComponentM)
 import Control.Natural ((:~>)(..))
 import Data.Constraint (withDict)

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/AddressDiscovery.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/AddressDiscovery.hs
@@ -4,8 +4,6 @@ module Ariadne.Wallet.Backend.AddressDiscovery
        , discoverHDAddressesWithUtxo
        ) where
 
-import Universum
-
 import Control.Lens (at, non, (?~))
 import Data.Conduit (runConduitRes, (.|))
 import qualified Data.Conduit.List as CL

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -24,7 +24,6 @@ module Ariadne.Wallet.Backend.KeyStorage
        , generateMnemonic
        ) where
 
-import Universum
 import qualified Universum.Unsafe as Unsafe
 
 import Control.Exception (Exception(displayException))
@@ -427,4 +426,4 @@ mkUntitled untitled namesVec = do -- no monad
       numbers = V.mapMaybe ((readMaybe @Natural) . T.unpack) untitledSuffixes
   if null untitledSuffixes || null numbers
       then untitled <> "0"
-      else untitled <> (show $ (Universum.maximum numbers) + 1)
+      else untitled <> (show $ (maximum numbers) + 1)

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Mode.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Mode.hs
@@ -10,8 +10,6 @@ module Ariadne.Wallet.Backend.Mode
        (
        ) where
 
-import Universum
-
 import qualified Data.ByteString as BS
 
 import Named ((!))

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Restore.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Restore.hs
@@ -5,7 +5,7 @@ module Ariadne.Wallet.Backend.Restore
        , restoreFromKeyFile
        ) where
 
-import Universum hiding (init)
+import Prelude hiding (init)
 
 import Control.Exception (Exception(displayException))
 import Control.Lens (at, non, (?~))

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
@@ -4,7 +4,7 @@ module Ariadne.Wallet.Backend.Tx
        ( sendTx
        ) where
 
-import Universum hiding (list)
+import Prelude hiding (list)
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.Buildable

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
@@ -25,7 +25,7 @@ module Ariadne.Wallet.Cardano.Kernel (
   , getWalletSnapshot
   ) where
 
-import Universum hiding (State, init)
+import Prelude hiding (init)
 
 import Control.Monad.Component (ComponentM, buildComponent_)
 import qualified Data.Map.Strict as Map

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Accounts.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Accounts.hs
@@ -6,13 +6,11 @@ module Ariadne.Wallet.Cardano.Kernel.Accounts (
     , CreateAccountError(..)
     ) where
 
-import qualified Prelude
-import Universum
-
 import Control.Monad.Error.Class (liftEither, throwError)
 import qualified Data.Text.Buildable
 import Formatting (bprint, build, formatToString, (%))
 import qualified Formatting as F
+import qualified Text.Show
 
 import Data.Acid (AcidState, query, update)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Actions.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Actions.hs
@@ -16,7 +16,6 @@ import Control.Concurrent.Chan
 import Control.Lens (makeLenses, (%=), (+=), (-=), (.=))
 import qualified Data.Text.Buildable
 import Formatting (bprint, build, shown, (%))
-import Universum
 
 import Pos.Core.Chrono
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Addresses.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Addresses.hs
@@ -4,13 +4,11 @@ module Ariadne.Wallet.Cardano.Kernel.Addresses (
     , CreateAddressError(..)
     ) where
 
-import qualified Prelude
-import Universum
-
 import Control.Monad.Error.Class (liftEither, throwError)
 import qualified Data.Text.Buildable
 import Formatting (bprint, build, formatToString, (%))
 import qualified Formatting as F
+import qualified Text.Show
 
 import Data.Acid (AcidState, query, update)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
@@ -6,8 +6,6 @@ module Ariadne.Wallet.Cardano.Kernel.Bip32
        , makePubKeyHdwAddressUsingPath
        ) where
 
-import Universum
-
 import Named (Named(..))
 
 import Cardano.Crypto.Wallet.Types (DerivationIndex)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip39.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip39.hs
@@ -3,8 +3,6 @@ module Ariadne.Wallet.Cardano.Kernel.Bip39
        , mnemonicToSeedNoPassword
        ) where
 
-import Universum
-
 import Loot.Crypto.Bip39 (entropyToMnemonic, mnemonicToSeed)
 
 -- The empty string below is called a passphrase in BIP-39, but

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
@@ -7,8 +7,6 @@ module Ariadne.Wallet.Cardano.Kernel.Bip44
     , encodeBip44DerivationPathFromAccount
     ) where
 
-import Universum
-
 import Pos.Crypto.HD (firstHardened, firstNonHardened, isHardened)
 
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
@@ -33,8 +33,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.AcidState (
   , ObservableRollbackUseInTestsOnly(..)
   ) where
 
-import Universum
-
 import Control.Lens (at, non, to)
 import Control.Lens.TH (makeLenses)
 import Control.Monad.Except (MonadError, catchError, runExcept)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/BlockMeta.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/BlockMeta.hs
@@ -9,8 +9,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.BlockMeta (
   , blockMetaSlotId
   ) where
 
-import Universum
-
 import Control.Lens.TH (makeLenses)
 import qualified Data.Map.Strict as Map
 import Data.SafeCopy

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -65,8 +65,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet (
   , eskToHdRootId
   ) where
 
-import Universum
-
 import Control.Lens (at)
 import Control.Lens.TH (makeLenses)
 import qualified Data.ByteString as BS

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
@@ -16,8 +16,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Create (
   , initHdAddress
   ) where
 
-import Universum
-
 import Control.Lens (at, (.=))
 import Data.SafeCopy (base, deriveSafeCopySimple)
 import qualified Data.Text.Buildable

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Delete.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Delete.hs
@@ -8,8 +8,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Delete (
   , deleteHdAccount
   ) where
 
-import Universum
-
 import Control.Lens ((%=))
 import Data.SafeCopy (base, deriveSafeCopySimple)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Derivation.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Derivation.hs
@@ -4,8 +4,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Derivation (
     , deriveBip44KeyPair
     ) where
 
-import Universum
-
 import qualified Data.Set as S
 import qualified Data.Vector as V
 import Named ((!))

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
@@ -31,8 +31,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Read (
   , readHdAddressByCardanoAddress
   ) where
 
-import Universum
-
 import Control.Lens (at)
 
 import Pos.Core (Address, Coin, sumCoins)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Update.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Update.hs
@@ -5,8 +5,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Update (
   , updateHdAccountName
   ) where
 
-import Universum
-
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
 import Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState
 import Ariadne.Wallet.Cardano.Kernel.Util (modifyAndGetNew)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/InDb.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/InDb.hs
@@ -5,8 +5,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.InDb (
   , fromDb
   ) where
 
-import Universum
-
 import Control.Lens.TH (makeLenses)
 import Data.Coerce (coerce)
 import Data.SafeCopy

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Resolved.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Resolved.hs
@@ -11,8 +11,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Resolved (
   , rbSlot
   ) where
 
-import Universum
-
 import Control.Lens.TH (makeLenses)
 import qualified Data.Map as Map
 import Data.SafeCopy (base, deriveSafeCopySimple)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
@@ -36,7 +36,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Spec (
   , currentAddrUtxoBalance
   ) where
 
-import Universum hiding (elems)
+import Prelude hiding (elems)
 
 import Control.Lens (at, lens, non, to, (?~))
 import Control.Lens.TH (makeLenses)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Read.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Read.hs
@@ -7,8 +7,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Read (
   , queryAccountAvailableBalance
   ) where
 
-import Universum
-
 import qualified Data.Map.Strict as Map
 
 import qualified Pos.Core as Core

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
@@ -11,8 +11,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Update (
   , observableRollbackUseInTestsOnly
   ) where
 
-import Universum
-
 import Data.SafeCopy (base, deriveSafeCopySimple)
 
 import Test.QuickCheck (Arbitrary(..))

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Util.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Util.hs
@@ -16,8 +16,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Util (
   , utxoRestrictToInputs
   ) where
 
-import Universum
-
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Sqlite.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Sqlite.hs
@@ -17,9 +17,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Sqlite (
     , unsafeMigrateMetaDB
     ) where
 
-import qualified Prelude
-import Universum
-
 import Database.Beam.Backend.SQL
   (FromBackendRow, HasSqlValueSyntax(..), IsSql92DataTypeSyntax, varCharType)
 import Database.Beam.Backend.SQL.SQL92

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta.hs
@@ -9,7 +9,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.TxMeta (
 
 import qualified Ariadne.Wallet.Cardano.Kernel.DB.Sqlite as ConcreteStorage
 import Ariadne.Wallet.Cardano.Kernel.DB.TxMeta.Types as Types
-import Universum
 
 -- Concrete instantiation of 'MetaDBHandle'
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta/Types.hs
@@ -33,8 +33,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.TxMeta.Types (
   , uniqueElements
   ) where
 
-import Universum
-
 import Control.Lens.TH (makeLenses)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/AcidState.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/AcidState.hs
@@ -16,8 +16,6 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState (
   , throwError
   ) where
 
-import Universum
-
 import Control.Monad.Except
 import Data.Acid (Update)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
@@ -34,8 +34,7 @@ module Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet (
   , (@+)
   ) where
 
-import qualified Prelude
-import Universum hiding (toList)
+import Prelude hiding (toList)
 
 import qualified Control.Lens as Lens
 import Data.Coerce (coerce)
@@ -53,6 +52,7 @@ import Pos.Infra.Util.LogSafe
   (BuildableSafe, SecureLog, buildSafeList, getSecureLog, secure)
 import Serokell.Util (listJsonIndent)
 import Test.QuickCheck (Arbitrary(..))
+import qualified Text.Show
 
 {-# ANN module ("HLint: ignore Unnecessary hiding" :: Text) #-}
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Decrypt.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Decrypt.hs
@@ -15,8 +15,6 @@ module Ariadne.Wallet.Cardano.Kernel.Decrypt
        , decryptAddress
        ) where
 
-import Universum
-
 import qualified Data.List.NonEmpty as NE
 import Pos.Client.Txp.History (TxHistoryEntry(..))
 import Pos.Core

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
@@ -14,8 +14,6 @@ module Ariadne.Wallet.Cardano.Kernel.Internal (
   , walletLogMessage
   ) where
 
-import Universum hiding (State)
-
 import Control.Lens.TH
 
 import System.Wlog (Severity(..))

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Keystore.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Keystore.hs
@@ -29,7 +29,7 @@ module Ariadne.Wallet.Cardano.Kernel.Keystore (
     , bracketTestKeystore
     ) where
 
-import Universum hiding (toList)
+import Prelude hiding (toList)
 
 import Control.Concurrent (modifyMVar_, withMVar)
 import Control.Monad.Component (ComponentM, buildComponent)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/PrefilterTx.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/PrefilterTx.hs
@@ -11,8 +11,6 @@ module Ariadne.Wallet.Cardano.Kernel.PrefilterTx
        , prefilterUtxo
        ) where
 
-import Universum
-
 import Data.List (nub)
 import qualified Data.List.NonEmpty as NE
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Types.hs
@@ -19,8 +19,6 @@ module Ariadne.Wallet.Cardano.Kernel.Types (
   , txUtxo
   ) where
 
-import Universum
-
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Text.Buildable (Buildable(..))

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Util.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Util.hs
@@ -24,8 +24,6 @@ module Ariadne.Wallet.Cardano.Kernel.Util (
   , getCurrentTimestamp
   ) where
 
-import Universum
-
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Time.Clock.POSIX (getPOSIXTime)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Wallets.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Wallets.hs
@@ -11,12 +11,11 @@ module Ariadne.Wallet.Cardano.Kernel.Wallets (
     , createWalletHdSeq
     ) where
 
-import qualified Prelude
-import Universum
 
 import qualified Data.Text.Buildable
 import Formatting (bprint, build, formatToString, (%))
 import qualified Formatting as F
+import qualified Text.Show
 
 import Data.Acid.Advanced (update')
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
@@ -5,8 +5,6 @@ module Ariadne.Wallet.Cardano.Kernel.Word31
     , word31ToWord32
     ) where
 
-import Universum
-
 import Data.SafeCopy (base, deriveSafeCopySimple)
 import qualified Data.Text.Buildable (Buildable(..))
 import Formatting (bprint, int)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
@@ -3,8 +3,6 @@ module Ariadne.Wallet.Cardano.WalletLayer.Kernel
     , passiveWalletLayerWithDBComponent
     ) where
 
-import Universum
-
 import Control.Monad.Component (ComponentM, buildComponent)
 import Data.Acid (AcidState, closeAcidState, openLocalStateFrom)
 import Data.Maybe (fromJust)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
@@ -2,8 +2,6 @@ module Ariadne.Wallet.Cardano.WalletLayer.Types
     ( PassiveWalletLayer (..)
     ) where
 
-import Universum
-
 import qualified Ariadne.Wallet.Cardano.Kernel.Accounts as Kernel
 import qualified Ariadne.Wallet.Cardano.Kernel.Addresses as Kernel
 import qualified Ariadne.Wallet.Cardano.Kernel.DB.AcidState as Kernel

--- a/ariadne/cardano/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Face.hs
@@ -14,8 +14,6 @@ module Ariadne.Wallet.Face
   , WalletUIFace(..)
   ) where
 
-import Universum
-
 import Serokell.Data.Memory.Units (Byte)
 
 import Pos.Client.Txp.Util (InputSelectionPolicy(..))

--- a/ariadne/cardano/src/Ariadne/Wallet/Knit.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Knit.hs
@@ -1,10 +1,8 @@
 module Ariadne.Wallet.Knit where
 
-import Universum hiding (preview)
-
 import qualified Data.ByteArray as ByteArray
 
-import Control.Lens hiding (parts, (<&>))
+import Control.Lens (makePrisms)
 import Serokell.Data.Memory.Units (fromBytes)
 import Text.Earley
 

--- a/ariadne/cardano/src/Ariadne/Wallet/UiAdapter.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/UiAdapter.hs
@@ -24,8 +24,6 @@ module Ariadne.Wallet.UiAdapter
   , formatHdRootId
   ) where
 
-import Universum
-
 import qualified Data.Vector as V
 import Formatting (sformat, (%))
 

--- a/ariadne/cardano/test/Spec.hs
+++ b/ariadne/cardano/test/Spec.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import Control.Spoon (teaspoon)
 import qualified Data.ByteString.Lazy as BSL

--- a/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
@@ -1,8 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Ariadne.Cardano.Arbitrary where
 
-import Universum
-
 import Ariadne.Config.Cardano (CardanoConfig(..))
 import Data.Text (pack)
 import Data.Time.Units (fromMicroseconds)

--- a/ariadne/cardano/test/Test/Ariadne/Knit.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Knit.hs
@@ -8,8 +8,6 @@ module Test.Ariadne.Knit
        ( knitSpec
        ) where
 
-import Universum
-
 import qualified Ariadne.Cardano.Knit as Knit
 import Ariadne.TaskManager.Face (TaskId(..))
 import qualified Ariadne.TaskManager.Knit as Knit

--- a/ariadne/cardano/test/Test/Ariadne/Wallet/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Wallet/Arbitrary.hs
@@ -1,8 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Ariadne.Wallet.Arbitrary where
 
-import Universum
-
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
 import Test.QuickCheck.Gen (elements)
 

--- a/ariadne/core/src/Ariadne/Knit/Backend.hs
+++ b/ariadne/core/src/Ariadne/Knit/Backend.hs
@@ -4,8 +4,6 @@ module Ariadne.Knit.Backend
   , createKnitBackend
   ) where
 
-import Universum hiding (atomically)
-
 import NType (AllConstrained, KnownSpine)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 

--- a/ariadne/core/src/Ariadne/Knit/Face.hs
+++ b/ariadne/core/src/Ariadne/Knit/Face.hs
@@ -1,7 +1,5 @@
 module Ariadne.Knit.Face where
 
-import Universum
-
 import Control.Exception (SomeException)
 import Data.List.NonEmpty (NonEmpty)
 import Text.PrettyPrint.ANSI.Leijen (Doc)

--- a/ariadne/core/src/Ariadne/Knit/Help.hs
+++ b/ariadne/core/src/Ariadne/Knit/Help.hs
@@ -1,7 +1,5 @@
 module Ariadne.Knit.Help (generateKnitHelp) where
 
-import Universum
-
 import NType (AllConstrained, KnownSpine)
 
 import qualified Data.List as List

--- a/ariadne/core/src/Ariadne/TaskManager/Backend.hs
+++ b/ariadne/core/src/Ariadne/TaskManager/Backend.hs
@@ -1,7 +1,5 @@
 module Ariadne.TaskManager.Backend (createTaskManagerFace) where
 
-import Universum
-
 import Control.Concurrent.Async
 import Control.Lens as L
 import Control.Monad.Component (ComponentM, buildComponent_)

--- a/ariadne/core/src/Ariadne/TaskManager/Face.hs
+++ b/ariadne/core/src/Ariadne/TaskManager/Face.hs
@@ -1,7 +1,5 @@
 module Ariadne.TaskManager.Face where
 
-import Universum
-
 import Control.Concurrent.Async
 import Control.Exception (Exception, SomeException)
 

--- a/ariadne/core/src/Ariadne/TaskManager/Knit.hs
+++ b/ariadne/core/src/Ariadne/TaskManager/Knit.hs
@@ -1,11 +1,9 @@
 module Ariadne.TaskManager.Knit where
 
-import Universum hiding (preview)
-
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Exception
-import Control.Lens
+import Control.Lens (makePrisms)
 import Formatting hiding (text)
 import Text.Earley
 import qualified Text.Megaparsec.Char as P

--- a/ariadne/core/src/Ariadne/UX/CommandHistory.hs
+++ b/ariadne/core/src/Ariadne/UX/CommandHistory.hs
@@ -7,8 +7,6 @@ module Ariadne.UX.CommandHistory
     , toPrevCommand
     ) where
 
-import Universum
-
 import Control.Monad.Component (ComponentM, buildComponent_)
 import qualified Data.Text as T
 import Database.SQLite.Simple

--- a/ariadne/core/src/Ariadne/Util.hs
+++ b/ariadne/core/src/Ariadne/Util.hs
@@ -4,8 +4,6 @@ module Ariadne.Util
     )
     where
 
-import Universum
-
 import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
 
 atomicRunStateIORef' :: IORef s -> State s a -> IO a

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -35,7 +35,6 @@ _definitions:
         - MultiParamTypeClasses
         - MultiWayIf
         - NegativeLiterals
-        - NoImplicitPrelude
         - OverloadedLabels
         - OverloadedStrings
         - PatternSynonyms
@@ -54,7 +53,8 @@ _definitions:
         - ViewPatterns
 
     - &dependencies
-        - base >= 4.7 && < 5
+        - base-noprelude >= 4.7 && < 5
+        - loot-prelude
         - universum
 
     - &ghc-options
@@ -68,6 +68,7 @@ _definitions:
         - -Wno-safe
         - -Wno-missing-local-signatures
         - -Wno-monomorphism-restriction
+        - -Wno-implicit-prelude
         - -Werror
 
   _utils:

--- a/knit/package.yaml
+++ b/knit/package.yaml
@@ -10,6 +10,8 @@ dependencies:
 
 library:
   <<: *lib-common
+  default-extensions:
+    - NoImplicitPrelude
   dependencies:
     - Earley
     - QuickCheck
@@ -33,6 +35,8 @@ library:
 tests:
   knit-test:
     <<: *test-common
+    default-extensions:
+      - NoImplicitPrelude
     dependencies:
       - QuickCheck
       - hspec

--- a/ui/cli-app/Glue.hs
+++ b/ui/cli-app/Glue.hs
@@ -15,8 +15,6 @@ module Glue
        , putUpdateEventToUI
        ) where
 
-import Universum
-
 import Control.Exception (displayException)
 import Data.Text (pack)
 import Data.Unique

--- a/ui/cli-app/Main.hs
+++ b/ui/cli-app/Main.hs
@@ -1,7 +1,5 @@
 module Main where
 
-import Universum
-
 import NType (N(..))
 
 import Ariadne.Config.TH (getCommitHash)

--- a/ui/cli-lib/src/Ariadne/UI/Cli.hs
+++ b/ui/cli-lib/src/Ariadne/UI/Cli.hs
@@ -3,8 +3,6 @@ module Ariadne.UI.Cli
        , createAriadneUI
        ) where
 
-import Universum
-
 import Control.Monad.Component (ComponentM, buildComponent_)
 import Data.Text (strip, unlines)
 

--- a/ui/cli-lib/src/Ariadne/UI/Cli/Face.hs
+++ b/ui/cli-lib/src/Ariadne/UI/Cli/Face.hs
@@ -7,8 +7,6 @@ module Ariadne.UI.Cli.Face
        , UiCommandEvent (..)
        ) where
 
-import Universum
-
 import Data.Loc.Span (Span)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -15,8 +15,6 @@ module Glue
        , historyToUI
        ) where
 
-import Universum
-
 import Control.Exception (displayException)
 import Control.Lens (ix)
 import Data.Double.Conversion.Text (toFixed)

--- a/ui/qt-app/Main.hs
+++ b/ui/qt-app/Main.hs
@@ -1,7 +1,5 @@
 module Main where
 
-import Universum
-
 import Control.Monad.Component (ComponentM)
 import NType (N(..))
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -3,8 +3,6 @@ module Ariadne.UI.Qt
   , createAriadneUI
   ) where
 
-import Universum
-
 import Control.Concurrent
 import Control.Monad.Component (ComponentM, buildComponent_)
 import Control.Monad.Extra (loopM)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/AnsiToHTML.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/AnsiToHTML.hs
@@ -4,8 +4,6 @@ module Ariadne.UI.Qt.AnsiToHTML
     , csiToHTML
     ) where
 
-import Universum
-
 import Formatting
 
 import qualified Data.Text as T

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -27,8 +27,6 @@ module Ariadne.UI.Qt.Face
        , UiSelectionInfo(..)
        ) where
 
-import Universum
-
 import Data.Loc.Span (Span)
 import Data.Tree (Tree)
 import Text.PrettyPrint.ANSI.Leijen (Doc)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
@@ -4,8 +4,6 @@ module Ariadne.UI.Qt.MainWindow
     , handleMainWindowEvent
     ) where
 
-import Universum
-
 import Control.Lens (magnify, makeLensesWith)
 
 import Graphics.UI.Qtah.Core.Types (QtWindowType(Dialog))

--- a/ui/qt-lib/src/Ariadne/UI/Qt/StyleSheet.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/StyleSheet.hs
@@ -3,7 +3,6 @@ module Ariadne.UI.Qt.StyleSheet
   ) where
 
 import Data.FileEmbed
-import Data.Text
 
 styleSheet :: Text
 styleSheet = $(embedStringFile "resources/stylesheet.qss")

--- a/ui/qt-lib/src/Ariadne/UI/Qt/UI.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/UI.hs
@@ -1,7 +1,5 @@
 module Ariadne.UI.Qt.UI where
 
-import Universum
-
 import qualified Data.ByteString as BS
 
 import Graphics.UI.Qtah.Signal (Signal, connect_)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/ConfirmMnemonic.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/ConfirmMnemonic.hs
@@ -3,8 +3,6 @@ module Ariadne.UI.Qt.Widgets.Dialogs.ConfirmMnemonic
   , runConfirmMnemonic
   ) where
 
-import Universum
-
 import qualified Data.Text as T
 import Formatting
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Delete.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Delete.hs
@@ -4,8 +4,6 @@ module Ariadne.UI.Qt.Widgets.Dialogs.Delete
   , runDelete
   ) where
 
-import Universum
-
 import qualified Data.Text as T
 import Formatting
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/NewWallet.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/NewWallet.hs
@@ -5,8 +5,6 @@ module Ariadne.UI.Qt.Widgets.Dialogs.NewWallet
   , NewWalletResult(..)
   ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 
 import Data.Bits

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
@@ -1,7 +1,5 @@
 module Ariadne.UI.Qt.Widgets.Dialogs.Util where
 
-import Universum
-
 import Data.Bits
 
 import Graphics.UI.Qtah.Core.Types (alignHCenter, alignVCenter)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Help.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Help.hs
@@ -4,8 +4,6 @@ module Ariadne.UI.Qt.Widgets.Help
     , showHelpWindow
     ) where
 
-import Universum
-
 import qualified Data.Text as T
 
 import Control.Lens (makeLensesWith)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Logs.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Logs.hs
@@ -5,8 +5,6 @@ module Ariadne.UI.Qt.Widgets.Logs
     , showLogsWindow
     ) where
 
-import Universum
-
 import Formatting
 
 import Control.Lens (makeLensesWith)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Repl.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Repl.hs
@@ -5,8 +5,6 @@ module Ariadne.UI.Qt.Widgets.Repl
        , toggleRepl
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import Formatting
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/TopBar.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/TopBar.hs
@@ -7,8 +7,6 @@ module Ariadne.UI.Qt.Widgets.TopBar
   , displayBlockchainInfo
   ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 
 import Data.Bits

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Wallet.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Wallet.hs
@@ -5,8 +5,6 @@ module Ariadne.UI.Qt.Widgets.Wallet
        , handleWalletEvent
        ) where
 
-import Universum
-
 import Control.Lens (magnify, makeLensesWith)
 import Data.Tree (Tree(..))
 import Graphics.UI.Qtah.Signal (connect_)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletInfo.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletInfo.hs
@@ -6,8 +6,6 @@ module Ariadne.UI.Qt.Widgets.WalletInfo
        , handleWalletInfoEvent
        ) where
 
-import Universum
-
 import Data.Text (toUpper)
 
 import Control.Lens (makeLensesWith)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletTree.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletTree.hs
@@ -6,8 +6,6 @@ module Ariadne.UI.Qt.Widgets.WalletTree
        , handleWalletTreeEvent
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import Graphics.UI.Qtah.Signal (connect_)
 

--- a/ui/vty-app/Glue.hs
+++ b/ui/vty-app/Glue.hs
@@ -19,8 +19,6 @@ module Glue
        , historyToUI
        ) where
 
-import Universum
-
 import Control.Exception (displayException)
 import Control.Lens (ix)
 import Data.Double.Conversion.Text (toFixed)

--- a/ui/vty-app/Main.hs
+++ b/ui/vty-app/Main.hs
@@ -1,7 +1,5 @@
 module Main where
 
-import Universum
-
 import Control.Monad.Component (ComponentM)
 import NType (N(..))
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty.hs
@@ -3,8 +3,6 @@ module Ariadne.UI.Vty
   , createAriadneUI
   ) where
 
-import Universum
-
 import qualified Brick as B
 import Brick.BChan
 import Control.Monad.Component (ComponentM, buildComponent_)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/AnsiToVty.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/AnsiToVty.hs
@@ -1,7 +1,5 @@
 module Ariadne.UI.Vty.AnsiToVty (ansiToVty, csiToVty, pprDoc) where
 
-import Universum
-
 import Control.Monad.Trans.Writer
 
 import qualified Data.Text as T

--- a/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
@@ -3,8 +3,6 @@ module Ariadne.UI.Vty.App
   , app
   ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith, uses, (%=), (.=))
 import Data.Char (toLower)
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -46,8 +46,6 @@ module Ariadne.UI.Vty.Face
        , UiSelectionInfo(..)
        ) where
 
-import Universum
-
 import Data.Loc.Span (Span)
 import Data.Tree (Tree)
 import Data.Version (Version)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Focus.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Focus.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Focus
      ( withFocusIndicator
      ) where
 
-import Universum
-
 import qualified Brick as B
 import qualified Graphics.Vty as V
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Keyboard.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Keyboard.hs
@@ -5,8 +5,6 @@ module Ariadne.UI.Vty.Keyboard
      , vtyToEditKey
      ) where
 
-import Universum
-
 import Graphics.Vty
 
 data KeyboardEvent

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Knit.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Knit.hs
@@ -1,7 +1,5 @@
 module Ariadne.UI.Vty.Knit where
 
-import Universum hiding (preview)
-
 import Text.Earley
 
 import Ariadne.UI.Vty.Face

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Scrolling.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Scrolling.hs
@@ -8,8 +8,6 @@ module Ariadne.UI.Vty.Scrolling
      , fixedScrollingViewport
      ) where
 
-import Universum
-
 import Ariadne.UI.Vty.Keyboard
 
 import qualified Brick as B

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Theme.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Theme.hs
@@ -1,5 +1,7 @@
 module Ariadne.UI.Vty.Theme where
 
+import Prelude hiding (on)
+
 import Brick
 import Graphics.Vty
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
@@ -53,8 +53,6 @@ module Ariadne.UI.Vty.Widget
        , ReifiedLens(..)
        ) where
 
-import Universum
-
 import Control.Lens
   (ReifiedLens(..), ReifiedLens', assign, makeLensesWith, to, (%=), (.=))
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/About.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/About.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.About
        ( initAboutWidget
        ) where
 
-import Universum
-
 import qualified Brick as B
 import qualified Brick.Widgets.Center as B
 import qualified Graphics.Vty as V

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Account.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Account.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Account
        ( initAccountWidget
        ) where
 
-import Universum
-
 import Control.Exception (handle)
 import Control.Lens (assign, ix, makeLensesWith, (%=), (.=))
 import System.Hclip (ClipboardException, setClipboard)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.AddWallet
        ( initAddWalletWidget
        ) where
 
-import Universum
-
 import Control.Lens (assign, makeLensesWith, (.=))
 
 import qualified Brick as B

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Button.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Button.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Form.Button
        ( initButtonWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 
 import qualified Brick as B

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Checkbox.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Checkbox.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Form.Checkbox
        ( initCheckboxWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 
 import qualified Brick as B

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Edit.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Edit.hs
@@ -5,13 +5,10 @@ module Ariadne.UI.Vty.Widget.Form.Edit
        , initPasswordWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith, (.=))
 import Data.Char (isSpace)
 import Data.List ((!!))
 import Data.Text.Zipper (TextZipper)
-import Prelude (until)
 
 import qualified Brick as B
 import qualified Data.Text as T
@@ -278,3 +275,10 @@ smartBreakLine :: TextZipper Text -> TextZipper Text
 smartBreakLine tz =
   let indentation = T.takeWhile isSpace (TZ.currentLine tz)
   in TZ.insertMany indentation (TZ.breakLine tz)
+
+until :: (a -> Bool) -> (a -> a) -> a -> a
+until p f = go
+  where
+    go x
+      | p x = x
+      | otherwise = go (f x)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/List.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/List.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Form.List
        ( initListWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith, (%=), (.=))
 
 import qualified Brick as B

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Send.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Send.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Form.Send
        ( initSendWidget
        ) where
 
-import Universum
-
 import Control.Lens (assign, at, lens, makeLensesWith, uses, (%=), (.=), (<<+=))
 import Data.Map (Map)
 import Data.Maybe (fromJust)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Help.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Help.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Help
        ( initHelpWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 
 import qualified Brick as B

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Logs.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Logs.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Logs
        ( initLogsWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith, zoom, (+=), (.=))
 import qualified Data.Text as Text
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Menu.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Menu.hs
@@ -3,8 +3,6 @@ module Ariadne.UI.Vty.Widget.Menu
        , initMenuWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith)
 import Data.Char (toLower)
 import Data.Maybe (fromJust)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Repl.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Repl.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Repl
        ( initReplWidget
        ) where
 
-import Universum
-
 import Control.Lens (assign, makeLensesWith, traversed, zoom, (.=))
 import Named
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Status.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Status.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Status
        ( initStatusWidget
        ) where
 
-import Universum
-
 import Control.Lens (makeLensesWith, (.=))
 import Data.List as List
 import Data.Version (Version, showVersion)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Tree.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Tree.hs
@@ -4,8 +4,6 @@ module Ariadne.UI.Vty.Widget.Tree
        ( initTreeWidget
        ) where
 
-import Universum
-
 import Control.Lens (ix, makeLensesWith, uses, (.=))
 import Data.List (findIndex, intercalate)
 import Data.Tree (Tree(..))

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Wallet.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Wallet.hs
@@ -2,8 +2,6 @@ module Ariadne.UI.Vty.Widget.Wallet
        ( initWalletWidget
        ) where
 
-import Universum
-
 import Control.Exception (handle)
 import Control.Lens (assign, ix, makeLensesWith, uses, (%=), (.=))
 import System.Hclip (ClipboardException, setClipboard)


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-318

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [Configuration documentation](docs/configuration.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
Knit still uses default Prelude as-per @int-index's requests.