### PR TITLE
[AD-456] Use String to store space between tokens

### DIFF
--- a/ariadne/cardano/test/Test/Ariadne/Knit.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Knit.hs
@@ -41,7 +41,7 @@ propAcceptsAnyInput = property $ isJust . (tokenize' @Components) . fromString
 
 propHandlesValidInput :: Property
 propHandlesValidInput =
-    property $ \x -> (map snd $ tokenize $ detokenize @Components x) === x
+    property $ \x -> (map _lItem $ snd $ tokenize $ detokenize @Components x) === x
 
 instance Arbitrary (Token Components) where
   arbitrary = genTokenComponents @Components
@@ -94,8 +94,8 @@ alphasList = ['A'..'Z'] <> ['a'..'z']
 tokenUnknownList :: forall components.
   (KnownSpine components, AllConstrained (ComponentTokenizer components) components)
   => [Knit.Token components]
-tokenUnknownList = filter unknown $ map snd
-  (foldMap ((tokenize @components) . T.singleton) ([minBound..maxBound] :: [Char]))
+tokenUnknownList = filter unknown $ map _lItem $ snd $
+  foldMap ((tokenize @components) . T.singleton) ([minBound..maxBound] :: [Char])
   where
     unknown :: Token components -> Bool
     unknown (TokenUnknown _) = True

--- a/knit/src/Knit/DisplayError.hs
+++ b/knit/src/Knit/DisplayError.hs
@@ -115,7 +115,7 @@ ppParseError (ParseError str (Report {..})) =
   <+> hcat (punctuate (text ", or ") $ map text expected)
   <$> renderLines
   where
-    unconsumedDesc = maybe "end of input" ppToken . listToMaybe . fmap snd $ unconsumed
+    unconsumedDesc = maybe "end of input" ppToken . listToMaybe . fmap _lItem $ unconsumed
     strLines = nonEmpty $ take spanLines . drop (spanLineStart - 1) $ T.lines str
     renderLines = case strLines of
         Nothing ->
@@ -141,8 +141,8 @@ ppParseError (ParseError str (Report {..})) =
 
     isTokenUnknown = isRight . matching _TokenUnknown
     unknownSpans :: [Span]
-    unknownSpans = map (getSSpan . fst) . takeWhile (isTokenUnknown . snd) $ unconsumed
+    unknownSpans = map _lSpan . takeWhile (isTokenUnknown . _lItem) $ unconsumed
     span = NE.head $
-        case nonEmpty (joinAsc unknownSpans) <|> nonEmpty (map (getSSpan . fst) unconsumed) of
+        case nonEmpty (joinAsc unknownSpans) <|> nonEmpty (map _lSpan unconsumed) of
             Nothing -> spanFromTo strEndLoc (addColumn 1 strEndLoc) :|[]
             Just x  -> x

--- a/knit/src/Knit/ParseTreeExt.hs
+++ b/knit/src/Knit/ParseTreeExt.hs
@@ -12,15 +12,15 @@ import Knit.Tokenizer
 data ParseTreeExt
 
 type instance XExprProcCall ParseTreeExt _ _ = NoExt
-type instance XExprLit ParseTreeExt _ components = (SSpan, Token components)
+type instance XExprLit ParseTreeExt _ components = Located (Token components)
 type instance XXExpr ParseTreeExt cmd components =
-    ExprInBrackets (SSpan, Token components) (Expr ParseTreeExt cmd components)
+    ExprInBrackets (Located (Token components)) (Expr ParseTreeExt cmd components)
 
 type instance XProcCall ParseTreeExt _ (Expr ParseTreeExt _ components) =
-    Maybe (SSpan, Token components)
+    Maybe (Located (Token components))
 
 type instance XArgPos ParseTreeExt _ = NoExt
-type instance XArgKw ParseTreeExt (Expr ParseTreeExt _ components) = (SSpan, Token components)
+type instance XArgKw ParseTreeExt (Expr ParseTreeExt _ components) = Located (Token components)
 type instance XXArg ParseTreeExt _ = Void
 
 data ExprInBrackets br a = ExprInBrackets br a br

--- a/knit/src/Knit/Parser.hs
+++ b/knit/src/Knit/Parser.hs
@@ -29,8 +29,8 @@ import Knit.Tokenizer
 
 tok
   :: Getting (First a) (Token components) a
-  -> Prod r e (SSpan, Token components) ((SSpan, Token components), a)
-tok p = terminal (\x -> (x,) <$> preview (_2 . p) x)
+  -> Prod r e (Located (Token components)) (Located (Token components), a)
+tok p = terminal (\x -> (x,) <$> preview (lItem . p) x)
 
 class ComponentTokenToLit components component where
   componentTokenToLit :: Token components -> Maybe (Lit components)
@@ -39,8 +39,8 @@ gComponentsLit
   :: forall components r.
      (AllConstrained (ComponentTokenToLit components) components, KnownSpine components)
   => Grammar r (Prod r Text
-        (SSpan, Token components)
-        ((SSpan, Token components), Lit components))
+        (Located (Token components))
+        (Located (Token components), Lit components))
 gComponentsLit = go (knownSpine @components)
   where
     go
@@ -48,20 +48,20 @@ gComponentsLit = go (knownSpine @components)
          (AllConstrained (ComponentTokenToLit components) components')
       => Spine components'
       -> Grammar r (Prod r Text
-            (SSpan, Token components)
-            ((SSpan, Token components), Lit components))
+            (Located (Token components))
+            (Located (Token components), Lit components))
     go (Base ()) = rule A.empty
     go (Step (Proxy :: Proxy component, xs)) = do
       nt1 <- go xs
       nt2 <- rule $ terminal $ \t -> do
-        lit <- componentTokenToLit @_ @component $ snd t
+        lit <- componentTokenToLit @_ @component $ _lItem t
         pure (t, lit)
       rule $ nt1 <|> nt2
 
 gExpr
   :: forall components r.
      (AllConstrained (ComponentTokenToLit components) components, KnownSpine components)
-  => Grammar r (Prod r Text (SSpan, Token components) (Expr ParseTreeExt CommandId components))
+  => Grammar r (Prod r Text (Located (Token components)) (Expr ParseTreeExt CommandId components))
 gExpr = mdo
     ntName <- rule $ tok _TokenName
     ntKey <- rule $ tok _TokenKey
@@ -104,7 +104,7 @@ gExpr = mdo
 mkExprGroup
   :: Alternative f
   => f (Expr ParseTreeExt CommandId components)
-  -> f (SSpan, Token components)
+  -> f (Located (Token components))
   -> f (Expr ParseTreeExt CommandId components)
 mkExprGroup expr sep =
     (Knit.Prelude.foldl' opAndThen)
@@ -116,12 +116,12 @@ mkExprGroup expr sep =
 
 pExpr
   :: (AllConstrained (ComponentTokenToLit components) components, KnownSpine components)
-  => Parser Text [(SSpan, Token components)] (Expr ParseTreeExt CommandId components)
+  => Parser Text [Located (Token components)] (Expr ParseTreeExt CommandId components)
 pExpr = parser gExpr
 
 data ParseError components = ParseError
     { peSource :: Text
-    , peReport :: Report Text [(SSpan, Token components)]
+    , peReport :: Report Text [Located (Token components)]
     }
 
 parseTree
@@ -131,7 +131,7 @@ parseTree
      )
   => Text
   -> Either (ParseError components) (Expr ParseTreeExt CommandId components)
-parseTree str = over _Left (ParseError str) . toEither . fullParses pExpr . tokenize $ str
+parseTree str = over _Left (ParseError str) . toEither . fullParses pExpr . snd . tokenize $ str
   where
     toEither = \case
       ([] , r) -> Left r
@@ -147,4 +147,4 @@ parse
 parse = second dropParseTreeExt . parseTree
 
 parseErrorSpans :: ParseError components -> [Span]
-parseErrorSpans = List.map (getSSpan . fst) . unconsumed . peReport
+parseErrorSpans = List.map _lSpan . unconsumed . peReport


### PR DESCRIPTION
**Description:**
Store space between the tokens as `String`s instead of `Span`s. This simplifies some parts of autocompletion and allows to store different kinds of unimportant characters between the tokens like tabs or comments.

**YT issue:** https://issues.serokell.io/issue/AD-456

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [Configuration documentation](docs/configuration.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
