### PR TITLE
[AD-394] Clear wallet pane when nothing selected

### DIFF
--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletInfo.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/WalletInfo.hs
@@ -77,7 +77,7 @@ initWalletInfo langFace uiWalletFace itemModel selectionModel = do
   QLayout.setContentsMarginsRaw headerLayout 36 12 36 12
   QLayout.setSpacing headerLayout 36
 
-  itemNameLabel <- QLabel.newWithText ("Select something..." :: String)
+  itemNameLabel <- QLabel.newWithText $ toString selectSomethingText
   QObject.setObjectName itemNameLabel ("itemNameLabel" :: String)
   QLayout.addWidget headerLayout itemNameLabel
   QBoxLayout.addStretch headerLayout
@@ -154,6 +154,7 @@ initWalletInfo langFace uiWalletFace itemModel selectionModel = do
 
 data WalletInfoEvent
   = WalletInfoSelectionChange UiSelectionInfo
+  | WalletInfoDeselect
   | WalletInfoSendCommandResult UiCommandId UiSendCommandResult
   | WalletInfoNewAccountCommandResult UiCommandId UiNewAccountCommandResult
   | WalletInfoNewAddressCommandResult UiCommandId UiNewAddressCommandResult
@@ -188,6 +189,15 @@ handleWalletInfoEvent UiLangFace{..} ev = do
       -- `itemNameLabel` stores capitalized text, but we need the original for delete dialog
       writeIORef currentItemName $ fromMaybe "" itemName
 
+    WalletInfoDeselect -> do
+      QLabel.setText itemNameLabel $ toString selectSomethingText
+      QLabel.setText balanceLabel ("" :: String)
+      QWidget.hide createAccountButton
+      QWidget.hide requestButton
+      QWidget.hide deleteItemButton
+
+      writeIORef currentItem Nothing
+      writeIORef currentItemName ""
 
     WalletInfoSendCommandResult _commandId result -> case result of
       UiSendCommandSuccess hash -> do
@@ -251,3 +261,6 @@ sendButtonClicked UiLangFace{..} uiWalletFace WalletInfo{..} _checked = whenJust
     SendSuccess SendOptions{..} -> langPutUiCommand (UiSend wIdx soAccounts soAddress soAmount) >>= \case
       Left err -> void $ QMessageBox.critical walletInfo ("Error" :: String) $ toString err
       Right _ -> pass
+
+selectSomethingText :: Text
+selectSomethingText = "Select something..."


### PR DESCRIPTION
**Description:** When backend sends WalletUpdateEvent with emtpy selection, clear
WaletInfo widget as well. Otherwise after deleting current wallet the
widget contains stale info.

Clearing WalletInfo widget is the easiest way to achieve this, but I'm not 100% sure the best. Is there a case when backend sends empty selection info, but UI **must not** clear wallet pane?

**YT issue:** https://issues.serokell.io/issue/AD-394

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [Configuration documentation](docs/configuration.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
