### PR TITLE
[AD-279] Add Send dialog

### DIFF
--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -14,7 +14,7 @@ import NType (N(..), Rec)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.Cardano.Backend (createCardanoBackend)
-import Ariadne.Cardano.Face (CardanoEvent, CardanoFace(..))
+import Ariadne.Cardano.Face (CardanoEvent, CardanoFace(..), decodeTextAddress)
 import Ariadne.Config.Ariadne (AriadneConfig(..))
 import Ariadne.Config.CLI (getConfig)
 import Ariadne.Config.History (HistoryConfig(..))
@@ -94,6 +94,8 @@ initializeEverything MainSettings {..}
     walletUIFace = WalletUIFace
       { walletGenerateMnemonic = generateMnemonic
       , walletDefaultEntropySize = wcEntropySize walletConfig
+      , walletValidateAddress = isRight . decodeTextAddress
+      , walletCoinPrecision = 6
       }
   PasswordManager {..} <- createPasswordManager
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Face.hs
@@ -97,6 +97,8 @@ data WalletUIFace =
   WalletUIFace
     { walletGenerateMnemonic :: Byte -> IO [Text]
     , walletDefaultEntropySize :: Byte
+    , walletValidateAddress :: Text -> Bool
+    , walletCoinPrecision :: Int
     }
 
 -- | Superclass for wallet password exceptions

--- a/stack.yaml
+++ b/stack.yaml
@@ -114,8 +114,8 @@ extra-deps:
 
 ## We are using our fork because we added some stuff there
 - git: https://github.com/serokell/qtah
-  # master branch that follows upstream
-  commit: abb4932248c82dc5c662a20d8f177acbc7cfa722
+  # srk-september branch until merged upstream
+  commit: d6ce93a5bdde87fe4b70a1f0a1441954315017d8
   subdirs:
   - qtah-generator
   - qtah-cpp

--- a/ui/qt-app/Main.hs
+++ b/ui/qt-app/Main.hs
@@ -41,5 +41,7 @@ main = defaultMain mainSettings
           uiWalletFace = UiWalletFace
             { uiGenerateMnemonic = walletGenerateMnemonic
             , uiDefaultEntropySize = walletDefaultEntropySize
+            , uiValidateAddress = walletValidateAddress
+            , uiCoinPrecision = walletCoinPrecision
             }
         in createAriadneUI uiWalletFace historyFace putPass

--- a/ui/qt-lib/package.yaml
+++ b/ui/qt-lib/package.yaml
@@ -30,6 +30,7 @@ library:
     - lens
     - loc
     - qtah
+    - scientific
     - serokell-util
     - stm
     - text

--- a/ui/qt-lib/resources/stylesheet.qss
+++ b/ui/qt-lib/resources/stylesheet.qss
@@ -347,5 +347,24 @@ QDialog QPushButton[styleRole="copyAddressButton"]:hover:pressed {
     background: rgba(52, 52, 62, 25);
 }
 
+QDialog QWidget#accountsSelector {
+    background: #f0f0f0;
+    border: 1px solid rgba(52, 52, 62, 51);
+    border-radius: 2px;
+}
+
+QDialog QLabel#accountsSelectorDisplay {
+    /* QSS text-align property works only for buttons and progress bars */
+    qproperty-alignment: AlignRight;
+}
+
+QDialog QLineEdit#sendAmountEdit, QDialog QLineEdit#sendAmountEdit:focus {
+    border: none;
+    font-size: 20px;
+    color: #34343e;
+
+    qproperty-alignment: AlignRight;
+}
+
 /* vim: ft=css
 */

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -30,6 +30,7 @@ module Ariadne.UI.Qt.Face
 
 import qualified Control.Concurrent.Event as CE
 import Data.Loc.Span (Span)
+import Data.Scientific (Scientific)
 import Data.Tree (Tree)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
@@ -91,7 +92,7 @@ data UiEvent
 -- | Commands issued by the UI widgets
 data UiCommand
   = UiSelect [Word]
-  | UiSend Text Text  -- ^ Address, amount
+  | UiSend Word [Word] Text Scientific -- ^ Wallet idx, accounts, address, amount
   | UiRestoreWallet Text (Maybe Text) Text Bool -- ^ Name, password, mnemonic, full restore
   | UiNewAccount Text  -- ^ Name
   | UiNewAddress Word Word -- ^ Wallet index, account index
@@ -142,6 +143,8 @@ data UiWalletFace =
   UiWalletFace
     { uiGenerateMnemonic :: Byte -> IO [Text]
     , uiDefaultEntropySize :: Byte
+    , uiValidateAddress :: Text -> Bool
+    , uiCoinPrecision :: Int
     }
 
 -- Interface for the command history

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Send.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Send.hs
@@ -1,0 +1,271 @@
+module Ariadne.UI.Qt.Widgets.Dialogs.Send
+  ( SendInputs(..)
+  , SendOptions(..)
+  , SendResult(..)
+  , runSend
+  ) where
+
+import Data.Scientific (Scientific, normalize, isInteger)
+import qualified Data.Text as T
+
+import Graphics.UI.Qtah.Signal (connect_)
+
+import Graphics.UI.Qtah.Core.HPoint (HPoint(..))
+import Graphics.UI.Qtah.Core.HSize (HSize(..))
+import qualified Graphics.UI.Qtah.Core.QEvent as QEvent
+import qualified Graphics.UI.Qtah.Core.QObject as QObject
+import qualified Graphics.UI.Qtah.Core.QLocale as QLocale
+import Graphics.UI.Qtah.Core.Types (QtWindowType(Popup))
+import qualified Graphics.UI.Qtah.Event as Event
+import qualified Graphics.UI.Qtah.Gui.QValidator as QValidator
+import qualified Graphics.UI.Qtah.Gui.QDoubleValidator as QDoubleValidator
+import qualified Graphics.UI.Qtah.Gui.QMouseEvent as QMouseEvent
+import qualified Graphics.UI.Qtah.Widgets.QAbstractButton as QAbstractButton
+import qualified Graphics.UI.Qtah.Widgets.QBoxLayout as QBoxLayout
+import qualified Graphics.UI.Qtah.Widgets.QCheckBox as QCheckBox
+import qualified Graphics.UI.Qtah.Widgets.QDialog as QDialog
+import qualified Graphics.UI.Qtah.Widgets.QHBoxLayout as QHBoxLayout
+import qualified Graphics.UI.Qtah.Widgets.QLabel as QLabel
+import qualified Graphics.UI.Qtah.Widgets.QLineEdit as QLineEdit
+import qualified Graphics.UI.Qtah.Widgets.QPushButton as QPushButton
+import qualified Graphics.UI.Qtah.Widgets.QVBoxLayout as QVBoxLayout
+import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
+
+import Ariadne.UI.Qt.Face
+import Ariadne.UI.Qt.UI
+import Ariadne.UI.Qt.Util
+import Ariadne.UI.Qt.Widgets.Dialogs.Util
+
+data SendInputs = SendInputsSingle Word | SendInputsMulti [UiAccountInfo]
+
+data SendOptions =
+  SendOptions
+    { soAddress :: Text
+    , soAmount :: Scientific
+    , soAccounts :: [Word]
+    }
+
+data SendResult = SendSuccess SendOptions | SendCancel
+
+data AccountCheckbox =
+  AccountCheckbox
+    { aIdx :: Word
+    , checkbox :: QCheckBox.QCheckBox
+    , accountName :: Text
+    }
+
+data AccountSelector =
+  AccountSelector
+    { dropdownWidget :: QWidget.QWidget
+    , checkboxes :: [AccountCheckbox]
+    }
+
+data Send =
+  Send
+    { send :: QDialog.QDialog
+    , amountEdit :: QLineEdit.QLineEdit
+    , addressEdit :: QLineEdit.QLineEdit
+    , sendButton :: QPushButton.QPushButton
+    , fromDisplay :: QLabel.QLabel
+    , accountSelector :: Either Word AccountSelector
+    , uiWalletFace :: UiWalletFace
+    }
+
+initSend :: UiWalletFace -> SendInputs -> IO Send
+initSend uiWalletFace@UiWalletFace{..} sendInputs = do
+  send <- QDialog.new
+  layout <- createLayout send
+
+  QWidget.setWindowTitle send ("SEND" :: String)
+
+  amountLabel <- QLabel.newWithText ("<b>AMOUNT</b>" :: String)
+  amountLayout <- QHBoxLayout.new
+  amountEdit <- QLineEdit.new
+  unitLabel <- QLabel.newWithText $ toString $ unitToHtml ADA
+  QObject.setObjectName amountEdit ("sendAmountEdit" :: String)
+  QLineEdit.setPlaceholderText amountEdit ("0" :: String)
+
+  cLocale <- QLocale.newWithName ("C" :: String)
+  QLocale.setNumberOptions cLocale QLocale.RejectGroupSeparator
+  validator <- QDoubleValidator.new
+  QValidator.setLocale validator cLocale
+  QDoubleValidator.setBottom validator 0
+  QDoubleValidator.setDecimals validator uiCoinPrecision
+  QLineEdit.setValidator amountEdit validator
+
+  QBoxLayout.addWidget amountLayout amountEdit
+  QBoxLayout.addWidget amountLayout unitLabel
+  QBoxLayout.setSpacing amountLayout 0
+  addRowLayout layout amountLabel amountLayout
+  addSeparator layout
+
+  fromAccountsLabel <- QLabel.newWithText ("<b>FROM</b>" :: String)
+  fromDisplay <- QLabel.newWithText ("select account..." :: String)
+  QObject.setObjectName fromDisplay ("accountsSelectorDisplay" :: String)
+
+  case sendInputs of
+    SendInputsSingle {} -> pass
+    SendInputsMulti {} -> do
+      addRow layout fromAccountsLabel fromDisplay
+      addSeparator layout
+
+  addressLabel <- QLabel.newWithText ("<b>ADDRESS</b>" :: String)
+  addressEdit <- QLineEdit.new
+
+  addRow layout addressLabel addressEdit
+  addSeparator layout
+
+  sendButton <- QPushButton.newWithText ("SEND" :: String)
+  void $ setProperty sendButton ("dialogButtonRole" :: Text) ("dialogAction" :: Text)
+
+  QBoxLayout.addWidget layout sendButton
+
+  QBoxLayout.addStretch layout
+
+  accountSelector <- case sendInputs of
+    SendInputsSingle aIdx -> return $ Left aIdx
+    SendInputsMulti uacis -> do
+      selector@AccountSelector{..} <- createAccountSelector uacis
+      QWidget.setParent dropdownWidget send
+      QWidget.hide dropdownWidget
+      -- This will magically make qt hide dropdown when user clicks outside it
+      QWidget.setWindowFlags dropdownWidget Popup
+
+      QWidget.setMinimumWidth fromDisplay =<< QWidget.width dropdownWidget
+
+      return $ Right selector
+
+  let s = Send{..}
+
+  connect_ sendButton QAbstractButton.clickedSignal $ \_ -> QDialog.accept send
+  connect_ amountEdit QLineEdit.textChangedSignal $ \_ -> revalidate s
+  connect_ addressEdit QLineEdit.textChangedSignal $ \_ -> revalidate s
+
+  whenRight accountSelector $ \as@AccountSelector{..} -> do
+    void $ Event.onEvent fromDisplay $
+      \(ev :: QMouseEvent.QMouseEvent) -> do
+        eventType <- QEvent.eventType ev
+        if eventType == QEvent.MouseButtonRelease
+          then toggleDropDown dropdownWidget s $> True
+          else return False
+
+    void $ Event.onEvent send $
+      \(ev :: QEvent.QEvent) -> do
+        eventType <- QEvent.eventType ev
+        dropdownVisible <- QWidget.isVisible dropdownWidget
+        if eventType == QEvent.Resize && dropdownVisible
+          then moveDropDown dropdownWidget s $> True
+          else return False
+
+    for_ checkboxes $
+      \AccountCheckbox{..} -> connect_ checkbox QAbstractButton.toggledSignal $ \_ -> accountsSelected as s
+
+  revalidate s
+
+  return s
+
+runSend :: UiWalletFace -> SendInputs -> IO SendResult
+runSend uiWalletFace sendInputs = do
+  s@Send{send = send} <- initSend uiWalletFace sendInputs
+  result <- toEnum <$> QDialog.exec send
+
+  options <- fillSendOptions s
+
+  return $ case result of
+    QDialog.Accepted -> case options of
+      Just so -> SendSuccess so
+      Nothing -> SendCancel
+    QDialog.Rejected -> SendCancel
+
+fillSendOptions :: Send -> IO (Maybe SendOptions)
+fillSendOptions Send{..} = do
+  amount <- fromString <$> QLineEdit.text amountEdit
+  address <- fromString <$> QLineEdit.text addressEdit
+
+  accounts <- case accountSelector of
+    Left aIdx -> return [aIdx]
+    Right AccountSelector{..} -> map aIdx <$> filterM (QAbstractButton.isChecked . checkbox) checkboxes
+
+  let UiWalletFace{..} = uiWalletFace
+
+  return $ do
+    guard $ not (null address) && not (null accounts) && uiValidateAddress address
+    amount' :: Scientific <- normalize <$> readMaybe amount
+    -- Check that amount' has no more than uiCoinPrecision decimal digits
+    -- This is checked by QDoubleValidator, but just do be sure check again
+    guard $ amount' > 0 && isInteger (amount' * 10 ^^ uiCoinPrecision)
+
+    return $ SendOptions{soAmount = amount', soAddress = address, soAccounts = accounts}
+
+isValid :: Send -> IO Bool
+isValid = fmap isJust . fillSendOptions
+
+revalidate :: Send -> IO ()
+revalidate s@Send{..} = do
+  valid <- isValid s
+  QWidget.setEnabled sendButton valid
+
+createAccountSelector :: [UiAccountInfo] -> IO AccountSelector
+createAccountSelector uacis = do
+  dropdownWidget <- QWidget.new
+  layout <- QVBoxLayout.new
+  QWidget.setLayout dropdownWidget layout
+  QObject.setObjectName dropdownWidget ("accountsSelector" :: String)
+
+  checkboxes <- forM uacis $ createAccountCheckbox layout
+
+  QWidget.adjustSize dropdownWidget
+
+  return AccountSelector{..}
+
+createAccountCheckbox :: QVBoxLayout.QVBoxLayout -> UiAccountInfo -> IO AccountCheckbox
+createAccountCheckbox layout UiAccountInfo{..} = do
+  rowLayout <- QHBoxLayout.new
+  (checkbox, label) <- createCheckBoxWithLabel $ fromMaybe "" uaciLabel
+  balance <- QLabel.newWithText $ toString $
+    let (balance, unit) = uaciBalance in balance <> " " <> unitToHtmlSmall unit
+
+  QBoxLayout.addWidget rowLayout checkbox
+  QBoxLayout.addWidget rowLayout label
+  QBoxLayout.addStretch rowLayout
+  QBoxLayout.addWidget rowLayout balance
+
+  QBoxLayout.addLayout layout rowLayout
+
+  let
+    aIdx = head uaciPath
+    accountName = fromMaybe "" uaciLabel
+
+  return AccountCheckbox{..}
+
+toggleDropDown :: QWidget.QWidget -> Send -> IO ()
+toggleDropDown dropdownWidget s@Send{..} = do
+  visible <- QWidget.isVisible dropdownWidget
+  QWidget.setVisible dropdownWidget $ not visible
+  moveDropDown dropdownWidget s
+
+moveDropDown :: QWidget.QWidget -> Send -> IO ()
+moveDropDown dropdownWidget Send{..} = do
+  QWidget.raise dropdownWidget
+  -- dropdownWidget is a Popup window and thus uses global coordinates
+  -- therefore we need to translate parent-relative label position to global screen coordinates
+  HPoint{x = labelX, y = labelY} <- QWidget.mapToGlobal send =<< QWidget.pos fromDisplay
+  HSize{width = labelWidth, height = labelHeight} <- QWidget.size fromDisplay
+  QWidget.move dropdownWidget $ HPoint{x = labelX, y = labelY + labelHeight}
+  QWidget.adjustSize dropdownWidget
+
+  HSize{width = widgetWidth, height = widgetHeight} <- QWidget.size dropdownWidget
+  -- Make account widget occupy as much space as is available
+  when (widgetWidth < labelWidth) $ QWidget.resizeRaw dropdownWidget labelWidth widgetHeight
+
+selectAccountText :: Text
+selectAccountText = "select accounts..."
+
+accountsSelected :: AccountSelector -> Send -> IO ()
+accountsSelected AccountSelector{..} s@Send{..} = do
+  revalidate s
+
+  accountNames <- T.intercalate " + " . map accountName <$>
+    filterM (QAbstractButton.isChecked . checkbox) checkboxes
+  QLabel.setText fromDisplay $ toString $
+    if not $ null accountNames then accountNames else selectAccountText

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
@@ -93,16 +93,29 @@ createSubWidget = do
 
   return (widget, layout)
 
+createCheckBoxWithLabel :: Text -> IO (QCheckBox.QCheckBox, QLabel.QLabel)
+createCheckBoxWithLabel labelText = do
+  checkBox <- QCheckBox.new
+  QWidget.setSizePolicyRaw checkBox Maximum Maximum
+  checkBoxLabel <- QLabel.newWithText $ toString labelText
+  QLabel.setWordWrap checkBoxLabel True
+
+  void $ Event.onEvent checkBoxLabel $
+    \(ev :: QMouseEvent.QMouseEvent) -> do
+      eventType <- QEvent.eventType ev
+      if eventType == QEvent.MouseButtonRelease
+        then QAbstractButton.toggle checkBox $> True
+        else return False
+
+  return (checkBox, checkBoxLabel)
+
 createCheckBox
   :: QVBoxLayout.QVBoxLayout
   -> CheckboxPosition
   -> Text
   -> IO QCheckBox.QCheckBox
 createCheckBox layout checkBoxPos labelText = do
-  checkBox <- QCheckBox.new
-  QWidget.setSizePolicyRaw checkBox Maximum Maximum
-  checkBoxLabel <- QLabel.newWithText $ toString labelText
-  QLabel.setWordWrap checkBoxLabel True
+  (checkBox, checkBoxLabel) <- createCheckBoxWithLabel labelText
   QWidget.setMinimumSizeRaw checkBoxLabel 600 30
 
   checkBoxLayout <- QHBoxLayout.new
@@ -115,13 +128,6 @@ createCheckBox layout checkBoxPos labelText = do
       QBoxLayout.addWidget checkBoxLayout checkBox
 
   QBoxLayout.addLayout layout checkBoxLayout
-
-  void $ Event.onEvent checkBoxLabel $
-    \(ev :: QMouseEvent.QMouseEvent) -> do
-      eventType <- QEvent.eventType ev
-      if eventType == QEvent.MouseButtonRelease
-        then QAbstractButton.toggle checkBox $> True
-        else return False
 
   return checkBox
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Wallet.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Wallet.hs
@@ -44,7 +44,7 @@ initWallet langFace uiWalletFace = do
   selectionModel <- QItemSelectionModel.newWithModel itemModel
 
   (qWalletTree, walletTree) <- initWalletTree langFace uiWalletFace itemModel selectionModel
-  (qWalletInfo, walletInfo) <- initWalletInfo langFace itemModel selectionModel
+  (qWalletInfo, walletInfo) <- initWalletInfo langFace uiWalletFace itemModel selectionModel
 
   layout <- QHBoxLayout.new
   QObject.setObjectName layout ("walletLayout" :: String)


### PR DESCRIPTION
**Description:** A dialog to send transaction. There are some questions to discuss.

qtah commit was updated to include QEvent::Type PlatformSurface value.
Without this generic QEvent handler fails with `toEnum` error.

**YT issue:** https://issues.serokell.io/issue/AD-279

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [Configuration documentation](docs/configuration.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
