### PR TITLE
[AD-408] Replace Union (:~:) a with ElemEv a

### DIFF
--- a/knit/src/Knit/Eval.hs
+++ b/knit/src/Knit/Eval.hs
@@ -108,7 +108,7 @@ componentEvalProcCall ctx (ProcCall CommandProc{..} args) = do
     commandExec
       :: forall components'.
          AllConstrained (ComponentCommandExec m components) components'
-      => Union ((:~:) component) components'
+      => ElemEv component components'
       -> ComponentCommandRepr components component
       -> m (Value components)
     commandExec (Base v) = absurd v


### PR DESCRIPTION
**Description:** Replace `Union (:~:) a` with `ElemEv a`

**YT issue:** https://issues.serokell.io/issue/AD-408

**Checklist:**

- [ ] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
- [ ] My code complies with the [style guide](docs/code-style.md)
- [ ] Tested my changes if they modify code
