### PR TITLE
Fix ghc-options for ariadne-qt-app.cabal

### DIFF
--- a/ui/qt-app/package.yaml
+++ b/ui/qt-app/package.yaml
@@ -7,6 +7,10 @@ executables:
     <<: *exec-common
     source-dirs: .
     ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+      - -O2
       - -dynamic
     dependencies:
       - ansi-wl-pprint


### PR DESCRIPTION
**Description:**
Apparently, YAML can't into merging lists, so the override in `package.yaml` replaces the one in exec-common.
Thus, I did a horrible act of copy-pasting ghc-options. :(

**Checklist:**

- [ ] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [ ] Tested my changes if they modify code

