### PR TITLE
[AD-377] mute read-only knit commands

### DIFF
--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -77,6 +77,7 @@ data UiFace = UiFace
 data UiLangFace = forall err expr. UiLangFace
   { langPutCommand :: expr -> IO UiCommandId
   , langPutUiCommand :: UiCommand -> IO (Either Text UiCommandId)
+  , langPutUISilentCommand :: UiCommand -> IO (Either Text UiCommandId)
   , langParse :: Text -> Either err expr
   , langPpExpr :: expr -> Doc
   , langPpParseError :: err -> Doc

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Tree.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Tree.hs
@@ -224,4 +224,4 @@ performSelect
   -> WidgetEventM TreeWidgetState p ()
 performSelect path = do
   UiLangFace{..} <- use treeLangFaceL
-  void . liftIO . langPutUiCommand $ UiSelect path
+  void . liftIO . langPutUISilentCommand $ UiSelect path


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-377

**Checklist:**

- [x] Updated docs if necessary (Not necessary)
- [x] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [ ] Tested my changes if they modify code

**Description:**

Remove read-only commands (`select`) in TUI from the `Repl` and the history, when launched by the UI.