### PR TITLE
[AD-369] Call newPending in sendTx

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
@@ -193,7 +193,9 @@ sendTx
                 ourAddresses
                 (map TxOutAux outs)
                 (const newChangeAddress)
-        liftIO $ whenLeftM (awlNewPending awl ourAccountId txAux) throwM
+        -- TODO: call newPending even when inputs are selected from multiple accounts.
+        when (length accountsToUse == 1) $
+            liftIO $ whenLeftM (awlNewPending awl ourAccountId txAux) throwM
         let tx = taTx txAux
         let txId = hash tx
         liftIO $ printAction $ formatSubmitTxMsg tx

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
@@ -193,7 +193,7 @@ sendTx
                 ourAddresses
                 (map TxOutAux outs)
                 (const newChangeAddress)
-        -- TODO: call newPending even when inputs are selected from multiple accounts.
+        -- [AD-518] TODO: call newPending even when inputs are selected from multiple accounts.
         when (length accountsToUse == 1) $
             liftIO $ whenLeftM (awlNewPending awl ourAccountId txAux) throwM
         let tx = taTx txAux

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
@@ -193,9 +193,7 @@ sendTx
                 ourAddresses
                 (map TxOutAux outs)
                 (const newChangeAddress)
-        liftIO $ awlNewPending awl ourAccountId txAux >>= \case
-            Left e -> throwM e
-            Right () -> pass
+        liftIO $ whenLeftM (awlNewPending awl ourAccountId txAux) throwM
         let tx = taTx txAux
         let txId = hash tx
         liftIO $ printAction $ formatSubmitTxMsg tx

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
@@ -31,14 +31,14 @@ module Ariadne.Wallet.Cardano.Kernel
 
 import Prelude hiding (init)
 
-import Control.Monad.Component
-  (ComponentM, buildComponent, buildComponent_, runComponentM)
+import Control.Monad.Component (ComponentM, buildComponent, buildComponent_)
 import Data.Acid (AcidState)
 import Data.Acid.Advanced (query', update')
 import qualified Data.Map.Strict as Map
 import System.Wlog (Severity(..))
 
 import Pos.Core.Chrono (OldestFirst)
+import Pos.Core.Txp (TxAux)
 import Pos.Crypto (ProtocolMagic)
 
 import Ariadne.Wallet.Cardano.Kernel.Internal
@@ -180,7 +180,7 @@ activeWalletComponent walletPassive = do
 --
 -- If the pending transaction is successfully added to the wallet state, the
 -- submission layer is notified accordingly.
-newPending :: ActiveWallet -> HdAccountId -> Txp.TxAux -> IO (Either NewPendingError ())
+newPending :: ActiveWallet -> HdAccountId -> TxAux -> IO (Either NewPendingError ())
 newPending aw accountId tx =
     update' (walletPassive aw ^. wallets) $ NewPending accountId (InDb tx)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel.hs
@@ -25,7 +25,6 @@ module Ariadne.Wallet.Cardano.Kernel
          -- * Active wallet
        , ActiveWallet -- opaque
        , activeWalletComponent
-       , bracketActiveWallet
        , newPending
        , NewPendingError
        ) where
@@ -173,14 +172,6 @@ activeWalletComponent walletPassive = do
         (\_ -> liftIO $ do
             logMsg Error "stopping the wallet submission layer..."
         )
-
-bracketActiveWallet
-    :: PassiveWallet
-    -> (ActiveWallet -> IO a) -> IO a
-bracketActiveWallet walletPassive runActiveWallet = do
-    runComponentM "Active wallet"
-        (activeWalletComponent walletPassive)
-        runActiveWallet
 
 -- | Submit a new pending transaction
 --

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
@@ -44,7 +44,8 @@ import qualified Data.Map.Merge.Strict as Map.Merge
 import qualified Data.Map.Strict as Map
 import Data.SafeCopy (base, deriveSafeCopySimple)
 import qualified Data.Text.Buildable
-import Formatting (bprint, build, sformat, (%))
+import Formatting (bprint, build, formatToString, sformat, (%))
+import qualified GHC.Show (Show(show))
 
 import qualified Pos.Core as Core
 import Pos.Core.Chrono (OldestFirst(..))
@@ -128,6 +129,11 @@ instance Buildable NewPendingError where
         bprint ("NewPendingUnknown " % build) unknownAccount
     build (NewPendingFailed npf) =
         bprint ("NewPendingFailed " % build) npf
+
+instance Show NewPendingError where
+    show = formatToString build
+
+instance Exception NewPendingError
 
 newPending :: HdAccountId
            -> InDb Txp.TxAux

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/AcidState.hs
@@ -45,7 +45,6 @@ import qualified Data.Map.Strict as Map
 import Data.SafeCopy (base, deriveSafeCopySimple)
 import qualified Data.Text.Buildable
 import Formatting (bprint, build, formatToString, sformat, (%))
-import qualified GHC.Show (Show(show))
 
 import qualified Pos.Core as Core
 import Pos.Core.Chrono (OldestFirst(..))
@@ -116,6 +115,7 @@ data NewPendingError =
 
     -- | Some inputs are not in the wallet utxo
   | NewPendingFailed Spec.NewPendingFailed
+  deriving Show
 
 deriveSafeCopySimple 1 'base ''NewPendingError
 
@@ -130,10 +130,8 @@ instance Buildable NewPendingError where
     build (NewPendingFailed npf) =
         bprint ("NewPendingFailed " % build) npf
 
-instance Show NewPendingError where
-    show = formatToString build
-
-instance Exception NewPendingError
+instance Exception NewPendingError where
+    displayException = formatToString build
 
 newPending :: HdAccountId
            -> InDb Txp.TxAux

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec/Update.hs
@@ -47,6 +47,7 @@ import Ariadne.Wallet.Cardano.Kernel.DB.Util.AcidState
 data NewPendingFailed =
     -- | Some inputs are not in the wallet utxo
     NewPendingInputsUnavailable (Set (InDb Txp.TxIn))
+    deriving Show
 
 deriveSafeCopySimple 1 'base ''NewPendingFailed
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
@@ -9,6 +9,7 @@
 module Ariadne.Wallet.Cardano.Kernel.Internal
        ( -- * Passive wallet
          PassiveWallet(..)
+       , ActiveWallet(..)
        , walletKeystore
        , wallets
        , walletLogMessage
@@ -46,3 +47,16 @@ data PassiveWallet = PassiveWallet {
     }
 
 makeLenses ''PassiveWallet
+
+{-------------------------------------------------------------------------------
+  Active wallet
+-------------------------------------------------------------------------------}
+
+-- | Active wallet
+--
+-- An active wallet can do everything the passive wallet can, but also
+-- send new transactions.
+data ActiveWallet = ActiveWallet {
+      -- | The underlying passive wallet
+      walletPassive       :: PassiveWallet
+    }

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer.hs
@@ -2,12 +2,14 @@ module Ariadne.Wallet.Cardano.WalletLayer
        ( -- * Kernel
          passiveWalletLayerComponent
        , passiveWalletLayerCustomDBComponent
+       , activeWalletLayerComponent
          -- * We re-export the types since we want all the dependencies
          -- in this module, other modules shouldn't be touched.
        , module Types
        ) where
 
 import Ariadne.Wallet.Cardano.WalletLayer.Kernel
-  (passiveWalletLayerComponent, passiveWalletLayerCustomDBComponent)
+  (activeWalletLayerComponent, passiveWalletLayerComponent,
+  passiveWalletLayerCustomDBComponent)
 import Ariadne.Wallet.Cardano.WalletLayer.Types (PassiveWalletLayer)
 import Ariadne.Wallet.Cardano.WalletLayer.Types as Types

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
@@ -1,5 +1,6 @@
 module Ariadne.Wallet.Cardano.WalletLayer.Types
        ( PassiveWalletLayer (..)
+       , ActiveWalletLayer (..)
        ) where
 
 import qualified Ariadne.Wallet.Cardano.Kernel.Accounts as Kernel
@@ -14,6 +15,7 @@ import qualified Ariadne.Wallet.Cardano.Kernel.Wallets as Kernel
 import Pos.Block.Types (Blund)
 import Pos.Core (Coin)
 import Pos.Core.Chrono (NE, NewestFirst(..), OldestFirst(..))
+import qualified Pos.Core.Txp as Txp
 import Pos.Crypto (EncryptedSecretKey, PassPhrase)
 
 type Mnemonic = [Text]
@@ -105,4 +107,14 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , pwlLookupKeystore
           :: Kernel.HdRootId
           -> m (Maybe EncryptedSecretKey)
+    }
+
+data ActiveWalletLayer m = ActiveWalletLayer
+    { -- | The underlying passive wallet layer
+      walletPassiveLayer :: PassiveWalletLayer m
+
+    , awlNewPending
+          :: Kernel.HdAccountId
+          -> Txp.TxAux
+          -> m (Either Kernel.NewPendingError ())
     }

--- a/ariadne/cardano/test/backend/Test/Infrastructure/Generator.hs
+++ b/ariadne/cardano/test/backend/Test/Infrastructure/Generator.hs
@@ -74,7 +74,7 @@ genInductiveUsingModel GeneratorModel{..} = do
       }
   where
     potentialOurs = filter gmPotentialOurs gmAllAddresses
-    params ours   = (defEventsParams gmEstimateFee gmAllAddresses ours initUtxo)
+    params ours   = defEventsParams gmEstimateFee gmAllAddresses ours initUtxo
     initUtxo      = utxoRestrictToAddr (`elem` gmAllAddresses) $ trUtxo gmBoot
     initState     = initEventsGlobalState 1
 

--- a/ariadne/cardano/test/backend/Test/Infrastructure/Generator.hs
+++ b/ariadne/cardano/test/backend/Test/Infrastructure/Generator.hs
@@ -74,8 +74,7 @@ genInductiveUsingModel GeneratorModel{..} = do
       }
   where
     potentialOurs = filter gmPotentialOurs gmAllAddresses
-    -- TODO: newPending probability is set to 0 until AD-369 is resolved
-    params ours   = (defEventsParams gmEstimateFee gmAllAddresses ours initUtxo) {gepPendingProb = 0.0}
+    params ours   = (defEventsParams gmEstimateFee gmAllAddresses ours initUtxo)
     initUtxo      = utxoRestrictToAddr (`elem` gmAllAddresses) $ trUtxo gmBoot
     initState     = initEventsGlobalState 1
 

--- a/ariadne/cardano/test/backend/Test/Spec/Fixture.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/Fixture.hs
@@ -68,13 +68,14 @@ withPassiveWalletFixture pm prepareFixtures cc = do
             cc keystore layer wallet fixtures
 
 withActiveWalletFixture :: MonadIO m
-                        => GenActiveWalletFixture x
+                        => ProtocolMagic
+                        -> GenActiveWalletFixture x
                         -> (Keystore.Keystore -> ActiveWalletLayer m -> Kernel.ActiveWallet -> x -> IO a)
                         -> PropertyM IO a
-withActiveWalletFixture prepareFixtures cc = do
+withActiveWalletFixture pm prepareFixtures cc = do
     generateFixtures <- prepareFixtures
     liftIO $ Keystore.bracketTestKeystore $ \keystore -> do
-        bracketKernelPassiveWallet devNull keystore $ \passiveLayer passiveWallet -> do
+        bracketKernelPassiveWallet pm devNull keystore $ \passiveLayer passiveWallet -> do
             bracketKernelActiveWallet passiveLayer passiveWallet $ \activeLayer activeWallet -> do
                 fixtures <- generateFixtures keystore activeWallet
                 cc keystore activeLayer activeWallet fixtures

--- a/ariadne/cardano/test/backend/Test/Spec/Fixture.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/Fixture.hs
@@ -13,6 +13,7 @@ module Test.Spec.Fixture (
     , inMemoryDBComponent
     , bracketPassiveWallet
     , bracketKernelPassiveWallet
+    , bracketActiveWallet
     ) where
 
 import Control.Monad.Component (ComponentM, buildComponent_, runComponentM)
@@ -117,6 +118,14 @@ bracketKernelPassiveWallet pm logFunction keystore f =
     pwlComponent = do
         acidDB <- inMemoryDBComponent
         WalletLayer.passiveWalletLayerCustomDBComponent logFunction keystore acidDB pm
+
+bracketActiveWallet
+    :: Kernel.PassiveWallet
+    -> (Kernel.ActiveWallet -> IO a) -> IO a
+bracketActiveWallet walletPassive runActiveWallet = do
+    runComponentM "Active wallet"
+        (Kernel.activeWalletComponent walletPassive)
+        runActiveWallet
 
 bracketKernelActiveWallet
     :: forall m n a. (MonadIO m, MonadUnliftIO n)

--- a/ariadne/cardano/test/backend/Test/Spec/Kernel.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/Kernel.hs
@@ -14,7 +14,8 @@ import Pos.Crypto (ProtocolMagic)
 
 import Test.Infrastructure.Generator
 import Test.Infrastructure.Genesis
-import qualified Test.Spec.Fixture as Fixture (bracketPassiveWallet)
+import qualified Test.Spec.Fixture as Fixture
+  (bracketActiveWallet, bracketPassiveWallet)
 import Util.Buildable.Hspec
 import Util.Buildable.QuickCheck
 import UTxO.Bootstrap
@@ -153,5 +154,5 @@ bracketPassiveWallet pm postHook = do
 bracketActiveWallet :: (Kernel.ActiveWallet -> IO a) -> IO a
 bracketActiveWallet test =
     bracketPassiveWallet $ \passive ->
-        Kernel.bracketActiveWallet passive $ \active ->
+        Fixture.bracketActiveWallet passive $ \active ->
             test active

--- a/ariadne/cardano/test/backend/Test/Spec/Kernel.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/Kernel.hs
@@ -151,8 +151,8 @@ bracketPassiveWallet pm postHook = do
     logMessage _ _  = pass
 
 -- | Initialize active wallet in a manner suitable for generator-based testing
-bracketActiveWallet :: (Kernel.ActiveWallet -> IO a) -> IO a
-bracketActiveWallet test =
-    bracketPassiveWallet $ \passive ->
+bracketActiveWallet :: ProtocolMagic -> (Kernel.ActiveWallet -> IO a) -> IO a
+bracketActiveWallet pm test =
+    bracketPassiveWallet pm $ \passive ->
         Fixture.bracketActiveWallet passive $ \active ->
             test active


### PR DESCRIPTION
**Description:**

This is a duplicate of https://github.com/serokell/ariadne/pull/328, which was automatically closed upon merging https://github.com/serokell/ariadne/pull/321.

This PR reintroduces the `ActiveWallet` & `ActiveWalletLayer` and adds a call to `newPending` to `sendTx`. Design-wise, this goes the opposite way compared to the original implementation (the intent was to add a transaction to the submission layer after a successful call to `newPending`), but this is OK since semantics-wise we do the same thing: we first create a new transaction, then try calling `newPending`, and if the call fails, we propagate the exception without submitting the transaction.

The tests now also call `newPending`. This helped fix one of the two failing tests left after AD-167.

**YT issue:** https://issues.serokell.io/issue/AD-369

**Checklist:**

- [x] Updated docs if necessary (not necessary)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code