### PR TITLE
Add PatternSynonyms to .stylish-haskell

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -41,6 +41,7 @@ language_extensions:
   - NoImplicitPrelude
   - OverloadedLabels
   - OverloadedStrings
+  - PatternSynonyms
   - RecordWildCards
   - RecursiveDo
   - ScopedTypeVariables


### PR DESCRIPTION
**Description:** `stylish-haskell` doesn't work on
https://github.com/serokell/ariadne/blob/839815b5a42688995a771eb690309f50f6f56c8a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Repl.hs#L7
without `PatternSynonyms`.

**YT issue:** ~~https://issues.serokell.io/issue/AD-~~

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
