### PR TITLE
[AD-451] Fix double password request on new wallet

### DIFF
--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -95,8 +95,8 @@ knitFaceToUI UiFace{..} KnitFace{..} putPass =
       }
 
     extractPass = \case
-      UiNewWallet _ maybePass -> maybePass
-      UiRestoreWallet _ maybePass _ _ -> maybePass
+      UiNewWallet _ maybePass -> Just $ fromMaybe "" maybePass
+      UiRestoreWallet _ maybePass _ _ -> Just $ fromMaybe "" maybePass
       _ -> Nothing
     pushPassword password = putPass WalletIdTemporary password Nothing
 


### PR DESCRIPTION
**Description:** GUI sends password for new wallet as Maybe Text, where Nothing
represents "no password", while backend treated Nothing as "no password
information provided". Correct backend representation of "no password"
is "". This commit fixes it.

**YT issue:** https://issues.serokell.io/issue/AD-451

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
