### PR TITLE
Store cursor in the parse tree

### DIFF
--- a/ariadne/cardano/test/Test/Ariadne/Knit.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Knit.hs
@@ -41,7 +41,7 @@ propAcceptsAnyInput = property $ isJust . (tokenize' @Components) . fromString
 
 propHandlesValidInput :: Property
 propHandlesValidInput =
-    property $ \x -> (map _lItem $ snd $ tokenize $ detokenize @Components x) === x
+    property $ \x -> (map (^.twsToken.lItem) $ snd $ tokenize $ detokenize @Components x) === x
 
 instance Arbitrary (Token Components) where
   arbitrary = genTokenComponents @Components
@@ -94,8 +94,8 @@ alphasList = ['A'..'Z'] <> ['a'..'z']
 tokenUnknownList :: forall components.
   (KnownSpine components, AllConstrained (ComponentTokenizer components) components)
   => [Knit.Token components]
-tokenUnknownList = filter unknown $ map _lItem $ snd $
-  foldMap ((tokenize @components) . T.singleton) ([minBound..maxBound] :: [Char])
+tokenUnknownList = filter unknown $ map (^.twsToken.lItem) $
+    foldMap (snd . tokenize @components . T.singleton) ([minBound..maxBound] :: [Char])
   where
     unknown :: Token components -> Bool
     unknown (TokenUnknown _) = True

--- a/knit/package.yaml
+++ b/knit/package.yaml
@@ -17,6 +17,7 @@ library:
     - QuickCheck
     - ansi-wl-pprint
     - containers
+    - data-default
     - formatting
     - generic-arbitrary
     - lens
@@ -30,6 +31,7 @@ library:
     - split
     - text
     - text-format
+    - transformers
     - validation
 
 tests:

--- a/knit/src/Knit/Autocompletion.hs
+++ b/knit/src/Knit/Autocompletion.hs
@@ -2,7 +2,13 @@ module Knit.Autocompletion
        ( suggestions
        ) where
 
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Trans
+import Control.Monad.Trans.State.Strict
+import Data.Default
 import Data.List (isPrefixOf)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Loc (loc, spanFromTo)
 import Data.Maybe (mapMaybe)
 import Data.Semigroup ((<>))
@@ -32,209 +38,268 @@ suggestions
      , AllConstrained ComponentPrinter components
      )
   => proxy components
+  -> Cursor
   -> T.Text
-  -> [T.Text]
-suggestions _ cmd =
+  -> [(T.Text, Cursor)]
+suggestions _ cursor cmd =
   let
-    cmd' = "(" <> cmd
-    tokens = snd $ tokenize cmd'
+    (spaceBefore, tokens) = tokenize cmd
 
     tokenBalance = \case
       TokenParenthesis bs -> withBracketSide 1 (-1) bs
       _ -> 0
-    parensBalance = sum $ map (tokenBalance . _lItem) tokens
-    cmdLines = T.splitOn "\n" cmd'
+    parensBalance = sum $ map (tokenBalance . _lItem . _twsToken) tokens
+    cmdLines = T.splitOn "\n" cmd
     endLoc = (length cmdLines, T.length (last cmdLines) + 1)
 
     loc' a b = loc (fromIntegral a) (fromIntegral b)
-    locatedClosingBracket i t = Located
-      { _lSpan = spanFromTo
-          (loc' (fst endLoc) (snd endLoc + i))
-          (loc' (fst endLoc) (snd endLoc + i + 1))
-      , _lSpaceAfter = mempty
-      , _lItem = t
+    closingBracket i t = TokenWithSpace
+      { _twsToken = Located
+        { _lSpan = spanFromTo
+            (loc' (fst endLoc) (snd endLoc + i))
+            (loc' (fst endLoc) (snd endLoc + i + 1))
+        , _lItem = t
+        }
+      , _twsSpaceAfter = def
       }
 
-    tokens' = tokens ++ zipWith locatedClosingBracket [0..]
+    tokens' = tokens ++ zipWith closingBracket [0..]
       (replicate parensBalance (TokenParenthesis BracketSideClosing))
   in
     case fullParses (pExpr @components) tokens' of
       ([], _) -> []
       (tree:_, _) ->
-        map (T.drop 1
-          . T.dropEnd parensBalance
-          . T.pack
-          . show
-          . ppFormattedExpr)
-        $ suggestionExprs commandProcs parensBalance
-        $ fst $ parseTreeToFormattedExpr tree
+        let
+          (formattedExpr, spaceAfter) = parseTreeToFormattedExpr (Selection $ Just cursor) tree
+          makeSws = maybe def $ \space ->
+            SpaceWithSelection
+              (Space $ NonEmpty.toList $ getSkipped $ _lItem space)
+              (selectionInSpan (getCursor cursor) (_lSpan space))
+          processSuggestion ((suggestion, LeftSpace swsBefore), RightSpace swsAfter) =
+            let
+              (suggestionStr, selection) = ppFormattedExpr swsBefore suggestion swsAfter
+            in
+              ( T.dropEnd parensBalance suggestionStr
+              , maybe
+                  (error "Core invariant violated: no cursor after autocompletion")
+                  id
+                $ getSelection selection
+              )
+        in
+          map processSuggestion $
+            runStateT
+              (runStateT
+                (suggestionExprs commandProcs formattedExpr)
+                (LeftSpace $ makeSws spaceBefore))
+              (RightSpace $ makeSws spaceAfter)
+
+newtype LeftSpace = LeftSpace { getLeftSpace :: SpaceWithSelection }
+  deriving (Default)
+
+newtype RightSpace = RightSpace { getRightSpace :: SpaceWithSelection }
+  deriving (Default)
+
+type SuggestionMonad = StateT LeftSpace (StateT RightSpace [])
+
+liftLeft :: SuggestionMonad a -> SuggestionMonad a
+liftLeft = id
+
+liftRight :: StateT RightSpace [] a -> SuggestionMonad a
+liftRight = lift
+
+liftList :: [a] -> SuggestionMonad a
+liftList = lift . lift
 
 -- | Returns completion suggestions assuming that the expression was completed
--- with missing parentheses and wrapped into one extra pair of parentheses
--- before parsing.
+-- with missing parentheses before parsing.
 suggestionExprs
   :: forall components.
      [SomeCommandProc components]
-  -> Int -- ^ Number of added closing parentheses.
   -> Expr FormattedExprExt CommandId components
-  -> [Expr FormattedExprExt CommandId components]
-suggestionExprs procs = skipParensExpr
+  -> SuggestionMonad (Expr FormattedExprExt CommandId components)
+suggestionExprs procs = goExpr
   where
-    didn'tFindParen :: a
-    didn'tFindParen = error "Core invariant violated: not enough parentheses"
-
-    paddedOpUnit :: a
-    paddedOpUnit = error "Core invariant violated: space between OpUnit and closing paren"
-
-    skipParensExpr
-      :: Int
-      -> Expr FormattedExprExt CommandId components
-      -> [Expr FormattedExprExt CommandId components]
-    skipParensExpr n = \case
-      ExprLit NoExt _ -> didn'tFindParen
-      ExprProcCall NoExt p -> ExprProcCall NoExt <$> skipParensPc n p
-      XExpr (ExprInBrackets l e r) ->
-        if n > 1
-          then XExpr . exprInBrackets l r <$> skipParensExpr (n - 1) e
-          else XExpr . exprInBrackets l mempty <$>
-            if r == mempty
-              then autocompleteExpr e
-              else suggestExpr r e
-
-    skipParensPc
-      :: Int
-      -> ProcCall' FormattedExprExt CommandId components
-      -> [ProcCall' FormattedExprExt CommandId components]
-    skipParensPc n (ProcCall NoExt cmd args) =
-      case unsnoc args of
-        Nothing -> didn'tFindParen
-        Just (init', last') ->
-          ProcCall NoExt cmd . snoc init' <$> skipParensArg n last'
-
-    skipParensArg
-      :: Int
-      -> Arg' FormattedExprExt CommandId components
-      -> [Arg' FormattedExprExt CommandId components]
-    skipParensArg n = \case
-      ArgPos skipped e -> ArgPos skipped <$> skipParensExpr n e
-      ArgKw skipped name e -> ArgKw skipped name <$> skipParensExpr n e
-      XArg xxArg -> absurd xxArg
-
-    -- | Completes some unfinished word.
-    autocompleteExpr
+    goExpr
       :: Expr FormattedExprExt CommandId components
-      -> [Expr FormattedExprExt CommandId components]
-    autocompleteExpr = \case
-      ExprLit NoExt _ -> []
-      ExprProcCall NoExt p -> ExprProcCall NoExt <$> autocompletePc p
-      XExpr ExprInBrackets{} -> []
+      -> SuggestionMonad (Expr FormattedExprExt CommandId components)
+    goExpr = \case
+      lit@(ExprLit _ _) -> pure lit
+      ExprProcCall NoExt p -> ExprProcCall NoExt <$> goPc p
+      XExpr (ExprInBrackets l e r) -> do
+        oldLeft <- liftLeft get
+        oldRight <- liftRight get
+        liftLeft $ put $ LeftSpace $ fbSpace l
+        liftRight $ put $ RightSpace $ fbSpace r
+          <> SpaceWithSelection def (selectionAtTheStart $ fbBracketSelection r)
+        e' <- goExpr e
+        l' <- liftLeft $ gets $ \(LeftSpace lSpace) -> l { fbSpace = lSpace }
+        r' <- liftRight $ gets $ \(RightSpace rSpace) ->
+          FormattedBracket (selectionAtTheEnd rSpace) rSpace
+        liftLeft $ put oldLeft
+        liftRight $ put oldRight
+        pure $ XExpr $ ExprInBrackets l' e' r'
 
-    autocompletePc
+    goPc
       :: ProcCall' FormattedExprExt CommandId components
-      -> [ProcCall' FormattedExprExt CommandId components]
-    autocompletePc (ProcCall NoExt cmd args) =
+      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
+    goPc pc@(ProcCall pcSelection cmd args) =
       case cmd of
-        CommandIdOperator OpUnit -> toProcCall <$> suggestableProcs
+        CommandIdOperator OpUnit -> do
+          leftSpace <- liftLeft $ gets getLeftSpace
+          rightSpace <- liftRight $ gets getRightSpace
+          let space = leftSpace <> rightSpace
+          case getSelection $ swsSelection space of
+            Nothing -> pure pc
+            Just c -> do
+              let (leftSpace', rightSpace') = splitAtCursor c $ getSpace $ swsSpace space
+              liftLeft $ put $ LeftSpace $ SpaceWithSelection (Space leftSpace') def
+              liftRight $ put $ RightSpace
+                $ SpaceWithSelection (Space rightSpace') (Selection $ Just def)
+              liftList $ pc : map (toProcCall . fst) suggestableProcs
         CommandIdOperator OpAndThen ->
           case args of
-            [lhs, ArgPos skipped rhs] ->
-              ProcCall NoExt cmd
-              . snoc [lhs]
-              . ArgPos skipped
-              <$> autocompleteExpr rhs
-            _ -> invalidOperatorApplication
-        CommandIdName name ->
-          case unsnoc args of
-            Nothing ->
-              toProcCall <$> filter (isPrefixOfNeq (nameStr name) . nameStr . fst) suggestableProcs
-            Just (init', last') ->
-              ProcCall NoExt cmd . snoc init' <$> autocompleteArg name last'
+            [ArgPos (ArgPosSpace lRightSpace) lhs, ArgPos (ArgPosSpace rLeftSpace) rhs] -> do
+              -- lLeftSpace lhs lRightSpace ; rLeftSpace rhs rRightSpace
 
-    autocompleteArg
-      :: Name
-      -> Arg' FormattedExprExt CommandId components
-      -> [Arg' FormattedExprExt CommandId components]
-    autocompleteArg cmdName = \case
-      ArgPos
-          (ArgPosSkipped skipped)
-          (ExprProcCall NoExt (ProcCall NoExt (CommandIdName name) [])) ->
+              rRightSpace <- liftRight get
+              liftRight $ put $ RightSpace $ lRightSpace
+                <> SpaceWithSelection def (selectionAtTheStart pcSelection)
+              lhs' <- goExpr lhs
+              lRightSpace' <- liftRight get
+              liftRight $ put rRightSpace
+
+              lLeftSpace <- liftLeft get
+              liftLeft $ put $ LeftSpace rLeftSpace
+              rhs' <- goExpr rhs
+              rLeftSpace' <- liftLeft get
+              liftLeft $ put lLeftSpace
+
+              pure $ ProcCall (selectionAtTheEnd $ getRightSpace lRightSpace') cmd
+                [ ArgPos (ArgPosSpace $ getRightSpace lRightSpace') lhs'
+                , ArgPos (ArgPosSpace $ getLeftSpace rLeftSpace') rhs'
+                ]
+            _ -> invalidOperatorApplication
+        CommandIdName name -> do
+          ProcCall pcSelection' cmd' args' <-
+            goPcName
+              (ProcCall pcSelection name args)
+              (ProcCall pcSelection name $ reverse args)
+          pure $ ProcCall pcSelection' cmd' $ reverse args'
+
+    goPcName
+      :: ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
+      -> ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
+      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
+    goPcName pc = (>>= goPcRightSpace pc) . \case
+
+      ProcCall _ _ (XArg xxArg : _) -> absurd xxArg
+
+
+      ProcCall pcSelection pcName (ArgPos space e : argsRest) -> do
+        oldRight <- liftRight get
+        liftRight $ put $ RightSpace $ getArgPosSpace space
+        (ProcCall pcSelection' pcName' argsRest') <-
+          goPcName pc (ProcCall pcSelection pcName argsRest)
+        space' <- liftRight $ gets getRightSpace
+
         let
-          kwargs =
-            (\param ->
-              ArgKw
-                (ArgKwSkipped skipped mempty)
-                param
-                (ExprProcCall NoExt (ProcCall NoExt (CommandIdOperator OpUnit) []))
-            )
-            <$> filter (isPrefixOf (nameStr name) . nameStr) (procParams cmdName)
-          procCalls =
-            ArgPos (ArgPosSkipped skipped)
-            . ExprProcCall NoExt
-            . toProcCall
-            <$> filter
-              (\(proc, params) -> null params && isPrefixOfNeq (nameStr name) (nameStr proc))
-              suggestableProcs
-        in
-          kwargs ++ procCalls
-      ArgPos skipped e -> ArgPos skipped <$> autocompleteExpr e
-      ArgKw skipped name e -> ArgKw skipped name <$> autocompleteExpr e
-      XArg xxArg -> absurd xxArg
+          suggestKeyword
+            :: Expr FormattedExprExt CommandId components
+            -> SuggestionMonad (Arg' FormattedExprExt CommandId components)
+          suggestKeyword (ExprProcCall NoExt (ProcCall aPcSelection (CommandIdName aPcName) []))
+            | Just c <- getSelection aPcSelection =
+              liftList $ ArgPos (ArgPosSpace space') e : do
+                let (toComplete, _) = splitAtCursor c $ nameStr aPcName
+                pcParam <- procParams pcName
+                guard $ isPrefixOf toComplete $ nameStr pcParam
+                let selection = Selection $ Just $ cursorAfter $ nameStr pcParam ++ ":"
+                pure $ ArgKw (ArgKwSpace space' selection def) pcParam $
+                  ExprProcCall NoExt (ProcCall def (CommandIdOperator OpUnit) [])
+          suggestKeyword _ = liftList []
 
-    -- | Suggests possible keyword arguments and procedures.
-    suggestExpr
-      :: Skipped
-      -> Expr FormattedExprExt CommandId components
-      -> [Expr FormattedExprExt CommandId components]
-    suggestExpr padding = \case
-      ExprLit NoExt _ -> []
-      ExprProcCall NoExt p -> ExprProcCall NoExt <$> suggestPc padding p
-      XExpr ExprInBrackets{} -> []
+        oldLeft <- liftLeft get
+        liftLeft $ put def
+        liftRight $ put def
+        arg' <- suggestKeyword e <|> ArgPos (ArgPosSpace space') <$> goExpr e
 
-    suggestPc
-      :: Skipped
+        liftLeft $ put oldLeft
+        liftRight $ put oldRight
+
+        pure $ ProcCall pcSelection' pcName' (arg' : argsRest')
+
+
+      ProcCall pcSelection pcName (ArgKw space keyword e : argsRest) -> do
+        oldRight <- liftRight get
+        liftRight $ put $ RightSpace $ aksPrefix space
+        (ProcCall pcSelection' pcName' argsRest') <-
+          goPcName pc (ProcCall pcSelection pcName argsRest)
+        space' <- liftRight $ gets getRightSpace
+
+        oldLeft <- liftLeft get
+        liftLeft $ put def
+        liftRight $ put def
+        e' <- goExpr e
+
+        liftLeft $ put oldLeft
+        liftRight $ put oldRight
+
+        pure $ ProcCall pcSelection' pcName'
+          (ArgKw space { aksPrefix = space' } keyword e' : argsRest')
+
+
+      ProcCall pcSelection pcName [] ->
+        case getSelection pcSelection of
+          Nothing -> pure $ ProcCall pcSelection (CommandIdName pcName) []
+          Just c ->
+            let
+              pcNameStr = nameStr pcName
+              (toComplete, _) = splitAtCursor c pcNameStr
+            in
+              liftList $ (pure $ ProcCall pcSelection (CommandIdName pcName) []) <|> do
+                (pcName', _) <- suggestableProcs
+                guard $ isPrefixOf toComplete $ nameStr pcName'
+                guard $ pcName' /= pcName || c /= cursorAfter pcNameStr
+                pure $ toProcCall pcName'
+
+    goPcRightSpace
+      :: ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
       -> ProcCall' FormattedExprExt CommandId components
-      -> [ProcCall' FormattedExprExt CommandId components]
-    suggestPc padding (ProcCall NoExt cmd args) =
-      case cmd of
-        CommandIdOperator OpUnit -> paddedOpUnit
-        CommandIdOperator OpAndThen ->
-          case args of
-            [lhs, ArgPos
-                (ArgPosSkipped (Skipped ""))
-                (ExprProcCall NoExt (ProcCall NoExt (CommandIdOperator OpUnit) []))] ->
-              ProcCall NoExt cmd
-                . snoc [lhs]
-                . ArgPos (ArgPosSkipped padding)
-                . ExprProcCall NoExt
-                . toProcCall
-                <$> suggestableProcs
-            [lhs, ArgPos padding1 rhs] ->
-              ProcCall NoExt cmd
-                . snoc [lhs]
-                . ArgPos padding1
-                <$> suggestExpr padding rhs
-            _ -> invalidOperatorApplication
-        CommandIdName cmdName ->
-          let
-            kwargs =
-              ProcCall NoExt cmd
-              . snoc args
-              . (\param ->
-                  ArgKw
-                    (ArgKwSkipped padding mempty)
-                    param
-                    (ExprProcCall NoExt (ProcCall NoExt (CommandIdOperator OpUnit) []))
-                )
-              <$> procParams cmdName
-            procCalls =
-              ProcCall NoExt cmd
-              . snoc args
-              . ArgPos (ArgPosSkipped padding)
-              . ExprProcCall NoExt
-              . toProcCall
-              <$> filter (null . snd) suggestableProcs
-          in
-            kwargs ++ procCalls
+      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
+    goPcRightSpace (ProcCall _ pcName _) pc@(ProcCall pcSelection pcCmd pcArgs) = do
+      RightSpace right <- liftRight get
+      case getSelection $ swsSelection right of
+        Nothing -> pure pc
+        Just c ->
+          if c == def || c == cursorAfterSpace (swsSpace right)
+            then pure pc
+            else pure pc <|> do
+              let (leftSpace', rightSpace') = splitAtCursor c $ getSpace $ swsSpace right
+              liftRight $ put $ RightSpace
+                $ SpaceWithSelection (Space rightSpace') (Selection $ Just def)
+              pcParam <- liftList $ procParams pcName
+              let
+                arg' =
+                  ArgKw (ArgKwSpace (SpaceWithSelection (Space leftSpace') def) def def) pcParam $
+                    ExprProcCall NoExt (ProcCall def (CommandIdOperator OpUnit) [])
+              pure $ ProcCall pcSelection pcCmd $ arg' : pcArgs
+
+    selectionAtTheStart :: Selection -> Selection
+    selectionAtTheStart selection =
+      case getSelection selection of
+        Nothing -> def
+        Just c ->
+          if c == def
+            then selection
+            else def
+
+    selectionAtTheEnd :: SpaceWithSelection -> Selection
+    selectionAtTheEnd sws =
+      case getSelection $ swsSelection sws of
+        Nothing -> def
+        Just c ->
+          if cursorAfterSpace (swsSpace sws) == c
+            then Selection $ Just def
+            else def
 
     suggestableProcs :: [(Name, [Name])]
     suggestableProcs =
@@ -246,10 +311,9 @@ suggestionExprs procs = skipParensExpr
     procParams :: Name -> [Name]
     procParams cmdName = maybe [] snd $ find ((== cmdName) . fst) suggestableProcs
 
-    toProcCall = (\name -> ProcCall NoExt (CommandIdName name) []) . fst
+    toProcCall procName = ProcCall
+      (Selection $ Just $ cursorAfter $ nameStr procName)
+      (CommandIdName procName)
+      []
 
     nameStr = unpack . toLazyText . build
-
-    isPrefixOfNeq a b = isPrefixOf a b && a /= b
-
-    exprInBrackets l r x = ExprInBrackets l x r

--- a/knit/src/Knit/Autocompletion.hs
+++ b/knit/src/Knit/Autocompletion.hs
@@ -28,6 +28,219 @@ import Knit.Procedure
 import Knit.Syntax
 import Knit.Tokenizer
 
+data SuggestionCtx = SuggestionCtx
+  { _leftSpace :: SpaceWithSelection
+  , _rightSpace :: SpaceWithSelection
+  }
+makeLenses ''SuggestionCtx
+
+instance Default SuggestionCtx where
+  def = SuggestionCtx def def
+
+type SuggestionMonad = StateT SuggestionCtx []
+
+-- | Returns completion suggestions assuming that the expression was completed
+-- with missing parentheses before parsing.
+suggestionExprs
+  :: forall components.
+     [SomeCommandProc components]
+  -> Expr FormattedExprExt CommandId components
+  -> SuggestionMonad (Expr FormattedExprExt CommandId components)
+suggestionExprs procs = goExpr
+  where
+    goExpr
+      :: Expr FormattedExprExt CommandId components
+      -> SuggestionMonad (Expr FormattedExprExt CommandId components)
+    goExpr = \case
+      lit@(ExprLit _ _) -> pure lit
+      ExprProcCall NoExt p -> ExprProcCall NoExt <$> goPc p
+      XExpr (ExprInBrackets l e r) -> do
+        oldCtx <- get
+        leftSpace .= fbSpace l
+        rightSpace .= fbSpace r
+          <> SpaceWithSelection def (selectionAtTheStart $ fbBracketSelection r)
+        e' <- goExpr e
+        l' <- uses leftSpace $ \lSpace -> l { fbSpace = lSpace }
+        r' <- uses rightSpace $ \rSpace -> FormattedBracket (selectionAtTheEnd rSpace) rSpace
+        put oldCtx
+        pure $ XExpr $ ExprInBrackets l' e' r'
+
+    goPc
+      :: ProcCall' FormattedExprExt CommandId components
+      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
+    goPc pc@(ProcCall pcSelection cmd args) =
+      case cmd of
+        CommandIdOperator OpUnit -> do
+          lSpace <- use leftSpace
+          rSpace <- use rightSpace
+          let space = lSpace <> rSpace
+          case getSelection $ swsSelection space of
+            Nothing -> pure pc
+            Just c -> do
+              let (lSpace', rSpace') = splitAtCursor c $ getSpace $ swsSpace space
+              leftSpace .= SpaceWithSelection (Space lSpace') def
+              rightSpace .= SpaceWithSelection (Space rSpace') (Selection $ Just def)
+              lift $ pc : map (toProcCall . fst) suggestableProcs
+        CommandIdOperator OpAndThen ->
+          case args of
+            [ArgPos (ArgPosSpace lRightSpace) lhs, ArgPos (ArgPosSpace rLeftSpace) rhs] -> do
+              -- lLeftSpace lhs lRightSpace ; rLeftSpace rhs rRightSpace
+
+              rRightSpace <- use rightSpace
+              rightSpace .= lRightSpace <> SpaceWithSelection def (selectionAtTheStart pcSelection)
+              lhs' <- goExpr lhs
+              lRightSpace' <- use rightSpace
+              rightSpace .= rRightSpace
+
+              lLeftSpace <- use leftSpace
+              leftSpace .= rLeftSpace
+              rhs' <- goExpr rhs
+              rLeftSpace' <- use leftSpace
+              leftSpace .= lLeftSpace
+
+              pure $ ProcCall (selectionAtTheEnd lRightSpace') cmd
+                [ ArgPos (ArgPosSpace lRightSpace') lhs'
+                , ArgPos (ArgPosSpace rLeftSpace') rhs'
+                ]
+            _ -> invalidOperatorApplication
+        CommandIdName name -> do
+          ProcCall pcSelection' cmd' args' <-
+            goPcName
+              True
+              (ProcCall pcSelection name args)
+              (ProcCall pcSelection name $ reverse args)
+          pure $ ProcCall pcSelection' cmd' $ reverse args'
+
+    goPcName
+      :: Bool
+      -> ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
+      -> ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
+      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
+    goPcName firstCall pc = (>>= goPcRightSpace firstCall pc) . \case
+
+      ProcCall _ _ (XArg xxArg : _) -> absurd xxArg
+
+
+      ProcCall pcSelection pcName (ArgPos space e : argsRest) -> do
+        oldCtx <- get
+
+        rightSpace .= getArgPosSpace space
+        (ProcCall pcSelection' pcName' argsRest') <-
+          goPcName False pc (ProcCall pcSelection pcName argsRest)
+        space' <- use rightSpace
+
+        let
+          suggestKeyword
+            :: Expr FormattedExprExt CommandId components
+            -> SuggestionMonad (Arg' FormattedExprExt CommandId components)
+          suggestKeyword (ExprProcCall NoExt (ProcCall aPcSelection (CommandIdName aPcName) []))
+            | Just c <- getSelection aPcSelection =
+              lift $ ArgPos (ArgPosSpace space') e : do
+                let (toComplete, _) = splitAtCursor c $ nameStr aPcName
+                pcParam <- procParams pcName
+                guard $ isPrefixOf toComplete $ nameStr pcParam
+                let selection = Selection $ Just $ cursorAfter $ nameStr pcParam ++ ":"
+                pure $ ArgKw (ArgKwSpace space' selection def) pcParam $
+                  ExprProcCall NoExt (ProcCall def (CommandIdOperator OpUnit) [])
+          suggestKeyword _ = lift []
+
+        put def
+        arg' <- suggestKeyword e <|> ArgPos (ArgPosSpace space') <$> goExpr e
+
+        put oldCtx
+
+        pure $ ProcCall pcSelection' pcName' (arg' : argsRest')
+
+
+      ProcCall pcSelection pcName (ArgKw space keyword e : argsRest) -> do
+        oldCtx <- get
+
+        rightSpace .= aksPrefix space
+        (ProcCall pcSelection' pcName' argsRest') <-
+          goPcName False pc (ProcCall pcSelection pcName argsRest)
+        space' <- use rightSpace
+
+        leftSpace .= def
+        rightSpace .= def
+        e' <- goExpr e
+
+        put oldCtx
+
+        pure $ ProcCall pcSelection' pcName'
+          (ArgKw space { aksPrefix = space' } keyword e' : argsRest')
+
+
+      ProcCall pcSelection pcName [] ->
+        case getSelection pcSelection of
+          Nothing -> pure $ ProcCall pcSelection (CommandIdName pcName) []
+          Just c ->
+            let
+              pcNameStr = nameStr pcName
+              (toComplete, _) = splitAtCursor c pcNameStr
+            in
+              lift $ (pure $ ProcCall pcSelection (CommandIdName pcName) []) <|> do
+                (pcName', _) <- suggestableProcs
+                guard $ isPrefixOf toComplete $ nameStr pcName'
+                guard $ pcName' /= pcName || c /= cursorAfter pcNameStr
+                pure $ toProcCall pcName'
+
+    goPcRightSpace
+      :: Bool
+      -> ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
+      -> ProcCall' FormattedExprExt CommandId components
+      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
+    goPcRightSpace firstCall (ProcCall _ pcName _) pc@(ProcCall pcSelection pcCmd pcArgs) = do
+      right <- use rightSpace
+      case getSelection $ swsSelection right of
+        Nothing -> pure pc
+        Just c ->
+          if c == def || not firstCall && c == cursorAfterSpace (swsSpace right)
+            then pure pc
+            else pure pc <|> do
+              let (lSpace', rSpace') = splitAtCursor c $ getSpace $ swsSpace right
+              rightSpace .= SpaceWithSelection (Space rSpace') (Selection $ Just def)
+              pcParam <- lift $ procParams pcName
+              let
+                arg' =
+                  ArgKw (ArgKwSpace (SpaceWithSelection (Space lSpace') def) def def) pcParam $
+                    ExprProcCall NoExt (ProcCall def (CommandIdOperator OpUnit) [])
+              pure $ ProcCall pcSelection pcCmd $ arg' : pcArgs
+
+    selectionAtTheStart :: Selection -> Selection
+    selectionAtTheStart selection =
+      case getSelection selection of
+        Nothing -> def
+        Just c ->
+          if c == def
+            then selection
+            else def
+
+    selectionAtTheEnd :: SpaceWithSelection -> Selection
+    selectionAtTheEnd sws =
+      case getSelection $ swsSelection sws of
+        Nothing -> def
+        Just c ->
+          if cursorAfterSpace (swsSpace sws) == c
+            then Selection $ Just def
+            else def
+
+    suggestableProcs :: [(Name, [Name])]
+    suggestableProcs =
+      flip mapMaybe procs $ \(SomeCommandProc CommandProc{..}) ->
+        case cpName of
+          CommandIdName name -> Just (name, map (^._1) $ getParameters cpArgumentConsumer)
+          CommandIdOperator _ -> Nothing
+
+    procParams :: Name -> [Name]
+    procParams cmdName = maybe [] snd $ find ((== cmdName) . fst) suggestableProcs
+
+    toProcCall procName = ProcCall
+      (Selection $ Just $ cursorAfter $ nameStr procName)
+      (CommandIdName procName)
+      []
+
+    nameStr = unpack . toLazyText . build
+
 suggestions
   :: forall components proxy.
      ( KnownSpine components
@@ -78,7 +291,7 @@ suggestions _ cursor cmd =
             if cmd == ""
               then SpaceWithSelection def (Selection $ Just def)
               else makeSws x
-          processSuggestion ((suggestion, LeftSpace swsBefore), RightSpace swsAfter) =
+          processSuggestion (suggestion, SuggestionCtx swsBefore swsAfter) =
             let
               (suggestionStr, selection) = ppFormattedExpr swsBefore suggestion swsAfter
             in
@@ -91,236 +304,5 @@ suggestions _ cursor cmd =
         in
           map processSuggestion $
             runStateT
-              (runStateT
-                (suggestionExprs commandProcs formattedExpr)
-                (LeftSpace $ makeSws spaceBefore))
-              (RightSpace $ makeRightSws spaceAfter)
-
-newtype LeftSpace = LeftSpace { getLeftSpace :: SpaceWithSelection }
-  deriving (Default)
-
-newtype RightSpace = RightSpace { getRightSpace :: SpaceWithSelection }
-  deriving (Default)
-
-type SuggestionMonad = StateT LeftSpace (StateT RightSpace [])
-
-liftLeft :: SuggestionMonad a -> SuggestionMonad a
-liftLeft = id
-
-liftRight :: StateT RightSpace [] a -> SuggestionMonad a
-liftRight = lift
-
-liftList :: [a] -> SuggestionMonad a
-liftList = lift . lift
-
-{-# ANN module ("HLint: ignore Reduce duplication" :: T.Text) #-}
--- | Returns completion suggestions assuming that the expression was completed
--- with missing parentheses before parsing.
-suggestionExprs
-  :: forall components.
-     [SomeCommandProc components]
-  -> Expr FormattedExprExt CommandId components
-  -> SuggestionMonad (Expr FormattedExprExt CommandId components)
-suggestionExprs procs = goExpr
-  where
-    goExpr
-      :: Expr FormattedExprExt CommandId components
-      -> SuggestionMonad (Expr FormattedExprExt CommandId components)
-    goExpr = \case
-      lit@(ExprLit _ _) -> pure lit
-      ExprProcCall NoExt p -> ExprProcCall NoExt <$> goPc p
-      XExpr (ExprInBrackets l e r) -> do
-        oldLeft <- liftLeft get
-        oldRight <- liftRight get
-        liftLeft $ put $ LeftSpace $ fbSpace l
-        liftRight $ put $ RightSpace $ fbSpace r
-          <> SpaceWithSelection def (selectionAtTheStart $ fbBracketSelection r)
-        e' <- goExpr e
-        l' <- liftLeft $ gets $ \(LeftSpace lSpace) -> l { fbSpace = lSpace }
-        r' <- liftRight $ gets $ \(RightSpace rSpace) ->
-          FormattedBracket (selectionAtTheEnd rSpace) rSpace
-        liftLeft $ put oldLeft
-        liftRight $ put oldRight
-        pure $ XExpr $ ExprInBrackets l' e' r'
-
-    goPc
-      :: ProcCall' FormattedExprExt CommandId components
-      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
-    goPc pc@(ProcCall pcSelection cmd args) =
-      case cmd of
-        CommandIdOperator OpUnit -> do
-          leftSpace <- liftLeft $ gets getLeftSpace
-          rightSpace <- liftRight $ gets getRightSpace
-          let space = leftSpace <> rightSpace
-          case getSelection $ swsSelection space of
-            Nothing -> pure pc
-            Just c -> do
-              let (leftSpace', rightSpace') = splitAtCursor c $ getSpace $ swsSpace space
-              liftLeft $ put $ LeftSpace $ SpaceWithSelection (Space leftSpace') def
-              liftRight $ put $ RightSpace
-                $ SpaceWithSelection (Space rightSpace') (Selection $ Just def)
-              liftList $ pc : map (toProcCall . fst) suggestableProcs
-        CommandIdOperator OpAndThen ->
-          case args of
-            [ArgPos (ArgPosSpace lRightSpace) lhs, ArgPos (ArgPosSpace rLeftSpace) rhs] -> do
-              -- lLeftSpace lhs lRightSpace ; rLeftSpace rhs rRightSpace
-
-              rRightSpace <- liftRight get
-              liftRight $ put $ RightSpace $ lRightSpace
-                <> SpaceWithSelection def (selectionAtTheStart pcSelection)
-              lhs' <- goExpr lhs
-              lRightSpace' <- liftRight get
-              liftRight $ put rRightSpace
-
-              lLeftSpace <- liftLeft get
-              liftLeft $ put $ LeftSpace rLeftSpace
-              rhs' <- goExpr rhs
-              rLeftSpace' <- liftLeft get
-              liftLeft $ put lLeftSpace
-
-              pure $ ProcCall (selectionAtTheEnd $ getRightSpace lRightSpace') cmd
-                [ ArgPos (ArgPosSpace $ getRightSpace lRightSpace') lhs'
-                , ArgPos (ArgPosSpace $ getLeftSpace rLeftSpace') rhs'
-                ]
-            _ -> invalidOperatorApplication
-        CommandIdName name -> do
-          ProcCall pcSelection' cmd' args' <-
-            goPcName
-              True
-              (ProcCall pcSelection name args)
-              (ProcCall pcSelection name $ reverse args)
-          pure $ ProcCall pcSelection' cmd' $ reverse args'
-
-    goPcName
-      :: Bool
-      -> ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
-      -> ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
-      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
-    goPcName firstCall pc = (>>= goPcRightSpace firstCall pc) . \case
-
-      ProcCall _ _ (XArg xxArg : _) -> absurd xxArg
-
-
-      ProcCall pcSelection pcName (ArgPos space e : argsRest) -> do
-        oldRight <- liftRight get
-        liftRight $ put $ RightSpace $ getArgPosSpace space
-        (ProcCall pcSelection' pcName' argsRest') <-
-          goPcName False pc (ProcCall pcSelection pcName argsRest)
-        space' <- liftRight $ gets getRightSpace
-
-        let
-          suggestKeyword
-            :: Expr FormattedExprExt CommandId components
-            -> SuggestionMonad (Arg' FormattedExprExt CommandId components)
-          suggestKeyword (ExprProcCall NoExt (ProcCall aPcSelection (CommandIdName aPcName) []))
-            | Just c <- getSelection aPcSelection =
-              liftList $ ArgPos (ArgPosSpace space') e : do
-                let (toComplete, _) = splitAtCursor c $ nameStr aPcName
-                pcParam <- procParams pcName
-                guard $ isPrefixOf toComplete $ nameStr pcParam
-                let selection = Selection $ Just $ cursorAfter $ nameStr pcParam ++ ":"
-                pure $ ArgKw (ArgKwSpace space' selection def) pcParam $
-                  ExprProcCall NoExt (ProcCall def (CommandIdOperator OpUnit) [])
-          suggestKeyword _ = liftList []
-
-        oldLeft <- liftLeft get
-        liftLeft $ put def
-        liftRight $ put def
-        arg' <- suggestKeyword e <|> ArgPos (ArgPosSpace space') <$> goExpr e
-
-        liftLeft $ put oldLeft
-        liftRight $ put oldRight
-
-        pure $ ProcCall pcSelection' pcName' (arg' : argsRest')
-
-
-      ProcCall pcSelection pcName (ArgKw space keyword e : argsRest) -> do
-        oldRight <- liftRight get
-        liftRight $ put $ RightSpace $ aksPrefix space
-        (ProcCall pcSelection' pcName' argsRest') <-
-          goPcName False pc (ProcCall pcSelection pcName argsRest)
-        space' <- liftRight $ gets getRightSpace
-
-        oldLeft <- liftLeft get
-        liftLeft $ put def
-        liftRight $ put def
-        e' <- goExpr e
-
-        liftLeft $ put oldLeft
-        liftRight $ put oldRight
-
-        pure $ ProcCall pcSelection' pcName'
-          (ArgKw space { aksPrefix = space' } keyword e' : argsRest')
-
-
-      ProcCall pcSelection pcName [] ->
-        case getSelection pcSelection of
-          Nothing -> pure $ ProcCall pcSelection (CommandIdName pcName) []
-          Just c ->
-            let
-              pcNameStr = nameStr pcName
-              (toComplete, _) = splitAtCursor c pcNameStr
-            in
-              liftList $ (pure $ ProcCall pcSelection (CommandIdName pcName) []) <|> do
-                (pcName', _) <- suggestableProcs
-                guard $ isPrefixOf toComplete $ nameStr pcName'
-                guard $ pcName' /= pcName || c /= cursorAfter pcNameStr
-                pure $ toProcCall pcName'
-
-    goPcRightSpace
-      :: Bool
-      -> ProcCall FormattedExprExt Name (Expr FormattedExprExt CommandId components)
-      -> ProcCall' FormattedExprExt CommandId components
-      -> SuggestionMonad (ProcCall' FormattedExprExt CommandId components)
-    goPcRightSpace firstCall (ProcCall _ pcName _) pc@(ProcCall pcSelection pcCmd pcArgs) = do
-      RightSpace right <- liftRight get
-      case getSelection $ swsSelection right of
-        Nothing -> pure pc
-        Just c ->
-          if c == def || not firstCall && c == cursorAfterSpace (swsSpace right)
-            then pure pc
-            else pure pc <|> do
-              let (leftSpace', rightSpace') = splitAtCursor c $ getSpace $ swsSpace right
-              liftRight $ put $ RightSpace
-                $ SpaceWithSelection (Space rightSpace') (Selection $ Just def)
-              pcParam <- liftList $ procParams pcName
-              let
-                arg' =
-                  ArgKw (ArgKwSpace (SpaceWithSelection (Space leftSpace') def) def def) pcParam $
-                    ExprProcCall NoExt (ProcCall def (CommandIdOperator OpUnit) [])
-              pure $ ProcCall pcSelection pcCmd $ arg' : pcArgs
-
-    selectionAtTheStart :: Selection -> Selection
-    selectionAtTheStart selection =
-      case getSelection selection of
-        Nothing -> def
-        Just c ->
-          if c == def
-            then selection
-            else def
-
-    selectionAtTheEnd :: SpaceWithSelection -> Selection
-    selectionAtTheEnd sws =
-      case getSelection $ swsSelection sws of
-        Nothing -> def
-        Just c ->
-          if cursorAfterSpace (swsSpace sws) == c
-            then Selection $ Just def
-            else def
-
-    suggestableProcs :: [(Name, [Name])]
-    suggestableProcs =
-      flip mapMaybe procs $ \(SomeCommandProc CommandProc{..}) ->
-        case cpName of
-          CommandIdName name -> Just (name, map (^._1) $ getParameters cpArgumentConsumer)
-          CommandIdOperator _ -> Nothing
-
-    procParams :: Name -> [Name]
-    procParams cmdName = maybe [] snd $ find ((== cmdName) . fst) suggestableProcs
-
-    toProcCall procName = ProcCall
-      (Selection $ Just $ cursorAfter $ nameStr procName)
-      (CommandIdName procName)
-      []
-
-    nameStr = unpack . toLazyText . build
+              (suggestionExprs commandProcs formattedExpr)
+              (SuggestionCtx (makeSws spaceBefore) (makeRightSws spaceAfter))

--- a/knit/src/Knit/Autocompletion.hs
+++ b/knit/src/Knit/Autocompletion.hs
@@ -40,7 +40,7 @@ suggestions
   => proxy components
   -> Cursor
   -> T.Text
-  -> [(T.Text, Cursor)]
+  -> [(Cursor, T.Text)]
 suggestions _ cursor cmd =
   let
     (spaceBefore, tokens) = tokenize cmd
@@ -79,11 +79,11 @@ suggestions _ cursor cmd =
             let
               (suggestionStr, selection) = ppFormattedExpr swsBefore suggestion swsAfter
             in
-              ( T.dropEnd parensBalance suggestionStr
-              , maybe
+              ( maybe
                   (error "Core invariant violated: no cursor after autocompletion")
                   id
                 $ getSelection selection
+              , T.dropEnd parensBalance suggestionStr
               )
         in
           map processSuggestion $

--- a/knit/src/Knit/Autocompletion.hs
+++ b/knit/src/Knit/Autocompletion.hs
@@ -8,7 +8,6 @@ import Control.Monad.Trans
 import Control.Monad.Trans.State.Strict
 import Data.Default
 import Data.List (isPrefixOf)
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Loc (loc, spanFromTo)
 import Data.Maybe (mapMaybe)
 import Data.Semigroup ((<>))
@@ -73,7 +72,7 @@ suggestions _ cursor cmd =
           (formattedExpr, spaceAfter) = parseTreeToFormattedExpr (Selection $ Just cursor) tree
           makeSws = maybe def $ \space ->
             SpaceWithSelection
-              (Space $ NonEmpty.toList $ getSkipped $ _lItem space)
+              (Space $ toList $ getSkipped $ _lItem space)
               (selectionInSpan (getCursor cursor) (_lSpan space))
           makeRightSws x =
             if cmd == ""
@@ -114,6 +113,7 @@ liftRight = lift
 liftList :: [a] -> SuggestionMonad a
 liftList = lift . lift
 
+{-# ANN module ("HLint: ignore Reduce duplication" :: T.Text) #-}
 -- | Returns completion suggestions assuming that the expression was completed
 -- with missing parentheses before parsing.
 suggestionExprs

--- a/knit/src/Knit/Autocompletion.hs
+++ b/knit/src/Knit/Autocompletion.hs
@@ -67,7 +67,7 @@ suggestions _ cursor cmd =
       (replicate parensBalance (TokenParenthesis BracketSideClosing))
   in
     case fullParses (pExpr @components) tokens' of
-      ([], _) -> []
+      ([], _) -> [(cursor, cmd)]
       (tree:_, _) ->
         let
           (formattedExpr, spaceAfter) = parseTreeToFormattedExpr (Selection $ Just cursor) tree
@@ -75,6 +75,10 @@ suggestions _ cursor cmd =
             SpaceWithSelection
               (Space $ NonEmpty.toList $ getSkipped $ _lItem space)
               (selectionInSpan (getCursor cursor) (_lSpan space))
+          makeRightSws x =
+            if cmd == ""
+              then SpaceWithSelection def (Selection $ Just def)
+              else makeSws x
           processSuggestion ((suggestion, LeftSpace swsBefore), RightSpace swsAfter) =
             let
               (suggestionStr, selection) = ppFormattedExpr swsBefore suggestion swsAfter
@@ -91,7 +95,7 @@ suggestions _ cursor cmd =
               (runStateT
                 (suggestionExprs commandProcs formattedExpr)
                 (LeftSpace $ makeSws spaceBefore))
-              (RightSpace $ makeSws spaceAfter)
+              (RightSpace $ makeRightSws spaceAfter)
 
 newtype LeftSpace = LeftSpace { getLeftSpace :: SpaceWithSelection }
   deriving (Default)

--- a/knit/src/Knit/FormattedExprExt.hs
+++ b/knit/src/Knit/FormattedExprExt.hs
@@ -1,14 +1,33 @@
 module Knit.FormattedExprExt
        ( FormattedExprExt
-       , ArgPosSkipped(..)
-       , ArgKwSkipped(..)
+
+       , Space(..)
+       , Cursor(..)
+       , Selection(..)
+       , SpaceWithSelection(..)
+       , FormattedBracket(..)
+       , ArgPosSpace(..)
+       , ArgKwSpace(..)
+
+       , selectionInSpan
+       , cursorAfter
+       , cursorAfterSpace
+       , zoomInCursor
+       , zoomOutCursor
+       , splitAtCursor
 
        , parseTreeToFormattedExpr
        , ppFormattedExpr
        ) where
 
-import Text.PrettyPrint.ANSI.Leijen (Doc)
-import qualified Text.PrettyPrint.ANSI.Leijen as PP
+import Control.Monad (guard)
+import Data.Coerce (coerce)
+import Data.Default
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Loc
+import Data.Maybe (mapMaybe)
+import Data.Semigroup (First(..), Option(..), Semigroup(..), (<>))
+import qualified Data.Text as T
 
 import Knit.ParseTreeExt
 import Knit.Prelude
@@ -20,32 +39,67 @@ import Knit.Tokenizer
 data FormattedExprExt
 
 type instance XExprProcCall FormattedExprExt _ _ = NoExt
-type instance XExprLit FormattedExprExt _ _ = NoExt
+type instance XExprLit FormattedExprExt _ _ = Selection
 -- | Space between the brackets and nested expression.
 type instance XXExpr FormattedExprExt cmd components =
-    ExprInBrackets Skipped (Expr FormattedExprExt cmd components)
+    ExprInBrackets FormattedBracket (Expr FormattedExprExt cmd components)
 
 -- | Information about the space between procedure and its arguments and between
 -- the arguments is stored with the arguments. Their meaning depends on the
 -- context. In the case of 'OpAndThen' space between the arguments and semicolon
 -- is stored. In the case of 'CommandIdName' each argument stores the space
 -- before itself.
-type instance XProcCall FormattedExprExt _ _ = NoExt
+type instance XProcCall FormattedExprExt _ _ = Selection
 
-type instance XArgPos FormattedExprExt _ = ArgPosSkipped
-type instance XArgKw FormattedExprExt _ = ArgKwSkipped
+type instance XArgPos FormattedExprExt _ = ArgPosSpace
+type instance XArgKw FormattedExprExt _ = ArgKwSpace
 type instance XXArg FormattedExprExt _ = Void
 
-newtype ArgPosSkipped = ArgPosSkipped Skipped
-  deriving (Show)
+newtype Space = Space { getSpace :: String }
+  deriving (Show, Eq, Ord, Semigroup, Monoid, Default)
 
-data ArgKwSkipped = ArgKwSkipped
-  { aksPrefix :: Skipped
-  , aksBetween :: Skipped
-  } deriving (Show)
+newtype Cursor = Cursor { getCursor :: Loc }
+  deriving (Show, Eq, Ord)
 
-ppSkipped :: Skipped -> Doc
-ppSkipped (Skipped str) = PP.string str
+instance Default Cursor where
+  def = Cursor origin
+
+newtype Selection = Selection { getSelection :: Maybe Cursor }
+  deriving (Show, Eq, Ord, Default)
+
+data SpaceWithSelection = SpaceWithSelection
+  { swsSpace :: Space
+  , swsSelection :: Selection
+  } deriving (Show, Eq, Ord)
+
+instance Default SpaceWithSelection where
+  def = SpaceWithSelection def def
+
+instance Semigroup SpaceWithSelection where
+  a <> b = SpaceWithSelection
+    { swsSpace = swsSpace a <> swsSpace b
+    , swsSelection = coerce @ (Option (First Cursor))
+        $  coerce (swsSelection a)
+        <> coerce (zoomOutCursor (cursorAfterSpace $ swsSpace a) <$> getSelection (swsSelection b))
+    }
+
+instance Monoid SpaceWithSelection where
+  mempty = def
+  mappend = (<>)
+
+data FormattedBracket = FormattedBracket
+  { fbBracketSelection :: Selection
+  , fbSpace :: SpaceWithSelection
+  } deriving (Show, Eq, Ord)
+
+newtype ArgPosSpace = ArgPosSpace { getArgPosSpace :: SpaceWithSelection }
+  deriving (Show, Eq, Ord)
+
+data ArgKwSpace = ArgKwSpace
+  { aksPrefix :: SpaceWithSelection
+  , aksKwSelection :: Selection
+  , aksBetween :: SpaceWithSelection
+  } deriving (Show, Eq, Ord)
 
 procedureWithNoName :: a
 procedureWithNoName = error "Core invariant violated: procedure with no name"
@@ -53,100 +107,232 @@ procedureWithNoName = error "Core invariant violated: procedure with no name"
 opUnitWithAName :: a
 opUnitWithAName = error "Core invariant violated: OpUnit with a name"
 
+cursorAfter :: String -> Cursor
+cursorAfter str
+  | (_, _:xs) <- break (=='\n') str =
+      let y = getCursor $ cursorAfter xs
+      in Cursor $ loc (succ $ locLine y) (locColumn y)
+  | otherwise = Cursor $ loc 1 (fromIntegral $ length str + 1)
+
+cursorAfterSpace :: Space -> Cursor
+cursorAfterSpace = cursorAfter . getSpace
+
+zoomOutCursor :: Cursor -> Cursor -> Cursor
+zoomOutCursor (Cursor oldOrigin) (Cursor c) = Cursor $ loc
+    (locLine oldOrigin `add` locLine c)
+    (if locLine oldOrigin == 1
+      then locColumn oldOrigin `add` locColumn c
+      else locColumn c)
+  where
+    add :: (Num a, Enum a) => a -> a -> a
+    add x y = pred $ x + y
+
+zoomInCursor :: Cursor -> Cursor -> Cursor
+zoomInCursor (Cursor newOrigin) (Cursor c) = Cursor $ loc
+    (locLine c `sub` locLine newOrigin)
+    (if locLine c == locLine newOrigin
+      then locColumn c `sub` locColumn newOrigin
+      else locColumn c)
+  where
+    sub :: (Num a, Enum a) => a -> a -> a
+    sub a b = succ a - b
+
+splitAtCursor :: Cursor -> String -> (String, String)
+splitAtCursor (Cursor l) str
+  | l == origin = ("", str)
+splitAtCursor _ [] = ([], [])
+splitAtCursor (Cursor l) str@(x:xs)
+  | locLine l == 1 = first (x:) $ splitAtCursor (Cursor $ loc 1 (pred $ locColumn l)) xs
+  | otherwise =
+    let
+      (beforeNewline, afterNewline') = break (== '\n') str
+      (newline, afterNewline) = splitAt 1 afterNewline'
+    in
+      first ((beforeNewline ++ newline) ++)
+      $ splitAtCursor (Cursor $ loc (pred $ locLine l) (locColumn l)) afterNewline
+
+selectionInSpan :: Loc -> Span -> Selection
+selectionInSpan l s = Selection $
+  guard (spanStart s <= l && l <= spanEnd s)
+  $> zoomInCursor (Cursor $ spanStart s) (Cursor l)
+
 -- | Converts parse tree to formatted expression alongside with space skipped
--- after parsing provided tree. 'OpUnit' inside brackets is placed right before
--- the closing bracket i.e. "(<space> OpUnit)" instead of "(OpUnit <space>)".
+-- after parsing provided tree.
 parseTreeToFormattedExpr
   :: forall components.
-     Expr ParseTreeExt CommandId components
-  -> (Expr FormattedExprExt CommandId components, Skipped)
-parseTreeToFormattedExpr =
-  \case
-    XExpr (ExprInBrackets l e r) ->
-      let (e', se) = parseTreeToFormattedExpr e
-      in (XExpr $ ExprInBrackets (l^.lSpaceAfter) e' se, r^.lSpaceAfter)
-    ExprProcCall NoExt pc -> first (ExprProcCall NoExt) (pcToFormattedPc pc)
-    ExprLit tok lit -> (ExprLit NoExt lit, tok^.lSpaceAfter)
+     Selection
+  -> Expr ParseTreeExt CommandId components
+  -> (Expr FormattedExprExt CommandId components, Maybe (Located Skipped))
+parseTreeToFormattedExpr selection' = exprToFormattedExpr
   where
+    selection :: Located a -> Selection
+    selection = maybe
+      (const def)
+      (\cursor -> selectionInSpan (getCursor cursor) . _lSpan)
+      (getSelection selection')
+
+    skippedWithSelection :: Maybe (Located Skipped) -> SpaceWithSelection
+    skippedWithSelection Nothing = SpaceWithSelection def def
+    skippedWithSelection (Just t) = SpaceWithSelection
+      (Space $ NonEmpty.toList $ getSkipped $ _lItem t)
+      (selection t)
+
+    exprToFormattedExpr
+      :: Expr ParseTreeExt CommandId components
+      -> (Expr FormattedExprExt CommandId components, Maybe (Located Skipped))
+    exprToFormattedExpr =
+      \case
+        XExpr (ExprInBrackets l e r) ->
+          let
+            (e', se) = exprToFormattedExpr e
+          in
+            ( XExpr $ ExprInBrackets
+                FormattedBracket
+                  { fbBracketSelection = selection $ l^.twsToken
+                  , fbSpace = skippedWithSelection $ l^.twsSpaceAfter
+                  }
+                e'
+                FormattedBracket
+                  { fbBracketSelection = selection $ r^.twsToken
+                  , fbSpace = skippedWithSelection se
+                  }
+            , r^.twsSpaceAfter
+            )
+        ExprProcCall NoExt pc -> first (ExprProcCall NoExt) (pcToFormattedPc pc)
+        ExprLit tok lit -> (ExprLit (selection $ tok^.twsToken) lit, tok^.twsSpaceAfter)
+
     pcToFormattedPc
       :: ProcCall' ParseTreeExt CommandId components
-      -> (ProcCall' FormattedExprExt CommandId components, Skipped)
+      -> (ProcCall' FormattedExprExt CommandId components, Maybe (Located Skipped))
     pcToFormattedPc (ProcCall tok cmd args) =
       case cmd of
         CommandIdName _ ->
           case tok of
-            Just tok' -> first (ProcCall NoExt cmd) (argGo (tok'^.lSpaceAfter) args)
+            Just tok' -> first
+              (ProcCall (selection $ tok'^.twsToken) cmd)
+              (argGo (tok'^.twsSpaceAfter) args)
             Nothing -> procedureWithNoName
         CommandIdOperator op ->
           case (op, tok, args) of
             (OpAndThen, Just tok', [ArgPos NoExt lhs, ArgPos NoExt rhs]) ->
               let
-                (lhs', lSkipped) = parseTreeToFormattedExpr lhs
-                lhs'' = ArgPos (ArgPosSkipped lSkipped) lhs'
-                (rhs', rSkipped) = parseTreeToFormattedExpr rhs
-                rhs'' = ArgPos (ArgPosSkipped $ tok'^.lSpaceAfter) rhs'
+                (lhs', lSpace) = exprToFormattedExpr lhs
+                lhs'' = ArgPos (ArgPosSpace $ skippedWithSelection lSpace) lhs'
+                (rhs', rSpace) = exprToFormattedExpr rhs
+                rhs'' = ArgPos (ArgPosSpace $ skippedWithSelection $ tok'^.twsSpaceAfter) rhs'
               in
-                (ProcCall NoExt cmd [lhs'', rhs''], rSkipped)
+                (ProcCall (selection $ tok'^.twsToken) cmd [lhs'', rhs''], rSpace)
             (OpAndThen, Nothing, [_, _]) -> procedureWithNoName
 
-            (OpUnit, Nothing, []) -> (ProcCall NoExt cmd [], mempty)
+            (OpUnit, Nothing, []) -> (ProcCall def cmd [], def)
             (OpUnit, Just _, []) -> opUnitWithAName
 
             _ -> invalidOperatorApplication
 
     argToFormattedArg
-      :: Skipped
+      :: Maybe (Located Skipped)
       -> Arg' ParseTreeExt CommandId components
-      -> (Arg' FormattedExprExt CommandId components, Skipped)
+      -> (Arg' FormattedExprExt CommandId components, Maybe (Located Skipped))
     argToFormattedArg skippedBefore = \case
       XArg xxArg -> absurd xxArg
-      ArgPos NoExt a -> first (ArgPos (ArgPosSkipped skippedBefore)) (parseTreeToFormattedExpr a)
+      ArgPos NoExt a -> first
+        (ArgPos (ArgPosSpace $ skippedWithSelection skippedBefore))
+        (exprToFormattedExpr a)
       ArgKw nameTok name a ->
         let
-          skipped = ArgKwSkipped
-            { aksPrefix = skippedBefore
-            , aksBetween = nameTok^.lSpaceAfter
+          skipped = ArgKwSpace
+            { aksPrefix = skippedWithSelection skippedBefore
+            , aksKwSelection = selection $ nameTok^.twsToken
+            , aksBetween = skippedWithSelection $ nameTok^.twsSpaceAfter
             }
         in
-          first (ArgKw skipped name) (parseTreeToFormattedExpr a)
+          first (ArgKw skipped name) (exprToFormattedExpr a)
 
     argGo
-      :: Skipped
+      :: Maybe (Located Skipped)
       -> [Arg' ParseTreeExt CommandId components]
-      -> ([Arg' FormattedExprExt CommandId components], Skipped)
+      -> ([Arg' FormattedExprExt CommandId components], Maybe (Located Skipped))
     argGo skippedBefore [] = ([], skippedBefore)
     argGo skippedBefore (arg : args) =
       let (arg', skippedAfter) = argToFormattedArg skippedBefore arg
       in first (arg' :) (argGo skippedAfter args)
 
+data FormattedChar = FChar Char | FCursor
+  deriving (Show, Eq, Ord)
+
+type FormattedString = [FormattedChar]
+
+insertCursor :: Cursor -> String -> FormattedString
+insertCursor cursor str =
+  let (before, after) = splitAtCursor cursor str
+  in map FChar before ++ [FCursor] ++ map FChar after
+
+strWithSelection :: Selection -> String -> FormattedString
+strWithSelection = maybe (map FChar) insertCursor . getSelection
+
+convertFormattedOutput :: FormattedString -> (T.Text, Selection)
+convertFormattedOutput str =
+  ( T.pack $ mapMaybe (\case FChar c -> Just c; FCursor -> Nothing) str
+  , findSelection 1 str
+  )
+
+findSelection :: Line -> FormattedString -> Selection
+findSelection _ [] = def
+findSelection line str =
+  let (pref, suff) = break (\c -> c == FChar '\n' || c == FCursor) str
+  in case suff of
+    [] -> def
+    (FChar '\n'):rest -> findSelection (succ line) rest
+    FCursor:_ -> Selection $ Just $ Cursor $ loc line (fromIntegral $ length pref + 1)
+    _ -> error "Core invariant violated: list head does not satisfy predicate after 'break'"
+
 ppFormattedExpr
   :: forall components.
      AllConstrained ComponentPrinter components
-  => Expr FormattedExprExt CommandId components
-  -> Doc
-ppFormattedExpr =
-  \case
-    ExprLit NoExt l -> ppLit l
-    ExprProcCall NoExt p -> ppProcCall p
-    XExpr (ExprInBrackets l e r) ->
-      PP.parens $ ppSkipped l PP.<> ppFormattedExpr e PP.<> ppSkipped r
+  => SpaceWithSelection
+  -> Expr FormattedExprExt CommandId components
+  -> SpaceWithSelection
+  -> (T.Text, Selection)
+ppFormattedExpr swsBefore expr swsAfter = convertFormattedOutput $
+    ppSpace swsBefore ++ ppFExpr expr ++ ppSpace swsAfter
   where
-    ppProcCall (ProcCall NoExt commandName args) =
+    ppSpace :: SpaceWithSelection -> FormattedString
+    ppSpace (SpaceWithSelection (Space str) c) = strWithSelection c str
+
+    ppFExpr
+      :: Expr FormattedExprExt CommandId components
+      -> FormattedString
+    ppFExpr = \case
+      ExprLit c l -> strWithSelection c $ show $ ppLit l
+      ExprProcCall NoExt p -> ppProcCall p
+      XExpr (ExprInBrackets l e r) ->
+           strWithSelection (fbBracketSelection l) "("
+        ++ ppSpace (fbSpace l)
+        ++ ppFExpr e
+        ++ ppSpace (fbSpace r)
+        ++ strWithSelection (fbBracketSelection r) ")"
+
+    ppProcCall (ProcCall c commandName args) =
       case commandName of
-        CommandIdName name -> ppProcedureCall name args
-        CommandIdOperator op -> ppOperatorCall op args
+        CommandIdName name -> ppProcedureCall (strWithSelection c $ show $ nameToDoc name) args
+        CommandIdOperator op -> ppOperatorCall c op args
 
-    ppOperatorCall OpUnit [] = mempty
-    ppOperatorCall OpAndThen [ArgPos (ArgPosSkipped lp) l, ArgPos (ArgPosSkipped rp) r] =
-      ppFormattedExpr l PP.<> ppSkipped lp PP.<> PP.char ';' PP.<>
-      ppSkipped rp PP.<> ppFormattedExpr r
-    ppOperatorCall _ _ = invalidOperatorApplication
-
-    ppProcedureCall procName args = nameToDoc procName PP.<> mconcat (map ppArg args)
+    ppProcedureCall procName args = procName ++ mconcat (map ppArg args)
 
     ppArg = \case
-      ArgPos (ArgPosSkipped prefix) a -> ppSkipped prefix PP.<> ppFormattedExpr a
-      ArgKw ArgKwSkipped{..} name a ->
-        ppSkipped aksPrefix PP.<> nameToDoc name PP.<> PP.colon PP.<>
-        ppSkipped aksBetween PP.<> ppFormattedExpr a
+      ArgPos (ArgPosSpace prefix) a -> ppSpace prefix ++ ppFExpr a
+      ArgKw ArgKwSpace{..} name a ->
+           ppSpace aksPrefix
+        ++ strWithSelection aksKwSelection (show (nameToDoc name) ++ ":")
+        ++ ppSpace aksBetween
+        ++ ppFExpr a
       XArg xxArg -> absurd xxArg
+
+    ppOperatorCall _ OpUnit [] = mempty
+    ppOperatorCall c OpAndThen [ArgPos (ArgPosSpace ls) l, ArgPos (ArgPosSpace rs) r] =
+         ppFExpr l
+      ++ ppSpace ls
+      ++ strWithSelection c ";"
+      ++ ppSpace rs
+      ++ ppFExpr r
+    ppOperatorCall _ _ _ = invalidOperatorApplication

--- a/knit/src/Knit/ParseTreeExt.hs
+++ b/knit/src/Knit/ParseTreeExt.hs
@@ -12,15 +12,15 @@ import Knit.Tokenizer
 data ParseTreeExt
 
 type instance XExprProcCall ParseTreeExt _ _ = NoExt
-type instance XExprLit ParseTreeExt _ components = Located (Token components)
+type instance XExprLit ParseTreeExt _ components = TokenWithSpace components
 type instance XXExpr ParseTreeExt cmd components =
-    ExprInBrackets (Located (Token components)) (Expr ParseTreeExt cmd components)
+    ExprInBrackets (TokenWithSpace components) (Expr ParseTreeExt cmd components)
 
 type instance XProcCall ParseTreeExt _ (Expr ParseTreeExt _ components) =
-    Maybe (Located (Token components))
+    Maybe (TokenWithSpace components)
 
 type instance XArgPos ParseTreeExt _ = NoExt
-type instance XArgKw ParseTreeExt (Expr ParseTreeExt _ components) = Located (Token components)
+type instance XArgKw ParseTreeExt (Expr ParseTreeExt _ components) = TokenWithSpace components
 type instance XXArg ParseTreeExt _ = Void
 
 data ExprInBrackets br a = ExprInBrackets br a br

--- a/ui/vty-app/Glue.hs
+++ b/ui/vty-app/Glue.hs
@@ -24,6 +24,7 @@ module Glue
 import qualified Control.Concurrent.Event as CE
 import Control.Exception (displayException)
 import Control.Lens (ix)
+import Data.Coerce
 import Data.Double.Conversion.Text (toFixed)
 import Data.Tree (Tree(..))
 import Data.Unique
@@ -72,7 +73,7 @@ knitFaceToUI UiFace{..} KnitFace{..} putPass =
     , langPutUiCommand = putUiCommand False
     , langPutUISilentCommand = putUiCommand True
     , langParse = Knit.parse
-    , langAutocomplete = Knit.suggestions (Proxy @components)
+    , langAutocomplete = coerce $ Knit.suggestions (Proxy @components)
     , langPpExpr = Knit.ppExpr
     , langPpParseError = Knit.ppParseError
     , langParseErrSpans = Knit.parseErrorSpans

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -55,7 +55,7 @@ module Ariadne.UI.Vty.Face
        ) where
 
 import qualified Control.Concurrent.Event as CE
-import Data.Loc.Span (Span)
+import Data.Loc (Loc, Span)
 import Data.Tree (Tree)
 import Data.Version (Version)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
@@ -90,7 +90,7 @@ data UiLangFace = forall err expr. UiLangFace
   , langPutUiCommand :: UiCommand -> IO (Either Text UiCommandId)
   , langPutUISilentCommand :: UiCommand -> IO (Either Text UiCommandId)
   , langParse :: Text -> Either err expr
-  , langAutocomplete :: Text -> [Text]
+  , langAutocomplete :: Loc -> Text -> [(Loc, Text)]
   , langPpExpr :: expr -> Doc
   , langPpParseError :: err -> Doc
   , langParseErrSpans :: err -> [Span]


### PR DESCRIPTION
**Description:** Cursor is now stored inside the tree. This allows to use all of the input in the autocompletion (before only text before the cursor was parsed for autocompletion purposes) and has potential use cases for other editing features. On the other hand, it is quite hard to manipulate the tree with all that formatting info, and maybe something should be done about it.

**YT issue:** https://issues.serokell.io/issue/AD-458

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
