### PR TITLE
[AD-455] Make PasswordManager store HdRootId

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
@@ -125,7 +125,7 @@ fromWalletRef :: WalletReference -> WalletId
 fromWalletRef = \case
     WalletRefByUIindex wrd -> WalletIdByUiIndex wrd
     WalletRefSelection     -> WalletIdSelected
-    _ -> WalletIdTemporary
+    WalletRefByHdRootId hid -> WalletIdByBackend $ show hid
 
 -- TODO: make 'append' and 'rewrite' modes for wallet acid-state database.
 -- If running append mode (append wallets to existing database) it should be

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
@@ -117,7 +117,7 @@ sendTx
     unless noConfirm $
         unlessM (waitUiConfirm . ConfirmSend . map txOutToInfo $ toList outs) $
             throwM SendTxNotConfirmed
-    pp <- getPassPhrase walletRef
+    pp <- getPassPhrase $ WalletRefByHdRootId walletRootId
     voidWrongPass walletRef . runCardanoMode $
         sendTxDo wallets walletRootId pp filteredAccounts =<< cardanoGetDiffusion
   where

--- a/ariadne/core/src/Ariadne/UX/PasswordManager.hs
+++ b/ariadne/core/src/Ariadne/UX/PasswordManager.hs
@@ -31,6 +31,7 @@ data WalletId
     | WalletIdByUiIndex !Word
     -- ^ id based on the Ui index
     -- TODO: [AD-294] Remove knowledge of UI indices from Wallet backend
+    | WalletIdByBackend !Text
     deriving (Eq, Ord)
 
 data PasswordManager = PasswordManager


### PR DESCRIPTION
**Description:** 

Wallet backend needs to generate new address for change when sending TX. To do so it needs password for the wallet. When it requests password from password manager, request turns into `WalletIdTemporary` request and thus can't use previous password obtained by `WalletIdByUiIndex` request. This happens because `walletNewAddress` knows nothing about UI indices and `PasswordManager` knows nothing about `HdRootId`.

I made `PasswordManager` polymorphic over backend wallet id type and had to propagate a type variable through a lot of code.

On the second thought though, maybe it would be better to hide backend wallet id type behind some monomorphic data type and expose only that to UI, so that UI can't see what's in there, only backend and password manager can.

**YT issue:** https://issues.serokell.io/issue/AD-455

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
