### PR TITLE
[AD-340] use always explicit exports and enforce its style

### DIFF
--- a/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Backend.hs
@@ -1,4 +1,6 @@
-module Ariadne.Cardano.Backend (createCardanoBackend) where
+module Ariadne.Cardano.Backend
+       ( createCardanoBackend
+       ) where
 
 import qualified Universum.Unsafe as Unsafe (fromJust)
 

--- a/ariadne/cardano/src/Ariadne/Cardano/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Face.hs
@@ -9,7 +9,7 @@ module Ariadne.Cardano.Face
        , CardanoEvent (..)
        , CardanoFace (..)
 
-       -- * Re-exports from Cardano
+         -- * Re-exports from Cardano
        , Coin
        , EpochOrSlot (..)
        , EpochIndex (..)

--- a/ariadne/cardano/src/Ariadne/Cardano/Knit.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Knit.hs
@@ -1,4 +1,26 @@
-module Ariadne.Cardano.Knit where
+module Ariadne.Cardano.Knit
+       ( Cardano
+       , Currency(..)
+
+       , ComponentValue(..)
+       , ComponentInflate(..)
+       , ComponentLit(..)
+       , ComponentToken(..)
+       , ComponentTokenizer(..)
+       , ComponentDetokenizer(..)
+       , ComponentLitGrammar(..)
+       , ComponentPrinter(..)
+       , ComponentCommandRepr(..)
+       , ComponentLitToValue(..)
+       , ComponentExecContext(..)
+       , ComponentCommandExec(..)
+       , ComponentCommandProcs(..)
+
+       , showCoin
+       , txOutCommandName
+       , tyPublicKey
+       , tyTxOut
+       ) where
 
 import Control.Lens (makePrisms, prism')
 import Control.Natural (type (~>))

--- a/ariadne/cardano/src/Ariadne/Cardano/Orphans.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Orphans.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Ariadne.Cardano.Orphans
-       (
-       ) where
+module Ariadne.Cardano.Orphans () where
 
 import Pos.Client.CLI.NodeOptions (CommonNodeArgs(..))
 import Pos.Client.CLI.Options (CommonArgs(..))

--- a/ariadne/cardano/src/Ariadne/Cardano/Orphans.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Orphans.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Ariadne.Cardano.Orphans where
+module Ariadne.Cardano.Orphans
+       (
+       ) where
 
 import Pos.Client.CLI.NodeOptions (CommonNodeArgs(..))
 import Pos.Client.CLI.Options (CommonArgs(..))

--- a/ariadne/cardano/src/Ariadne/Config/CLI.hs
+++ b/ariadne/cardano/src/Ariadne/Config/CLI.hs
@@ -1,11 +1,11 @@
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
 module Ariadne.Config.CLI
-    ( getConfig
-    -- * Exported for testing
-    , opts
-    , mergeConfigs
-    ) where
+       ( getConfig
+         -- * Exported for testing
+       , opts
+       , mergeConfigs
+       ) where
 
 import Control.Lens (makeLensesWith, zoom, (%=))
 import Data.List.Utils (replace)

--- a/ariadne/cardano/src/Ariadne/Config/Cardano.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Cardano.hs
@@ -1,23 +1,22 @@
 module Ariadne.Config.Cardano
-       (
-         -- * Config type
+       ( -- * Config type
          CardanoConfig (..)
 
-       -- * Defaults
+         -- * Defaults
        , defaultLoggerConfig
        , defaultConfigurationYaml
        , defaultGenesisJson
        , defaultCardanoConfig
 
-       -- * Helpers
+         -- * Helpers
        , cardanoFieldModifier
 
-       -- * Construction of various stuff
+         -- * Construction of various stuff
        , mkLoggingParams
        , getNodeParams
        , gtSscParams
 
-       -- * Lenses
+         -- * Lenses
        , ccDbPathL
        , ccRebuildDBL
        , ccNetworkTopologyL
@@ -28,8 +27,7 @@ module Ariadne.Config.Cardano
        , ccConfigurationOptionsL
        , ccEkgParamsL
 
-
-       -- * Exports for tests
+         -- * Exports for tests
        , defaultTopology
        ) where
 

--- a/ariadne/cardano/src/Ariadne/Config/DhallUtil.hs
+++ b/ariadne/cardano/src/Ariadne/Config/DhallUtil.hs
@@ -1,20 +1,20 @@
 module Ariadne.Config.DhallUtil
-    ( defalultIfNothing
-    , parseField
-    , interpretFilePath
-    , interpretWord16
-    , interpretInt
-    , interpretBytestringUTF8
-    , interpretByte
-    , injectInt
-    , injectFilePath
-    , injectByteStringUTF8
-    , injectWord16
-    , injectByte
-    , injectMaybe
-    , toDhall
-    , fromDhall)
-    where
+       ( defalultIfNothing
+       , parseField
+       , interpretFilePath
+       , interpretWord16
+       , interpretInt
+       , interpretBytestringUTF8
+       , interpretByte
+       , injectInt
+       , injectFilePath
+       , injectByteStringUTF8
+       , injectWord16
+       , injectByte
+       , injectMaybe
+       , toDhall
+       , fromDhall
+       ) where
 
 import Data.Functor.Contravariant (Contravariant(..))
 import qualified Data.HashMap.Strict.InsOrd as Map

--- a/ariadne/cardano/src/Ariadne/Config/History.hs
+++ b/ariadne/cardano/src/Ariadne/Config/History.hs
@@ -1,9 +1,9 @@
 module Ariadne.Config.History
-  ( defaultHistoryConfig
-  , historyFieldModifier
-  , HistoryConfig (..)
-  , hcPathL
-  ) where
+       ( defaultHistoryConfig
+       , historyFieldModifier
+       , HistoryConfig (..)
+       , hcPathL
+       ) where
 
 import Control.Lens (makeLensesWith)
 import qualified Data.HashMap.Strict.InsOrd as Map

--- a/ariadne/cardano/src/Ariadne/Config/TH.hs
+++ b/ariadne/cardano/src/Ariadne/Config/TH.hs
@@ -1,4 +1,6 @@
-module Ariadne.Config.TH (getCommitHash) where
+module Ariadne.Config.TH
+       ( getCommitHash
+       ) where
 
 import Data.Char (isSpace)
 import Formatting (sformat, string, (%))

--- a/ariadne/cardano/src/Ariadne/Config/Update.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Update.hs
@@ -1,7 +1,8 @@
 module Ariadne.Config.Update
-  ( defaultUpdateConfig
-  , updateFieldModifier
-  , UpdateConfig (..)) where
+       ( defaultUpdateConfig
+       , updateFieldModifier
+       , UpdateConfig (..)
+       ) where
 
 import Ariadne.Config.DhallUtil (interpretInt, injectInt, parseField)
 import qualified Data.HashMap.Strict.InsOrd as Map

--- a/ariadne/cardano/src/Ariadne/Config/Wallet.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Wallet.hs
@@ -1,10 +1,11 @@
 module Ariadne.Config.Wallet
-  ( defaultWalletConfig
-  , wcEntropySizeL
-  , wcKeyfilePathL
-  , wcAcidDBPathL
-  , walletFieldModifier
-  , WalletConfig (..)) where
+       ( defaultWalletConfig
+       , wcEntropySizeL
+       , wcKeyfilePathL
+       , wcAcidDBPathL
+       , walletFieldModifier
+       , WalletConfig (..)
+       ) where
 
 import Control.Lens (makeLensesWith)
 import qualified Data.HashMap.Strict.InsOrd as Map

--- a/ariadne/cardano/src/Ariadne/Update/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Update/Backend.hs
@@ -1,4 +1,6 @@
-module Ariadne.Update.Backend where
+module Ariadne.Update.Backend
+       ( runUpdateCheck
+       ) where
 
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (throwIO)

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
@@ -1,8 +1,8 @@
 module Ariadne.Wallet.Backend
-  ( WalletFace(..)
-  , WalletPreface(..)
-  , createWalletBackend
-  ) where
+       ( WalletFace(..)
+       , WalletPreface(..)
+       , createWalletBackend
+       ) where
 
 import Control.Monad.Component (ComponentM)
 import Control.Natural ((:~>)(..))

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -1,8 +1,7 @@
 -- | Part of backend which manages keys, wallets, accounts, addresses.
 
 module Ariadne.Wallet.Backend.KeyStorage
-       (
-         -- * Commands/other functions
+       ( -- * Commands/other functions
          refreshState
        , resolveWalletRef
        , resolveWalletRefThenRead

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Mode.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Mode.hs
@@ -6,9 +6,7 @@
 -- of using 'CardanoMode' (because 'CardanoMode' is not Ariadne's
 -- business), but life is hard.
 
-module Ariadne.Wallet.Backend.Mode
-       (
-       ) where
+module Ariadne.Wallet.Backend.Mode () where
 
 import qualified Data.ByteString as BS
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
@@ -4,24 +4,24 @@
 -- Cardano specific types (except those types that appear in the translation
 -- of the UTxO DSL), so that we can test it outside of a node context also
 -- (in unit tests).
-module Ariadne.Wallet.Cardano.Kernel (
-    -- * Passive wallet
-    PassiveWallet -- opaque
-  , DB -- opaque
-  , WalletId
-  , passiveWalletCustomDBComponent
-  , init
-  , walletLogMessage
-  , walletKeystore
-    -- ** Respond to block chain events
-  , applyBlock
-  , applyBlocks
-  , switchToFork
-    -- *** Testing
-  , observableRollbackUseInTestsOnly
-    -- ** The only effectful getter you will ever need
-  , getWalletSnapshot
-  ) where
+module Ariadne.Wallet.Cardano.Kernel
+       ( -- * Passive wallet
+         PassiveWallet -- opaque
+       , DB -- opaque
+       , WalletId
+       , passiveWalletCustomDBComponent
+       , init
+       , walletLogMessage
+       , walletKeystore
+         -- ** Respond to block chain events
+       , applyBlock
+       , applyBlocks
+       , switchToFork
+         -- *** Testing
+       , observableRollbackUseInTestsOnly
+         -- ** The only effectful getter you will ever need
+       , getWalletSnapshot
+       ) where
 
 import Prelude hiding (init)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Accounts.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Accounts.hs
@@ -1,10 +1,10 @@
-module Ariadne.Wallet.Cardano.Kernel.Accounts (
-      createAccount
-    , deleteAccount
-    , updateAccount
-    -- * Errors
-    , CreateAccountError(..)
-    ) where
+module Ariadne.Wallet.Cardano.Kernel.Accounts
+       ( createAccount
+       , deleteAccount
+       , updateAccount
+         -- * Errors
+       , CreateAccountError(..)
+       ) where
 
 import Control.Monad.Error.Class (liftEither, throwError)
 import qualified Data.Text.Buildable

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Actions.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Actions.hs
@@ -1,15 +1,15 @@
 module Ariadne.Wallet.Cardano.Kernel.Actions
-    ( WalletAction(..)
-    , WalletActionInterp(..)
-    , forkWalletWorker
-    , walletWorker
-    , interp
-    , interpList
-    , WalletWorkerState
-    , isInitialState
-    , hasPendingFork
-    , isValidState
-    ) where
+       ( WalletAction(..)
+       , WalletActionInterp(..)
+       , forkWalletWorker
+       , walletWorker
+       , interp
+       , interpList
+       , WalletWorkerState
+       , isInitialState
+       , hasPendingFork
+       , isValidState
+       ) where
 
 import Control.Concurrent.Async (async, link)
 import Control.Concurrent.Chan

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Addresses.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Addresses.hs
@@ -1,8 +1,8 @@
-module Ariadne.Wallet.Cardano.Kernel.Addresses (
-    createAddress
-    -- * Errors
-    , CreateAddressError(..)
-    ) where
+module Ariadne.Wallet.Cardano.Kernel.Addresses
+       ( createAddress
+         -- * Errors
+       , CreateAddressError(..)
+       ) where
 
 import Control.Monad.Error.Class (liftEither, throwError)
 import qualified Data.Text.Buildable

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip44.hs
@@ -1,11 +1,11 @@
 module Ariadne.Wallet.Cardano.Kernel.Bip44
-    ( Bip44DerivationPath (..)
-    , decodeBip44DerivationPath
-    , encodeBip44DerivationPath
-    , bip44PathToAddressId
-    , encodeBip44DerivationPathToAccount
-    , encodeBip44DerivationPathFromAccount
-    ) where
+       ( Bip44DerivationPath (..)
+       , decodeBip44DerivationPath
+       , encodeBip44DerivationPath
+       , bip44PathToAddressId
+       , encodeBip44DerivationPathToAccount
+       , encodeBip44DerivationPathFromAccount
+       ) where
 
 import Pos.Crypto.HD (firstHardened, firstNonHardened, isHardened)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
@@ -2,36 +2,36 @@
 {-# OPTIONS_GHC -fno-warn-deriving-typeable #-}
 
 -- | Acid-state database for the wallet kernel
-module Ariadne.Wallet.Cardano.Kernel.DB.AcidState (
-    -- * Top-level database
-    DB(..)
-  , dbHdWallets
-  , defDB
-    -- * Acid-state operations
-    -- ** Snapshot
-  , Snapshot(..)
-    -- ** Spec mandated updates
-  , NewPending(..)
-  , CancelPending(..)
-  , ApplyBlock(..)
-  , SwitchToFork(..)
-    -- ** Updates on HD wallets
-    -- *** CREATE
-  , CreateHdWallet(..)
-  , CreateHdAccount(..)
-  , CreateHdAddress(..)
-    -- *** UPDATE
-  , UpdateHdWalletName(..)
-  , UpdateHdWalletAssurance(..)
-  , UpdateHdAccountName(..)
-    -- *** DELETE
-  , DeleteHdRoot(..)
-  , DeleteHdAccount(..)
-    -- * Errors
-  , NewPendingError
-    -- * Testing
-  , ObservableRollbackUseInTestsOnly(..)
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.AcidState
+       ( -- * Top-level database
+         DB(..)
+       , dbHdWallets
+       , defDB
+         -- * Acid-state operations
+         -- ** Snapshot
+       , Snapshot(..)
+         -- ** Spec mandated updates
+       , NewPending(..)
+       , CancelPending(..)
+       , ApplyBlock(..)
+       , SwitchToFork(..)
+         -- ** Updates on HD wallets
+         -- *** CREATE
+       , CreateHdWallet(..)
+       , CreateHdAccount(..)
+       , CreateHdAddress(..)
+         -- *** UPDATE
+       , UpdateHdWalletName(..)
+       , UpdateHdWalletAssurance(..)
+       , UpdateHdAccountName(..)
+         -- *** DELETE
+       , DeleteHdRoot(..)
+       , DeleteHdAccount(..)
+         -- * Errors
+       , NewPendingError
+         -- * Testing
+       , ObservableRollbackUseInTestsOnly(..)
+       ) where
 
 import Control.Lens (at, non, to)
 import Control.Lens.TH (makeLenses)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/BlockMeta.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/BlockMeta.hs
@@ -1,13 +1,13 @@
 -- | Block metadata conform the wallet specification
-module Ariadne.Wallet.Cardano.Kernel.DB.BlockMeta (
-    -- * Block metadata
-    BlockMeta(..)
-  , AddressMeta(..)
-    -- ** Lenses
-  , addressMetaIsUsed
-  , blockMetaAddressMeta
-  , blockMetaSlotId
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.BlockMeta
+       ( -- * Block metadata
+         BlockMeta(..)
+       , AddressMeta(..)
+         -- ** Lenses
+       , addressMetaIsUsed
+       , blockMetaAddressMeta
+       , blockMetaSlotId
+       ) where
 
 import Control.Lens.TH (makeLenses)
 import qualified Data.Map.Strict as Map

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -1,68 +1,68 @@
 -- | HD wallets
-module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet (
-    -- * Supporting types
-    WalletName(..)
-  , AccountName(..)
-  , HdAccountIx(..)
-  , HdAddressIx(..)
-  , AssuranceLevel(..)
-  , HasSpendingPassword(..)
-    -- * HD wallet types proper
-  , HdWallets(..)
-  , HdRootId(..)
-  , HdAccountId(..)
-  , HdAddressChain(..)
-  , HdAddressId(..)
-  , HdRoot(..)
-  , HdAccount(..)
-  , HdAddress(..)
-    -- ** Initialiser
-  , initHdWallets
-    -- ** Lenses
-  , hdWalletsRoots
-  , hdWalletsAccounts
-  , hdWalletsAddresses
-  , hdAccountIdParent
-  , hdAccountIdIx
-  , hdAddressIdParent
-  , hdAddressIdIx
-  , hdAddressIdChain
-  , hdRootId
-  , hdRootName
-  , hdRootHasPassword
-  , hdRootAssurance
-  , hdRootCreatedAt
-  , hdAccountId
-  , hdAccountName
-  , hdAccountCurrentCheckpoint
-  , hdAccountCheckpoints
-  , hdAddressId
-  , hdAddressAddress
-  , hdAddressCheckpoints
-    -- ** Composite lenses
-  , hdAccountRootId
-  , hdAddressRootId
-  , hdAddressChain
-  , hdAddressAccountId
-    -- * Unknown identifiers
-  , UnknownHdRoot(..)
-  , UnknownHdAccount(..)
-  , UnknownHdAddress(..)
-  , embedUnknownHdRoot
-  , embedUnknownHdAccount
-    -- * Zoom to parts of the HD wallet
-  , zoomHdRootId
-  , zoomHdAccountId
-  , zoomHdAddressId
-    -- * Zoom variations that create on request
-  , zoomOrCreateHdRoot
-  , zoomOrCreateHdAccount
-  , zoomOrCreateHdAddress
-  , assumeHdRootExists
-  , assumeHdAccountExists
-    -- * General-utility functions
-  , eskToHdRootId
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
+       ( -- * Supporting types
+         WalletName(..)
+       , AccountName(..)
+       , HdAccountIx(..)
+       , HdAddressIx(..)
+       , AssuranceLevel(..)
+       , HasSpendingPassword(..)
+         -- * HD wallet types proper
+       , HdWallets(..)
+       , HdRootId(..)
+       , HdAccountId(..)
+       , HdAddressChain(..)
+       , HdAddressId(..)
+       , HdRoot(..)
+       , HdAccount(..)
+       , HdAddress(..)
+         -- ** Initialiser
+       , initHdWallets
+         -- ** Lenses
+       , hdWalletsRoots
+       , hdWalletsAccounts
+       , hdWalletsAddresses
+       , hdAccountIdParent
+       , hdAccountIdIx
+       , hdAddressIdParent
+       , hdAddressIdIx
+       , hdAddressIdChain
+       , hdRootId
+       , hdRootName
+       , hdRootHasPassword
+       , hdRootAssurance
+       , hdRootCreatedAt
+       , hdAccountId
+       , hdAccountName
+       , hdAccountCurrentCheckpoint
+       , hdAccountCheckpoints
+       , hdAddressId
+       , hdAddressAddress
+       , hdAddressCheckpoints
+         -- ** Composite lenses
+       , hdAccountRootId
+       , hdAddressRootId
+       , hdAddressChain
+       , hdAddressAccountId
+         -- * Unknown identifiers
+       , UnknownHdRoot(..)
+       , UnknownHdAccount(..)
+       , UnknownHdAddress(..)
+       , embedUnknownHdRoot
+       , embedUnknownHdAccount
+         -- * Zoom to parts of the HD wallet
+       , zoomHdRootId
+       , zoomHdAccountId
+       , zoomHdAddressId
+         -- * Zoom variations that create on request
+       , zoomOrCreateHdRoot
+       , zoomOrCreateHdAccount
+       , zoomOrCreateHdAddress
+       , assumeHdRootExists
+       , assumeHdAccountExists
+         -- * General-utility functions
+       , eskToHdRootId
+       ) where
 
 import Control.Lens (at)
 import Control.Lens.TH (makeLenses)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Create.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE RankNTypes #-}
 
 -- | CREATE operations on HD wallets
-module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Create (
-    -- * Errors
-    CreateHdRootError(..)
-  , CreateHdAccountError(..)
-  , CreateHdAddressError(..)
-    -- * Functions
-  , createHdRoot
-  , createHdAccount
-  , createHdAddress
-    -- * Initial values
-  , initHdRoot
-  , initHdAccount
-  , initHdAddress
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Create
+       ( -- * Errors
+         CreateHdRootError(..)
+       , CreateHdAccountError(..)
+       , CreateHdAddressError(..)
+        -- * Functions
+       , createHdRoot
+       , createHdAccount
+       , createHdAddress
+         -- * Initial values
+       , initHdRoot
+       , initHdAccount
+       , initHdAddress
+       ) where
 
 import Control.Lens (at, (.=))
 import Data.SafeCopy (base, deriveSafeCopySimple)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Delete.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Delete.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
 -- | DELETE operatiosn on HD wallets
-module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Delete (
-    DeleteHdAccountError(..)
-  , DeleteHdRootError(..)
-  , deleteHdRoot
-  , deleteHdAccount
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Delete
+       ( DeleteHdAccountError(..)
+       , DeleteHdRootError(..)
+       , deleteHdRoot
+       , deleteHdAccount
+       ) where
 
 import Control.Lens ((%=))
 import Data.SafeCopy (base, deriveSafeCopySimple)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Derivation.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Derivation.hs
@@ -1,9 +1,9 @@
-module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Derivation (
-      mkHdAccountIx
-    , mkHdAddressIx
-    , deriveBip44KeyPair
-    , deriveFirstBip44KeyPair
-    ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Derivation
+       ( mkHdAccountIx
+       , mkHdAddressIx
+       , deriveBip44KeyPair
+       , deriveFirstBip44KeyPair
+       ) where
 
 import qualified Data.Set as S
 import qualified Data.Vector as V

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Read.hs
@@ -7,29 +7,29 @@
 -- filtering and sorting. If we want the 'IxSet' stuff to be local to the
 -- "Kernel.DB" namespace (which would be a good thing), then filtering and
 -- sorting (and maybe even pagination) will need to happen here.
-module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Read (
-    -- | * Infrastructure
-    HdQuery
-  , HdQueryErr
-    -- | * Derived balance
-  , hdRootBalance
-  , hdAccountBalance
-  , hdAddressBalance
-    -- | Accumulate all accounts/addresses
-  , readAllHdRoots
-  , readAllHdAccounts
-  , readAllHdAddresses
-    -- | All wallets/accounts/addresses
-  , readAccountsByRootId
-  , readAddressesByRootId
-  , readAddressesByAccountId
-    -- | Single wallets/accounts/addresses
-  , readHdRoot
-  , readHdAccount
-  , readHdAccountCurrentCheckpoint
-  , readHdAddress
-  , readHdAddressByCardanoAddress
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Read
+       ( -- | * Infrastructure
+         HdQuery
+       , HdQueryErr
+         -- | * Derived balance
+       , hdRootBalance
+       , hdAccountBalance
+       , hdAddressBalance
+         -- | Accumulate all accounts/addresses
+       , readAllHdRoots
+       , readAllHdAccounts
+       , readAllHdAddresses
+         -- | All wallets/accounts/addresses
+       , readAccountsByRootId
+       , readAddressesByRootId
+       , readAddressesByAccountId
+         -- | Single wallets/accounts/addresses
+       , readHdRoot
+       , readHdAccount
+       , readHdAccountCurrentCheckpoint
+       , readHdAddress
+       , readHdAddressByCardanoAddress
+       ) where
 
 import Control.Lens (at)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Update.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet/Update.hs
@@ -1,9 +1,9 @@
 -- | UPDATE operations on HD wallets
-module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Update (
-    updateHdRootAssurance
-  , updateHdRootName
-  , updateHdAccountName
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Update
+       ( updateHdRootAssurance
+       , updateHdRootName
+       , updateHdAccountName
+       ) where
 
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
 import Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/InDb.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/InDb.hs
@@ -1,9 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Ariadne.Wallet.Cardano.Kernel.DB.InDb (
-    InDb(..)
-  , fromDb
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.InDb
+       ( InDb(..)
+       , fromDb
+       ) where
 
 import Control.Lens.TH (makeLenses)
 import Data.Coerce (coerce)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Resolved.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Resolved.hs
@@ -1,15 +1,15 @@
 -- | Resolved blocks and transactions
-module Ariadne.Wallet.Cardano.Kernel.DB.Resolved (
-    -- * Resolved blocks and transactions
-    ResolvedInput
-  , ResolvedTx(..)
-  , ResolvedBlock(..)
-    -- ** Lenses
-  , rtxInputs
-  , rtxOutputs
-  , rbTxs
-  , rbSlot
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.Resolved
+       ( -- * Resolved blocks and transactions
+         ResolvedInput
+       , ResolvedTx(..)
+       , ResolvedBlock(..)
+         -- ** Lenses
+       , rtxInputs
+       , rtxOutputs
+       , rbTxs
+       , rbSlot
+       ) where
 
 import Control.Lens.TH (makeLenses)
 import qualified Data.Map as Map

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
@@ -1,40 +1,40 @@
 {-# LANGUAGE RankNTypes #-}
 -- | Wallet state as mandated by the wallet specification
-module Ariadne.Wallet.Cardano.Kernel.DB.Spec (
-    -- * Wallet state as mandated by the spec
-    Pending(..)
-  , PendingTxs
-  , Balance
-  , AccCheckpoint(..)
-  , AccCheckpoints
-  , AddrCheckpoint(..)
-  , AddrCheckpoints
-  , emptyPending
-  , singletonPending
-  , unionPending
-  , removePending
-  , emptyAccCheckpoint
-  , emptyAddrCheckpoint
-    -- ** Lenses
-  , pendingTransactions
-  , accCheckpointUtxo
-  , accCheckpointUtxoBalance
-  , accCheckpointPending
-  , accCheckpointBlockMeta
-  , accCheckpointAddressMeta
-  , addrCheckpointUtxo
-  , addrCheckpointUtxoBalance
-    -- ** Lenses into the current checkpoint
-  , currentAccCheckpoint
-  , currentAccUtxo
-  , currentAccUtxoBalance
-  , currentAccPending
-  , currentAccPendingTxs
-  , currentAccBlockMeta
-  , currentAddrCheckpoint
-  , currentAddrUtxo
-  , currentAddrUtxoBalance
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.Spec
+       ( -- * Wallet state as mandated by the spec
+         Pending(..)
+       , PendingTxs
+       , Balance
+       , AccCheckpoint(..)
+       , AccCheckpoints
+       , AddrCheckpoint(..)
+       , AddrCheckpoints
+       , emptyPending
+       , singletonPending
+       , unionPending
+       , removePending
+       , emptyAccCheckpoint
+       , emptyAddrCheckpoint
+         -- ** Lenses
+       , pendingTransactions
+       , accCheckpointUtxo
+       , accCheckpointUtxoBalance
+       , accCheckpointPending
+       , accCheckpointBlockMeta
+       , accCheckpointAddressMeta
+       , addrCheckpointUtxo
+       , addrCheckpointUtxoBalance
+         -- ** Lenses into the current checkpoint
+       , currentAccCheckpoint
+       , currentAccUtxo
+       , currentAccUtxoBalance
+       , currentAccPending
+       , currentAccPendingTxs
+       , currentAccBlockMeta
+       , currentAddrCheckpoint
+       , currentAddrUtxo
+       , currentAddrUtxoBalance
+       ) where
 
 import Prelude hiding (elems)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Read.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Read.hs
@@ -1,11 +1,11 @@
 -- | READ-only operations on the wallet-spec state
-module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Read (
-    -- * Queries
-    queryAccountTotalBalance
-  , queryAccountUtxo
-  , queryAccountAvailableUtxo
-  , queryAccountAvailableBalance
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Read
+       ( -- * Queries
+         queryAccountTotalBalance
+       , queryAccountUtxo
+       , queryAccountAvailableUtxo
+       , queryAccountAvailableBalance
+       ) where
 
 import qualified Data.Map.Strict as Map
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
@@ -1,15 +1,15 @@
 -- | UPDATE operations on the wallet-spec state
-module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Update (
-    -- * Errors
-  NewPendingFailed(..)
-    -- * Updates
-  , newPending
-  , cancelPending
-  , applyBlock
-  , switchToFork
-    -- * Testing
-  , observableRollbackUseInTestsOnly
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Update
+       ( -- * Errors
+         NewPendingFailed(..)
+         -- * Updates
+       , newPending
+       , cancelPending
+       , applyBlock
+       , switchToFork
+         -- * Testing
+       , observableRollbackUseInTestsOnly
+       ) where
 
 import Data.SafeCopy (base, deriveSafeCopySimple)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Util.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Util.hs
@@ -1,20 +1,20 @@
 -- | UPDATE operations on the wallet-spec state
-module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Util (
-    PendingTxs
-  , Balance
-  , available
-  , balance
-  , balanceI
-  , disjoint
-  , isValidPendingTx
-  , pendingUtxo
-  , txAuxInputSet
-  , txIns
-  , utxoInputs
-  , unionTxOuts
-  , utxoRemoveInputs
-  , utxoRestrictToInputs
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.Spec.Util
+       ( PendingTxs
+       , Balance
+       , available
+       , balance
+       , balanceI
+       , disjoint
+       , isValidPendingTx
+       , pendingUtxo
+       , txAuxInputSet
+       , txIns
+       , utxoInputs
+       , unionTxOuts
+       , utxoRemoveInputs
+       , utxoRestrictToInputs
+       ) where
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Sqlite.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Sqlite.hs
@@ -2,20 +2,19 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Sqlite database for the 'TxMeta' portion of the wallet kernel.
-module Ariadne.Wallet.Cardano.Kernel.DB.Sqlite (
+module Ariadne.Wallet.Cardano.Kernel.DB.Sqlite
+       ( -- * Resource creation and acquisition
+         newConnection
+       , closeMetaDB
 
-    -- * Resource creation and acquisition
-      newConnection
-    , closeMetaDB
+         -- * Basic API
+       , putTxMeta
+       , getTxMeta
+       , getTxMetas
 
-    -- * Basic API
-    , putTxMeta
-    , getTxMeta
-    , getTxMetas
-
-    -- * Unsafe functions
-    , unsafeMigrateMetaDB
-    ) where
+         -- * Unsafe functions
+       , unsafeMigrateMetaDB
+       ) where
 
 import Database.Beam.Backend.SQL
   (FromBackendRow, HasSqlValueSyntax(..), IsSql92DataTypeSyntax, varCharType)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta.hs
@@ -1,11 +1,11 @@
 -- | Transaction metadata conform the wallet specification
-module Ariadne.Wallet.Cardano.Kernel.DB.TxMeta (
-    -- * Transaction metadata
-    module Types
+module Ariadne.Wallet.Cardano.Kernel.DB.TxMeta
+       ( -- * Transaction metadata
+         module Types
 
-  -- * Handy re-export to not leak our current choice of storage backend.
-  , openMetaDB
-  ) where
+         -- * Handy re-export to not leak our current choice of storage backend.
+       , openMetaDB
+       ) where
 
 import qualified Ariadne.Wallet.Cardano.Kernel.DB.Sqlite as ConcreteStorage
 import Ariadne.Wallet.Cardano.Kernel.DB.TxMeta.Types as Types

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/TxMeta/Types.hs
@@ -1,37 +1,37 @@
 -- | Transaction metadata conform the wallet specification
-module Ariadne.Wallet.Cardano.Kernel.DB.TxMeta.Types (
-    -- * Transaction metadata
-    TxMeta(..)
-    -- ** Lenses
-  , txMetaId
-  , txMetaAmount
-  , txMetaInputs
-  , txMetaOutputs
-  , txMetaCreationAt
-  , txMetaIsLocal
-  , txMetaIsOutgoing
+module Ariadne.Wallet.Cardano.Kernel.DB.TxMeta.Types
+       ( -- * Transaction metadata
+         TxMeta(..)
+         -- ** Lenses
+       , txMetaId
+       , txMetaAmount
+       , txMetaInputs
+       , txMetaOutputs
+       , txMetaCreationAt
+       , txMetaIsLocal
+       , txMetaIsOutgoing
 
-  -- * Transaction storage
-  , MetaDBHandle (..)
+         -- * Transaction storage
+       , MetaDBHandle (..)
 
-  -- * Filtering and sorting primitives
-  , Limit (..)
-  , Offset (..)
-  , Sorting (..)
-  , SortCriteria (..)
-  , SortDirection (..)
+         -- * Filtering and sorting primitives
+       , Limit (..)
+       , Offset (..)
+       , Sorting (..)
+       , SortCriteria (..)
+       , SortDirection (..)
 
-  -- * Domain-specific errors
-  , TxMetaStorageError (..)
-  , InvariantViolation (..)
+         -- * Domain-specific errors
+       , TxMetaStorageError (..)
+       , InvariantViolation (..)
 
-  -- * Strict & lenient equalities
-  , exactlyEqualTo
-  , isomorphicTo
+         -- * Strict & lenient equalities
+       , exactlyEqualTo
+       , isomorphicTo
 
-  -- * Internals useful for testing
-  , uniqueElements
-  ) where
+         -- * Internals useful for testing
+       , uniqueElements
+       ) where
 
 import Control.Lens.TH (makeLenses)
 import qualified Data.List as List

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/AcidState.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/AcidState.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE RankNTypes #-}
 
 -- | Some utilities for working with acid-state
-module Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState (
-    -- * Acid-state updates with support for errors
-    Update'
-  , runUpdate'
-  , runUpdateNoErrors
-  , mapUpdateErrors
-    -- * Zooming
-  , zoom
-  , zoomDef
-  , zoomCreate
-  , zoomAll
-    -- ** Convenience re-exports
-  , throwError
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState
+       ( -- * Acid-state updates with support for errors
+         Update'
+       , runUpdate'
+       , runUpdateNoErrors
+       , mapUpdateErrors
+         -- * Zooming
+       , zoom
+       , zoomDef
+       , zoomCreate
+       , zoomAll
+         -- ** Convenience re-exports
+       , throwError
+       ) where
 
 import Control.Monad.Except
 import Data.Acid (Update)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
@@ -1,38 +1,38 @@
 {-# LANGUAGE ConstraintKinds, RankNTypes #-}
 
 -- | Infrastructure for working with indexed sets
-module Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet (
-    -- * Primary keys
-    HasPrimKey(..)
-  , OrdByPrimKey -- opaque
-    -- * Wrapper around IxSet
-  , IndicesOf
-  , IxSet
-  , Indexable
-    -- * Building 'Indexable' instances
-  , deleteIxAll
-  , ixFun
-  , ixList
-    -- * Queries
-  , getEQ
-  , member
-  , size
-  , getOne
-  , toMap
-    -- * Modification
-  , updateIxManyM
-    -- * Construction
-  , fromList
-  , singleton
-  , omap
-  , otraverse
-  , emptyIxSet
-    -- * Destruction
-  , toAscList
-  , toList
-    -- * Indexing
-  , (@+)
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet
+       ( -- * Primary keys
+         HasPrimKey(..)
+       , OrdByPrimKey -- opaque
+         -- * Wrapper around IxSet
+       , IndicesOf
+       , IxSet
+       , Indexable
+         -- * Building 'Indexable' instances
+       , deleteIxAll
+       , ixFun
+       , ixList
+         -- * Queries
+       , getEQ
+       , member
+       , size
+       , getOne
+       , toMap
+         -- * Modification
+       , updateIxManyM
+         -- * Construction
+       , fromList
+       , singleton
+       , omap
+       , otraverse
+       , emptyIxSet
+         -- * Destruction
+       , toAscList
+       , toList
+         -- * Indexing
+       , (@+)
+       ) where
 
 import Prelude hiding (toList)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
@@ -6,13 +6,13 @@
 -- Cardano specific types (except those types that appear in the translation
 -- of the UTxO DSL), so that we can test it outside of a node context also
 -- (in unit tests).
-module Ariadne.Wallet.Cardano.Kernel.Internal (
-    -- * Passive wallet
-    PassiveWallet(..)
-  , walletKeystore
-  , wallets
-  , walletLogMessage
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.Internal
+       ( -- * Passive wallet
+         PassiveWallet(..)
+       , walletKeystore
+       , wallets
+       , walletLogMessage
+       ) where
 
 import Control.Lens.TH
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Keystore.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Keystore.hs
@@ -10,25 +10,25 @@
 
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Ariadne.Wallet.Cardano.Kernel.Keystore (
-      Keystore -- opaque
-    , DeletePolicy(..)
-    , DuplicatedWalletKey(..)
-      -- * Constructing a keystore
-    , keystoreComponent
-    , bracketKeystore
-    , bracketLegacyKeystore
-    -- * Inserting values
-    , insert
-    -- * Deleting values
-    , delete
-    -- * Queries on a keystore
-    , lookup
-    -- * Conversions
-    , toList
-    -- * Tests handy functions
-    , bracketTestKeystore
-    ) where
+module Ariadne.Wallet.Cardano.Kernel.Keystore
+       ( Keystore -- opaque
+       , DeletePolicy(..)
+       , DuplicatedWalletKey(..)
+         -- * Constructing a keystore
+       , keystoreComponent
+       , bracketKeystore
+       , bracketLegacyKeystore
+       -- * Inserting values
+       , insert
+       -- * Deleting values
+       , delete
+       -- * Queries on a keystore
+       , lookup
+       -- * Conversions
+       , toList
+       -- * Tests handy functions
+       , bracketTestKeystore
+       ) where
 
 import Prelude hiding (toList)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Types.hs
@@ -1,23 +1,23 @@
-module Ariadne.Wallet.Cardano.Kernel.Types (
-    -- * Input resolution
-    -- ** Raw types
-    ResolvedTxInputs
-  , ResolvedBlockInputs
-  , RawResolvedTx(..)
-  , invRawResolvedTx
-  , mkRawResolvedTx
-  , RawResolvedBlock(..)
-  , invRawResolvedBlock
-  , mkRawResolvedBlock
-  -- ** Abstract Wallet/AccountIds
-  , WalletId (..)
-  , AccountId (..)
-  , accountToWalletId
-    -- ** From raw to derived types
-  , fromRawResolvedTx
-  , fromRawResolvedBlock
-  , txUtxo
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.Types
+       ( -- * Input resolution
+         -- ** Raw types
+         ResolvedTxInputs
+       , ResolvedBlockInputs
+       , RawResolvedTx(..)
+       , invRawResolvedTx
+       , mkRawResolvedTx
+       , RawResolvedBlock(..)
+       , invRawResolvedBlock
+       , mkRawResolvedBlock
+         -- ** Abstract Wallet/AccountIds
+       , WalletId (..)
+       , AccountId (..)
+       , accountToWalletId
+         -- ** From raw to derived types
+       , fromRawResolvedTx
+       , fromRawResolvedBlock
+       , txUtxo
+       ) where
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Util.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Util.hs
@@ -1,28 +1,28 @@
-module Ariadne.Wallet.Cardano.Kernel.Util (
-    -- * Lists
-    at
-    -- * Maps and sets
-  , disjoint
-  , withoutKeys
-  , restrictKeys
-    -- * Dealing with OldestFirst/NewestFirst
-  , liftOldestFirstF
-  , liftNewestFirstF
-  , liftOldestFirst
-  , liftNewestFirst
-    -- * Probabilities
-  , Probability
-  , toss
-    -- * MonadState utilities
-  , modifyAndGetOld
-  , modifyAndGetNew
-    -- * Operations on UTxO
-  , utxoBalance
-  , utxoRestrictToInputs
-  , paymentAmount
-    -- * General-utility functions
-  , getCurrentTimestamp
-  ) where
+module Ariadne.Wallet.Cardano.Kernel.Util
+       ( -- * Lists
+         at
+         -- * Maps and sets
+       , disjoint
+       , withoutKeys
+       , restrictKeys
+         -- * Dealing with OldestFirst/NewestFirst
+       , liftOldestFirstF
+       , liftNewestFirstF
+       , liftOldestFirst
+       , liftNewestFirst
+         -- * Probabilities
+       , Probability
+       , toss
+         -- * MonadState utilities
+       , modifyAndGetOld
+       , modifyAndGetNew
+         -- * Operations on UTxO
+       , utxoBalance
+       , utxoRestrictToInputs
+       , paymentAmount
+         -- * General-utility functions
+       , getCurrentTimestamp
+       ) where
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Wallets.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Wallets.hs
@@ -1,16 +1,16 @@
-module Ariadne.Wallet.Cardano.Kernel.Wallets (
-      createHdWallet
-    , updateHdWalletName
-    , updateHdWalletAssurance
-    , deleteHdWallet
-    , HasNonemptyPassphrase(..)
-    , mkHasPP
-    , CreateWithAddress(..)
-      -- * Errors
-    , CreateWalletError(..)
-    -- * Internal & testing use only
-    , createWalletHdSeq
-    ) where
+module Ariadne.Wallet.Cardano.Kernel.Wallets
+       ( createHdWallet
+       , updateHdWalletName
+       , updateHdWalletAssurance
+       , deleteHdWallet
+       , HasNonemptyPassphrase(..)
+       , mkHasPP
+       , CreateWithAddress(..)
+         -- * Errors
+       , CreateWalletError(..)
+       -- * Internal & testing use only
+       , createWalletHdSeq
+       ) where
 
 import qualified Data.Text.Buildable
 import Formatting (bprint, build, formatToString, (%))

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Word31.hs
@@ -1,9 +1,9 @@
 module Ariadne.Wallet.Cardano.Kernel.Word31
-    ( Word31
-    , Word31Exception (..)
-    , unsafeMkWord31
-    , word31ToWord32
-    ) where
+       ( Word31
+       , Word31Exception (..)
+       , unsafeMkWord31
+       , word31ToWord32
+       ) where
 
 import Data.SafeCopy (base, deriveSafeCopySimple)
 import qualified Data.Text.Buildable (Buildable(..))

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer.hs
@@ -1,11 +1,11 @@
 module Ariadne.Wallet.Cardano.WalletLayer
-    ( -- * Kernel
-      passiveWalletLayerComponent
-    , passiveWalletLayerCustomDBComponent
-    -- * We re-export the types since we want all the dependencies
-    -- in this module, other modules shouldn't be touched.
-    , module Types
-    ) where
+       ( -- * Kernel
+         passiveWalletLayerComponent
+       , passiveWalletLayerCustomDBComponent
+         -- * We re-export the types since we want all the dependencies
+         -- in this module, other modules shouldn't be touched.
+       , module Types
+       ) where
 
 import Ariadne.Wallet.Cardano.WalletLayer.Kernel
   (passiveWalletLayerComponent, passiveWalletLayerCustomDBComponent)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
@@ -1,6 +1,6 @@
 module Ariadne.Wallet.Cardano.WalletLayer.Kernel
        ( passiveWalletLayerComponent
-       , passiveWalletLayerWithDBComponent
+       , passiveWalletLayerCustomDBComponent
        ) where
 
 import qualified Universum.Unsafe as Unsafe (fromJust)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
@@ -1,7 +1,7 @@
 module Ariadne.Wallet.Cardano.WalletLayer.Kernel
-    ( passiveWalletLayerComponent
-    , passiveWalletLayerCustomDBComponent
-    ) where
+       ( passiveWalletLayerComponent
+       , passiveWalletLayerWithDBComponent
+       ) where
 
 import qualified Universum.Unsafe as Unsafe (fromJust)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
@@ -1,6 +1,6 @@
 module Ariadne.Wallet.Cardano.WalletLayer.Types
-    ( PassiveWalletLayer (..)
-    ) where
+       ( PassiveWalletLayer (..)
+       ) where
 
 import qualified Ariadne.Wallet.Cardano.Kernel.Accounts as Kernel
 import qualified Ariadne.Wallet.Cardano.Kernel.Addresses as Kernel

--- a/ariadne/cardano/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Face.hs
@@ -1,22 +1,22 @@
 module Ariadne.Wallet.Face
-  ( module Ariadne.Cardano.Face
-  , InputSelectionPolicy (..)
+       ( module Ariadne.Cardano.Face
+       , InputSelectionPolicy (..)
 
-  , WalletFace(..)
-  , WalletEvent(..)
-  , WalletReference(..)
-  , AccountReference(..)
-  , LocalAccountReference(..)
-  , WalletSelection(..)
-  , WalletName(..)
-  , Mnemonic(..)
-  , WalletRestoreType (..)
-  , WalletUIFace(..)
+       , WalletFace(..)
+       , WalletEvent(..)
+       , WalletReference(..)
+       , AccountReference(..)
+       , LocalAccountReference(..)
+       , WalletSelection(..)
+       , WalletName(..)
+       , Mnemonic(..)
+       , WalletRestoreType (..)
+       , WalletUIFace(..)
 
-  , SomeWalletPassException(..)
-  , walletPassExceptionToException
-  , walletPassExceptionFromException
-  ) where
+       , SomeWalletPassException(..)
+       , walletPassExceptionToException
+       , walletPassExceptionFromException
+       ) where
 
 import Data.Typeable (cast)
 import qualified GHC.Show as Show (Show (show))

--- a/ariadne/cardano/src/Ariadne/Wallet/Knit.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Knit.hs
@@ -1,4 +1,34 @@
-module Ariadne.Wallet.Knit where
+module Ariadne.Wallet.Knit
+       ( Wallet
+
+       , ComponentValue(..)
+       , ComponentInflate(..)
+       , ComponentLit(..)
+       , ComponentToken(..)
+       , ComponentTokenizer(..)
+       , ComponentDetokenizer(..)
+       , ComponentLitGrammar(..)
+       , ComponentPrinter(..)
+       , ComponentCommandRepr(..)
+       , ComponentLitToValue(..)
+       , ComponentExecContext(..)
+       , ComponentCommandExec(..)
+       , ComponentCommandProcs(..)
+
+       , refreshStateCommandName
+       , newAddressCommandName
+       , newAccountCommandName
+       , newWalletCommandName
+       , restoreCommandName
+       , restoreFromFileCommandName
+       , selectCommandName
+       , sendCommandName
+       , balanceCommandName
+       , renameCommandName
+       , removeCommandName
+
+       , getWalletRefArg
+       ) where
 
 import Control.Lens (makePrisms)
 import Serokell.Data.Memory.Units (fromBytes)

--- a/ariadne/cardano/src/Ariadne/Wallet/UiAdapter.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/UiAdapter.hs
@@ -1,28 +1,28 @@
 module Ariadne.Wallet.UiAdapter
-  ( UiWalletData(..)
-  , UiAccountData(..)
-  , UiWalletSelection(..)
-  , UiAddressData(..)
-  -- * Lens
-  , uwdName
-  , uwdId
-  , uwdAccounts
-  , uwdBalance
+       ( UiWalletData(..)
+       , UiAccountData(..)
+       , UiWalletSelection(..)
+       , UiAddressData(..)
+         -- * Lens
+       , uwdName
+       , uwdId
+       , uwdAccounts
+       , uwdBalance
 
-  , uadName
-  , uadAccountIdx
-  , uadAddresses
-  , uadBalance
+       , uadName
+       , uadAccountIdx
+       , uadAddresses
+       , uadBalance
 
-  , uiadAddress
-  , uiadAddressIdx
-  , uiadBalance
-  --
-  , toUiWalletDatas
-  , toUiWalletSelection
-  , formatAddressHash
-  , formatHdRootId
-  ) where
+       , uiadAddress
+       , uiadAddressIdx
+       , uiadBalance
+         --
+       , toUiWalletDatas
+       , toUiWalletSelection
+       , formatAddressHash
+       , formatHdRootId
+       ) where
 
 import qualified Data.Vector as V
 import Formatting (sformat, (%))

--- a/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Test.Ariadne.Cardano.Arbitrary where
+module Test.Ariadne.Cardano.Arbitrary
+       (
+       ) where
 
 import Ariadne.Config.Cardano (CardanoConfig(..))
 import Data.Time.Units (fromMicroseconds)

--- a/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Cardano/Arbitrary.hs
@@ -1,6 +1,14 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Ariadne.Cardano.Arbitrary
-       (
+       ( Arbitrary(..)
+       , genEkgParams
+       , genConfigurationOptions
+       , genValidTimestamp
+       , genMaybe
+       , genValidText
+       , genValidByteString
+       , genValidString
+       , genNetworkAddress
        ) where
 
 import Ariadne.Config.Cardano (CardanoConfig(..))

--- a/ariadne/cardano/test/Test/Ariadne/History/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/History/Arbitrary.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Test.Ariadne.History.Arbitrary
-       (
-       ) where
+module Test.Ariadne.History.Arbitrary () where
 
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
 

--- a/ariadne/cardano/test/Test/Ariadne/Update/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Update/Arbitrary.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Test.Ariadne.Update.Arbitrary
-       (
-       ) where
+module Test.Ariadne.Update.Arbitrary () where
 
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
 import Test.QuickCheck.Gen (elements)

--- a/ariadne/cardano/test/Test/Ariadne/Wallet/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Wallet/Arbitrary.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Test.Ariadne.Wallet.Arbitrary where
+module Test.Ariadne.Wallet.Arbitrary
+       (
+       ) where
 
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
 import Test.QuickCheck.Gen (elements)

--- a/ariadne/cardano/test/Test/Ariadne/Wallet/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Wallet/Arbitrary.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Test.Ariadne.Wallet.Arbitrary
-       (
-       ) where
+module Test.Ariadne.Wallet.Arbitrary () where
 
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
 import Test.QuickCheck.Gen (elements)

--- a/ariadne/core/src/Ariadne/Knit/Backend.hs
+++ b/ariadne/core/src/Ariadne/Knit/Backend.hs
@@ -1,8 +1,8 @@
 module Ariadne.Knit.Backend
-  ( Components
-  , KnitFace(..)
-  , createKnitBackend
-  ) where
+       ( Components
+       , KnitFace(..)
+       , createKnitBackend
+       ) where
 
 import NType (AllConstrained, KnownSpine)
 import Text.PrettyPrint.ANSI.Leijen (Doc)

--- a/ariadne/core/src/Ariadne/Knit/Face.hs
+++ b/ariadne/core/src/Ariadne/Knit/Face.hs
@@ -1,4 +1,8 @@
-module Ariadne.Knit.Face where
+module Ariadne.Knit.Face
+       ( KnitCommandResult(..)
+       , KnitCommandHandle(..)
+       , KnitFace(..)
+       ) where
 
 import Control.Exception (SomeException)
 import Data.List.NonEmpty (NonEmpty)

--- a/ariadne/core/src/Ariadne/Knit/Help.hs
+++ b/ariadne/core/src/Ariadne/Knit/Help.hs
@@ -1,4 +1,6 @@
-module Ariadne.Knit.Help (generateKnitHelp) where
+module Ariadne.Knit.Help
+       ( generateKnitHelp
+       ) where
 
 import qualified Universum.Unsafe as Unsafe (tail)
 

--- a/ariadne/core/src/Ariadne/TaskManager/Backend.hs
+++ b/ariadne/core/src/Ariadne/TaskManager/Backend.hs
@@ -1,4 +1,6 @@
-module Ariadne.TaskManager.Backend (createTaskManagerFace) where
+module Ariadne.TaskManager.Backend
+       ( createTaskManagerFace
+       ) where
 
 import Control.Concurrent.Async
 import Control.Lens as L

--- a/ariadne/core/src/Ariadne/TaskManager/Face.hs
+++ b/ariadne/core/src/Ariadne/TaskManager/Face.hs
@@ -1,4 +1,9 @@
-module Ariadne.TaskManager.Face where
+module Ariadne.TaskManager.Face
+       ( TaskId(..)
+       , TaskManagerFace(..)
+       , EvalErrorException(..)
+       , NoTaskException(..)
+       ) where
 
 import Control.Concurrent.Async
 import Control.Exception (Exception, SomeException)

--- a/ariadne/core/src/Ariadne/TaskManager/Knit.hs
+++ b/ariadne/core/src/Ariadne/TaskManager/Knit.hs
@@ -1,4 +1,22 @@
-module Ariadne.TaskManager.Knit where
+module Ariadne.TaskManager.Knit
+       ( TaskManager
+
+       , ComponentValue(..)
+       , ComponentInflate(..)
+       , ComponentCommandRepr(..)
+       , ComponentExecContext(..)
+       , ComponentLit(..)
+       , ComponentToken(..)
+       , ComponentLitToValue(..)
+       , ComponentTokenizer(..)
+       , ComponentDetokenizer(..)
+       , ComponentLitGrammar(..)
+       , ComponentPrinter(..)
+       , ComponentCommandExec(..)
+       , ComponentCommandProcs(..)
+
+       , killCommandName
+       ) where
 
 import Control.Concurrent
 import Control.Concurrent.Async

--- a/ariadne/core/src/Ariadne/UIConfig.hs
+++ b/ariadne/core/src/Ariadne/UIConfig.hs
@@ -1,8 +1,8 @@
 module Ariadne.UIConfig
-  ( licenseUrl
-  , changelogUrl
-  , aboutUrl
-  ) where
+       ( licenseUrl
+       , changelogUrl
+       , aboutUrl
+       ) where
 
 licenseUrl :: Text
 licenseUrl = "https://serokell.io/ariadne/license"

--- a/ariadne/core/src/Ariadne/UX/CommandHistory.hs
+++ b/ariadne/core/src/Ariadne/UX/CommandHistory.hs
@@ -1,11 +1,11 @@
 module Ariadne.UX.CommandHistory
-    ( CommandHistory
-    , openCommandHistory
-    , addCommand
-    , setPrefix
-    , toNextCommand
-    , toPrevCommand
-    ) where
+       ( CommandHistory
+       , openCommandHistory
+       , addCommand
+       , setPrefix
+       , toNextCommand
+       , toPrevCommand
+       ) where
 
 import Control.Monad.Component (ComponentM, buildComponent_)
 import qualified Data.Text as T

--- a/ariadne/core/src/Ariadne/Util.hs
+++ b/ariadne/core/src/Ariadne/Util.hs
@@ -1,8 +1,7 @@
 module Ariadne.Util
-    ( atomicRunStateIORef'
-    , postfixLFields
-    )
-    where
+       ( atomicRunStateIORef'
+       , postfixLFields
+       ) where
 
 import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -239,7 +239,14 @@ Use singular when naming modules (e.g. use `Data.Map` and
 
 ### Export Lists
 
-Always use explicit exports. Format export lists as follows:
+Always use explicit exports. If an export list is empty write it on one line,
+for example:
+
+```haskell
+module Test.Ariadne.Cardano.Arbitrary () where
+```
+
+Otherwise, format export lists as follows:
 
 ```haskell
 module Data.Set

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -239,7 +239,7 @@ Use singular when naming modules (e.g. use `Data.Map` and
 
 ### Export Lists
 
-Format export lists as follows:
+Always use explicit exports. Format export lists as follows:
 
 ```haskell
 module Data.Set
@@ -258,9 +258,7 @@ Some clarifications:
 1. Use 7 spaces indentation for export list (so that bracket is below
    the first letter in module name).
 2. You can split export list into sections or just write all as single section.
-3. It is strongly adviced to sort each section alpabetically. However,
-   classes, data types and type aliases should be written before
-   functions.
+3. Classes, data types and type aliases should be written before functions.
 
 ### Imports
 

--- a/knit/src/Knit.hs
+++ b/knit/src/Knit.hs
@@ -1,6 +1,6 @@
 module Knit
-  ( module X
-  ) where
+       ( module X
+       ) where
 
 import NType as X
 

--- a/knit/src/Knit/Core.hs
+++ b/knit/src/Knit/Core.hs
@@ -1,4 +1,38 @@
-module Knit.Core where
+module Knit.Core
+       ( Core
+
+       , ComponentValue(..)
+       , ComponentInflate(..)
+       , ComponentLit(..)
+       , ComponentToken(..)
+       , ComponentTokenizer(..)
+       , ComponentDetokenizer(..)
+       , ComponentLitGrammar(..)
+       , ComponentPrinter(..)
+       , ComponentCommandRepr(..)
+       , ComponentLitToValue(..)
+       , ComponentExecContext(..)
+       , ComponentCommandExec(..)
+       , ComponentCommandProcs(..)
+
+       , _ValueBool
+       , _ValueNumber
+       , _ValueString
+       , _ValueUnit
+       , _ValueFilePath
+       , _ValueList
+
+       , tyEither
+       , tyValue
+       , tyBool
+       , tyFilePath
+       , tyString
+       , tyInt
+       , tyWord
+       , tyWord8
+       , tyWord32
+       , tyWord64
+       ) where
 
 import Control.Applicative as A
 import Control.Lens

--- a/knit/src/Knit/DisplayError.hs
+++ b/knit/src/Knit/DisplayError.hs
@@ -1,12 +1,12 @@
 module Knit.DisplayError
-    ( ppArgumentError
-    , ppEvalError
-    , ppTypeError
-    , ppTypeName
-    , ppParseError
-    , ppProcError
-    , ppResolveErrors
-    ) where
+       ( ppArgumentError
+       , ppEvalError
+       , ppTypeError
+       , ppTypeName
+       , ppParseError
+       , ppProcError
+       , ppResolveErrors
+       ) where
 
 
 import Control.Applicative ((<|>))

--- a/knit/src/Knit/Eval.hs
+++ b/knit/src/Knit/Eval.hs
@@ -1,4 +1,14 @@
-module Knit.Eval where
+module Knit.Eval
+       ( EvalError(..)
+       , EvalT
+       , ExecContext
+
+       , ComponentExecContext
+       , ComponentCommandExec(..)
+       , ComponentLitToValue(..)
+
+       , evaluate
+       ) where
 
 import Control.Monad.Except
 import Data.Type.Equality

--- a/knit/src/Knit/Inflate.hs
+++ b/knit/src/Knit/Inflate.hs
@@ -1,4 +1,7 @@
-module Knit.Inflate where
+module Knit.Inflate
+       ( ComponentInflate(..)
+       , inflate
+       ) where
 
 import Knit.Prelude
 import Knit.Syntax

--- a/knit/src/Knit/Parser.hs
+++ b/knit/src/Knit/Parser.hs
@@ -1,6 +1,17 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
-module Knit.Parser where
+module Knit.Parser
+       ( ComponentLitGrammar(..)
+       , ParseError (..)
+       , tok
+       , parseErrorSpans
+       , inBrackets
+       , gComponentsLit
+       , gExpr
+       , mkExprGroup
+       , pExpr
+       , parse
+       ) where
 
 import Control.Applicative as A
 import Control.Applicative.Combinators.NonEmpty (sepBy1)

--- a/knit/src/Knit/Prelude.hs
+++ b/knit/src/Knit/Prelude.hs
@@ -1,7 +1,7 @@
 module Knit.Prelude
-  ( module X
-  , uprism
-  ) where
+       ( module X
+       , uprism
+       ) where
 
 import Prelude as X
 

--- a/knit/src/Knit/Printer.hs
+++ b/knit/src/Knit/Printer.hs
@@ -1,4 +1,13 @@
-module Knit.Printer where
+module Knit.Printer
+       ( ComponentPrinter(..)
+       , PrettyPrintValue
+       , ppLit
+       , ppToken
+       , ppExpr
+       , ppValue
+       , nameToDoc
+       , text
+       ) where
 
 import Data.List as List
 import Data.Monoid

--- a/knit/src/Knit/Procedure.hs
+++ b/knit/src/Knit/Procedure.hs
@@ -1,4 +1,11 @@
-module Knit.Procedure where
+module Knit.Procedure
+       ( ComponentCommandRepr
+       , CommandProc(..)
+       , ComponentCommandProcs(..)
+       , SomeCommandProc(..)
+       , commandProcs
+       , resolveProcNames
+       ) where
 
 import Control.Lens
 import Data.List as List

--- a/knit/src/Knit/Syntax.hs
+++ b/knit/src/Knit/Syntax.hs
@@ -1,4 +1,14 @@
-module Knit.Syntax where
+module Knit.Syntax
+       ( Operator(..)
+       , CommandId(..)
+       , Expr(..)
+       , ComponentLit
+       , Lit(..)
+       , ProcCall(..)
+       , Arg(..)
+       , toLit
+       , fromLit
+       ) where
 
 import Data.String
 

--- a/knit/src/Knit/Tokenizer.hs
+++ b/knit/src/Knit/Tokenizer.hs
@@ -1,6 +1,32 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
-module Knit.Tokenizer where
+module Knit.Tokenizer
+       ( BracketSide(..)
+       , Tokenizer
+       , ComponentToken
+       , ComponentTokenizer(..)
+       , ComponentDetokenizer(..)
+       , Token(..)
+
+       , _BracketSideOpening 
+       , _BracketSideClosing
+       , _Token
+       , _TokenSquareBracket
+       , _TokenParenthesis
+       , _TokenEquals
+       , _TokenSemicolon
+       , _TokenName
+       , _TokenKey
+       , _TokenUnknown
+
+       , toToken
+       , fromToken
+       , tokenize
+       , detokenize
+       , tokenize'
+       , longestMatch
+       , pSomeAlphaNum
+       ) where
 
 import Control.Applicative as A
 import Control.Lens

--- a/knit/src/Knit/Value.hs
+++ b/knit/src/Knit/Value.hs
@@ -3,7 +3,13 @@
 Values manipulated by Knit programs during evaluation/execution.
 
 -}
-module Knit.Value where
+module Knit.Value
+       ( ComponentValue
+       , ValueUnion
+       , Value(..)
+       , toValue
+       , fromValue
+       ) where
 
 import Knit.Prelude
 

--- a/ui/cli-app/Glue.hs
+++ b/ui/cli-app/Glue.hs
@@ -1,8 +1,7 @@
 -- | Glue code between the frontend and the backends.
 
 module Glue
-       (
-         -- * Knit ↔ Vty
+       ( -- * Knit ↔ Vty
          knitFaceToUI
 
          -- * Cardano ↔ Vty

--- a/ui/cli-app/Main.hs
+++ b/ui/cli-app/Main.hs
@@ -1,4 +1,6 @@
-module Main where
+module Main
+       ( main
+       ) where
 
 import NType (N(..))
 

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -1,8 +1,7 @@
 -- | Glue code between the frontend and the backends.
 
 module Glue
-       (
-         -- * Knit ↔ Qt
+       ( -- * Knit ↔ Qt
          knitFaceToUI
 
          -- * Cardano ↔ Qt

--- a/ui/qt-app/Main.hs
+++ b/ui/qt-app/Main.hs
@@ -1,4 +1,6 @@
-module Main where
+module Main
+       ( main
+       ) where
 
 import Control.Monad.Component (ComponentM)
 import NType (N(..))

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -1,7 +1,7 @@
 module Ariadne.UI.Qt
-  ( UiFace(..)
-  , createAriadneUI
-  ) where
+       ( UiFace(..)
+       , createAriadneUI
+       ) where
 
 import Control.Concurrent
 import Control.Monad.Component (ComponentM, buildComponent_)

--- a/ui/qt-lib/src/Ariadne/UI/Qt/AnsiToHTML.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/AnsiToHTML.hs
@@ -1,8 +1,8 @@
 module Ariadne.UI.Qt.AnsiToHTML
-    ( spanFormat
-    , simpleDocToHTML
-    , csiToHTML
-    ) where
+       ( spanFormat
+       , simpleDocToHTML
+       , csiToHTML
+       ) where
 
 import Formatting
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
@@ -1,8 +1,8 @@
 module Ariadne.UI.Qt.MainWindow
-    ( MainWindow
-    , initMainWindow
-    , handleMainWindowEvent
-    ) where
+       ( MainWindow
+       , initMainWindow
+       , handleMainWindowEvent
+       ) where
 
 import Control.Lens (magnify, makeLensesWith)
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/StyleSheet.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/StyleSheet.hs
@@ -1,6 +1,6 @@
 module Ariadne.UI.Qt.StyleSheet
-  ( styleSheet
-  ) where
+       ( styleSheet
+       ) where
 
 import Data.FileEmbed
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/UI.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/UI.hs
@@ -1,4 +1,10 @@
-module Ariadne.UI.Qt.UI where
+module Ariadne.UI.Qt.UI
+       ( UI
+       , QVariantCastable(..)
+       , runUI
+       , connectSignal
+       , setProperty
+       ) where
 
 import Graphics.UI.Qtah.Signal (Signal, connect_)
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/ConfirmMnemonic.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/ConfirmMnemonic.hs
@@ -1,7 +1,7 @@
 module Ariadne.UI.Qt.Widgets.Dialogs.ConfirmMnemonic
-  ( ConfirmMnemonicResult(..)
-  , runConfirmMnemonic
-  ) where
+       ( ConfirmMnemonicResult(..)
+       , runConfirmMnemonic
+       ) where
 
 import Formatting
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Delete.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Delete.hs
@@ -1,8 +1,8 @@
 module Ariadne.UI.Qt.Widgets.Dialogs.Delete
-  ( DeletingItem(..)
-  , DeletionResult(..)
-  , runDelete
-  ) where
+       ( DeletingItem(..)
+       , DeletionResult(..)
+       , runDelete
+       ) where
 
 import qualified Data.Text as T
 import Formatting

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/NewWallet.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/NewWallet.hs
@@ -1,9 +1,9 @@
 module Ariadne.UI.Qt.Widgets.Dialogs.NewWallet
-  ( runNewWallet
-  , NewWalletParameters(..)
-  , NewWalletSpecifier(..)
-  , NewWalletResult(..)
-  ) where
+       ( runNewWallet
+       , NewWalletParameters(..)
+       , NewWalletSpecifier(..)
+       , NewWalletResult(..)
+       ) where
 
 import Control.Lens (makeLensesWith)
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
@@ -1,4 +1,12 @@
-module Ariadne.UI.Qt.Widgets.Dialogs.Util where
+module Ariadne.UI.Qt.Widgets.Dialogs.Util
+       ( createLayout
+       , addHeader
+       , addRow
+       , addRowLayout
+       , addSeparator
+       , createSubWidget
+       , createCheckBox
+       ) where
 
 import Data.Bits
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
@@ -1,11 +1,15 @@
 module Ariadne.UI.Qt.Widgets.Dialogs.Util
-       ( createLayout
+       ( CheckboxPosition (..) 
+       , createLayout
        , addHeader
        , addRow
        , addRowLayout
        , addSeparator
        , createSubWidget
        , createCheckBox
+       , createCheckBoxWithLabel
+       , createPasswordField
+       , createRowLayout
        ) where
 
 import Data.Bits

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Help.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Help.hs
@@ -1,8 +1,8 @@
 module Ariadne.UI.Qt.Widgets.Help
-    ( Help
-    , initHelp
-    , showHelpWindow
-    ) where
+       ( Help
+       , initHelp
+       , showHelpWindow
+       ) where
 
 import qualified Data.Text as T
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Logs.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Logs.hs
@@ -1,9 +1,9 @@
 module Ariadne.UI.Qt.Widgets.Logs
-    ( Logs
-    , initLogs
-    , displayLogMessage
-    , showLogsWindow
-    ) where
+       ( Logs
+       , initLogs
+       , displayLogMessage
+       , showLogsWindow
+       ) where
 
 import Formatting
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/TopBar.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/TopBar.hs
@@ -1,12 +1,12 @@
 module Ariadne.UI.Qt.Widgets.TopBar
-  ( TopBar
-  , initTopBar
-  , doOnReplButtonClick
-  , doOnLogsAction
-  , doOnHelpAction
-  , doOnSettingsAction
-  , displayBlockchainInfo
-  ) where
+       ( TopBar
+       , initTopBar
+       , doOnReplButtonClick
+       , doOnLogsAction
+       , doOnHelpAction
+       , doOnSettingsAction
+       , displayBlockchainInfo
+       ) where
 
 import Control.Lens (makeLensesWith)
 

--- a/ui/vty-app/Glue.hs
+++ b/ui/vty-app/Glue.hs
@@ -1,8 +1,7 @@
 -- | Glue code between the frontend and the backends.
 
 module Glue
-       (
-         -- * Knit ↔ Vty
+       ( -- * Knit ↔ Vty
          knitFaceToUI
 
          -- * Cardano ↔ Vty

--- a/ui/vty-app/Main.hs
+++ b/ui/vty-app/Main.hs
@@ -1,4 +1,6 @@
-module Main where
+module Main
+       ( main
+       ) where
 
 import Control.Monad.Component (ComponentM)
 import NType (N(..))

--- a/ui/vty-lib/src/Ariadne/UI/Vty.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty.hs
@@ -1,7 +1,7 @@
 module Ariadne.UI.Vty
-  ( UiFace(..)
-  , createAriadneUI
-  ) where
+       ( UiFace(..)
+       , createAriadneUI
+       ) where
 
 import qualified Brick as B
 import Brick.BChan

--- a/ui/vty-lib/src/Ariadne/UI/Vty/AnsiToVty.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/AnsiToVty.hs
@@ -1,4 +1,8 @@
-module Ariadne.UI.Vty.AnsiToVty (ansiToVty, csiToVty, pprDoc) where
+module Ariadne.UI.Vty.AnsiToVty
+       (ansiToVty
+       , csiToVty
+       , pprDoc
+       ) where
 
 import Control.Monad.Trans.Writer
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
@@ -1,7 +1,7 @@
 module Ariadne.UI.Vty.App
-  ( initApp
-  , app
-  ) where
+       ( initApp
+       , app
+       ) where
 
 import Control.Lens (makeLensesWith, uses, (%=), (.=))
 import Data.Char (toLower)

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Focus.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Focus.hs
@@ -1,6 +1,6 @@
 module Ariadne.UI.Vty.Focus
-     ( withFocusIndicator
-     ) where
+       ( withFocusIndicator
+       ) where
 
 import qualified Brick as B
 import qualified Graphics.Vty as V

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Keyboard.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Keyboard.hs
@@ -1,9 +1,9 @@
 module Ariadne.UI.Vty.Keyboard
-     ( KeyboardEvent(..)
-     , KeyboardEditEvent(..)
-     , vtyToKey
-     , vtyToEditKey
-     ) where
+       ( KeyboardEvent(..)
+       , KeyboardEditEvent(..)
+       , vtyToKey
+       , vtyToEditKey
+       ) where
 
 import Graphics.Vty
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Knit.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Knit.hs
@@ -1,4 +1,7 @@
-module Ariadne.UI.Vty.Knit where
+module Ariadne.UI.Vty.Knit
+       ( UI
+       , ComponentExecContext(..)
+       ) where
 
 import Text.Earley
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Scrolling.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Scrolling.hs
@@ -1,12 +1,12 @@
 module Ariadne.UI.Vty.Scrolling
-     ( ScrollingAction(..)
-     , keyToScrollingAction
-     , handleScrollingEvent
-     , scrollToEnd
-     , fixedViewport
-     , scrollingViewport
-     , fixedScrollingViewport
-     ) where
+       ( ScrollingAction(..)
+       , keyToScrollingAction
+       , handleScrollingEvent
+       , scrollToEnd
+       , fixedViewport
+       , scrollingViewport
+       , fixedScrollingViewport
+       ) where
 
 import Ariadne.UI.Vty.Keyboard
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Theme.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Theme.hs
@@ -1,4 +1,6 @@
-module Ariadne.UI.Vty.Theme where
+module Ariadne.UI.Vty.Theme
+       ( defaultAttrMap
+       ) where
 
 import Prelude hiding (on)
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
@@ -48,7 +48,7 @@ module Ariadne.UI.Vty.Widget
        , handleWidgetScroll
        , handleWidgetEvent
 
-       -- Re-exports
+         -- Re-exports
        , ReifiedLens'
        , ReifiedLens(..)
        ) where


### PR DESCRIPTION
**Description:**
Makes exports explicit in every module and with the same style.

**YT issue:** https://issues.serokell.io/issue/AD-340

**Checklist:**

- [x] Updated docs if necessary (Updated [Code style](docs/code-style.md))
  - [x] [README](README.md) (Unnecessary)
  - [x] [TUI usage guide](docs/usage-tui.md) (Unnecessary)
  - [x] [Configuration documentation](docs/configuration.md) (Unnecessary)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
