### PR TITLE
[AD-428] Always run UI action in the main thread

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/serokell/cardano-sl
-  commit: a7c6f14c20df4b31acd3b552370185522f80c857 # ariadne branch
+  commit: df13f15b19876b4e2d5aaaf6754b5b5dc63756eb # ariadne branch
   subdirs:
   - binary
   - binary/test


### PR DESCRIPTION
**Description:** Always run UI action in the main thread. This is needed to fix Qt on macOS. Also, "Timers can only be stopped from the main thread" message is gone :tada: 

**YT issue:** https://issues.serokell.io/issue/AD-428

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [Configuration documentation](docs/configuration.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
