### PR TITLE
[AD-377] Mute balance and tx history commands as well

### DIFF
--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Account.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Account.hs
@@ -223,9 +223,9 @@ handleAccountWidgetEvent = \case
             use accountBalanceL >>= \case
               BalanceResultWaiting commandId
                 | Just taskId <- cmdTaskId commandId ->
-                    void . liftIO . langPutUiCommand $ UiKill taskId
+                    void . liftIO . langPutUISilentCommand $ UiKill taskId
               _ -> return ()
-            liftIO (langPutUiCommand UiBalance) >>=
+            liftIO (langPutUISilentCommand UiBalance) >>=
               assign accountBalanceL . either BalanceResultError BalanceResultWaiting
         updateFocusList
       _ -> return ()

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Wallet.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Wallet.hs
@@ -301,17 +301,17 @@ handleWalletWidgetEvent = \case
             use walletBalanceL >>= \case
               BalanceResultWaiting commandId
                 | Just taskId <- cmdTaskId commandId ->
-                    void . liftIO . langPutUiCommand $ UiKill taskId
+                    void . liftIO . langPutUISilentCommand $ UiKill taskId
               _ -> return ()
-            liftIO (langPutUiCommand UiBalance) >>=
+            liftIO (langPutUISilentCommand UiBalance) >>=
               assign walletBalanceL . either BalanceResultError BalanceResultWaiting
         whenM (use walletTxHistoryEnabledL) $ do
           use walletTxHistoryL >>= \case
             TxHistoryResultWaiting commandId
               | Just taskId <- cmdTaskId commandId ->
-                  void . liftIO . langPutUiCommand $ UiKill taskId
+                  void . liftIO . langPutUISilentCommand $ UiKill taskId
             _ -> return ()
-          liftIO (langPutUiCommand UiTxHistory) >>=
+          liftIO (langPutUISilentCommand UiTxHistory) >>=
             assign walletTxHistoryL . either TxHistoryResultError TxHistoryResultWaiting
 
         updateFocusList


### PR DESCRIPTION
**YT issue:** https://issues.serokell.io/issue/AD-377

**Checklist:**

- [ ] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
- [ ] Adressed HLint warnings and hints
- [ ] Rebased branch on current master and squashed all "Address PR comment" commits
- [x] Tested my changes if they modify code

**Description:**
Disciplina wallet uses balance and tx history commands in Wallet widget and they should be muted too.