### PR TITLE
[AD-425] Allow no accounts selection in send form

### DIFF
--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Send.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Send.hs
@@ -189,7 +189,7 @@ fillSendOptions Send{..} = do
   let UiWalletFace{..} = uiWalletFace
 
   return $ do
-    guard $ not (null address) && not (null accounts) && uiValidateAddress address
+    guard $ not (null address) && uiValidateAddress address
     amount' :: Scientific <- normalize <$> readMaybe amount
     -- Check that amount' has no more than uiCoinPrecision decimal digits
     -- This is checked by QDoubleValidator, but just do be sure check again


### PR DESCRIPTION
**Description:** Backend can select accounts automatically when none are selected by the
user.

**YT issue:** https://issues.serokell.io/issue/AD-425

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [Configuration documentation](docs/configuration.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
