### PR TITLE
[AD-432] Support custom finalizers for the UI

### DIFF
--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -70,9 +70,9 @@ data MainSettings (uiComponents :: [*]) uiFace uiLangFace = MainSettings
     , msUiExecContext ::
         !(uiFace ->
         Rec (Knit.ComponentExecContext IO (AllComponents uiComponents)) uiComponents)
-    , msKillUI :: !(SomeException -> IO ())
-    -- ^ Kill UI, should probably show some information about exception before killing
-    -- not necessary for VTY application for now
+    , msPutBackendErrorToUI :: !(uiFace -> SomeException -> IO ())
+    -- ^ Notify UI about exception, that occurs in backend.
+    -- Not necessary for VTY application for now
     }
 
 -- | Default implementation of the 'main' function.
@@ -170,8 +170,8 @@ initializeEverything MainSettings {..}
       -- This is needed because some UI libraries (Qt) insist on livng in the main thread
       withAsync serviceAction $ \serviceThread -> do
         -- Make custom link to service thread for UI apps.
-        -- It is going to call msKillUI and rethrow exception, if somethings goes wrong
-        linkUI serviceThread msKillUI
+        -- It is going to call msPutBackendErrorToUI and rethrow exception, if somethings goes wrong
+        linkUI serviceThread $ msPutBackendErrorToUI uiFace
         uiAction
 
   return mainAction

--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -5,8 +5,10 @@ module Ariadne.MainTemplate
        , defaultMain
        ) where
 
-import Control.Concurrent
+import Control.Concurrent (forkIO, myThreadId, throwTo)
 import Control.Concurrent.Async
+  (Async(..), AsyncCancelled(..), ExceptionInLinkedThread(..), race_,
+  waitCatch, withAsync)
 import Control.Monad.Component (ComponentM, runComponentM)
 import Control.Natural (($$))
 import Data.Version (Version)
@@ -181,7 +183,7 @@ linkUI thread finalizer = do
   void $ forkIO $ do
     r <- waitCatch thread
     case r of
-      Left e | (not . isCancel) e -> finalizer e >> throwTo me (ExceptionInLinkedThread thread e)
+      Left e | not $ isCancel e -> finalizer e >> throwTo me (ExceptionInLinkedThread thread e)
       _ -> pass
   where
     isCancel :: SomeException -> Bool

--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -170,7 +170,7 @@ initializeEverything MainSettings {..}
       -- This is needed because some UI libraries (Qt) insist on livng in the main thread
       withAsync serviceAction $ \serviceThread -> do
         -- Make custom link to service thread for UI apps.
-        -- It is going to call msPutBackendErrorToUI and rethrow exception, if somethings goes wrong
+        -- It is going to call msPutBackendErrorToUI and rethrow exception, if something goes wrong
         linkUI serviceThread $ msPutBackendErrorToUI uiFace
         uiAction
 

--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -182,7 +182,7 @@ linkQT thread finalizer = do
     r <- waitCatch thread
     case r of
       Left e -> finalizer e
-      _ -> return ()
+      _ -> pass
   where
     -- Actually forkRepeat from Control.Concurrent.Async required for linkQT
     forkRepeat :: IO a -> IO ThreadId
@@ -191,7 +191,7 @@ linkQT thread finalizer = do
         let go = do r <- tryIO (restore action)
                     case r of
                       Left _ -> go
-                      _ -> return ()
+                      _ -> pass
         in forkIO go
     -- Try with specified type
     tryIO :: IO a -> IO (Either SomeException a)

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -15,6 +15,9 @@ module Glue
 
          -- * Password Manager ↔ Vty
        , putPasswordEventToUI
+
+         -- * Cardano ↔ Qt
+       , putBackendErrorToUI
        ) where
 
 import qualified Control.Concurrent.Event as CE
@@ -254,6 +257,11 @@ cardanoEventToUI = \case
 putCardanoEventToUI :: UiFace -> CardanoEvent -> IO ()
 putCardanoEventToUI UiFace{..} ev =
   whenJust (cardanoEventToUI ev) putUiEvent
+
+-- Called when an exception in backend thread occurs
+putBackendErrorToUI :: UiFace -> SomeException -> IO ()
+putBackendErrorToUI UiFace{..} e = putUiEvent . UiBackendExceptionEvent $
+    UiBackendException e
 
 ----------------------------------------------------------------------------
 -- Glue between the Wallet backend and Qt frontend

--- a/ui/qt-app/Main.hs
+++ b/ui/qt-app/Main.hs
@@ -30,7 +30,7 @@ main = defaultMain mainSettings
         , msPutPasswordEventToUI = putPasswordEventToUI
         , msKnitFaceToUI = knitFaceToUI
         , msUiExecContext = const $ Base ()
-        , msKillUI = killQtUI
+        , msPutBackendErrorToUI = putBackendErrorToUI
         }
 
     createUI

--- a/ui/qt-app/Main.hs
+++ b/ui/qt-app/Main.hs
@@ -30,6 +30,7 @@ main = defaultMain mainSettings
         , msPutPasswordEventToUI = putPasswordEventToUI
         , msKnitFaceToUI = knitFaceToUI
         , msUiExecContext = const $ Base ()
+        , msKillUI = killQtUI
         }
 
     createUI

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -22,7 +22,6 @@ import qualified Graphics.UI.Qtah.Gui.QIcon as QIcon
 import qualified Graphics.UI.Qtah.Widgets.QApplication as QApplication
 import qualified Graphics.UI.Qtah.Widgets.QDialog as QDialog
 import qualified Graphics.UI.Qtah.Widgets.QMessageBox as QMessageBox
-import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
 
 import Control.Concurrent.STM.TBQueue
 
@@ -87,10 +86,10 @@ killQtUI e = do
   QMessageBox.setWindowTitle msg ("Error" :: String)
   QMessageBox.setIcon msg QMessageBox.Critical
   QMessageBox.setText msg ("Got exception from backend: " <> show e :: String)
-  connect_ msg QMessageBox.buttonClickedSignal $ \_ -> QCoreApplication.exit 1
+  connect_ msg QMessageBox.buttonClickedSignal $ \_ -> QDialog.accept msg
   connect_ msg QDialog.acceptedSignal $ QCoreApplication.exit 1
   connect_ msg QDialog.rejectedSignal $ QCoreApplication.exit 1
-  QWidget.show msg
+  void $ QDialog.exec msg
 
 mkEventBQueue :: IO (UiEventBQueue)
 mkEventBQueue = newTBQueueIO 100

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -87,9 +87,8 @@ killQtUI e = do
   QMessageBox.setIcon msg QMessageBox.Critical
   QMessageBox.setText msg ("Got exception from backend: " <> show e :: String)
   connect_ msg QMessageBox.buttonClickedSignal $ \_ -> QDialog.accept msg
-  connect_ msg QDialog.acceptedSignal $ QCoreApplication.exit 1
-  connect_ msg QDialog.rejectedSignal $ QCoreApplication.exit 1
   void $ QDialog.exec msg
+  QCoreApplication.exit 1
 
 mkEventBQueue :: IO (UiEventBQueue)
 mkEventBQueue = newTBQueueIO 100

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -10,7 +10,6 @@ import Control.Monad.Extra (loopM)
 
 import Ariadne.UI.Qt.Face
   (UiEvent(..), UiFace(..), UiHistoryFace, UiLangFace, UiWalletFace)
-import Graphics.UI.Qtah.Signal (connect_)
 
 import Foreign.Hoppy.Runtime (withScopedPtr)
 import qualified Graphics.UI.Qtah.Core.QCoreApplication as QCoreApplication
@@ -20,8 +19,8 @@ import qualified Graphics.UI.Qtah.Event as Event
 import qualified Graphics.UI.Qtah.Gui.QFontDatabase as QFontDatabase
 import qualified Graphics.UI.Qtah.Gui.QIcon as QIcon
 import qualified Graphics.UI.Qtah.Widgets.QApplication as QApplication
-import qualified Graphics.UI.Qtah.Widgets.QDialog as QDialog
 import qualified Graphics.UI.Qtah.Widgets.QMessageBox as QMessageBox
+import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
 
 import Control.Concurrent.STM.TBQueue
 
@@ -82,12 +81,8 @@ runUIEventLoop eventIORef dispatcherIORef uiWalletFace historyFace putPass langF
 
 killQtUI :: SomeException -> IO ()
 killQtUI e = do
-  msg <- QMessageBox.new
-  QMessageBox.setWindowTitle msg ("Error" :: String)
-  QMessageBox.setIcon msg QMessageBox.Critical
-  QMessageBox.setText msg ("Got exception from backend: " <> show e :: String)
-  connect_ msg QMessageBox.buttonClickedSignal $ \_ -> QDialog.accept msg
-  void $ QDialog.exec msg
+  msg <- QWidget.new
+  void $ QMessageBox.critical msg ("Error" :: String) ("Got exception from backend: " <> show e :: String)
   QCoreApplication.exit 1
 
 mkEventBQueue :: IO (UiEventBQueue)

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -1,7 +1,6 @@
 module Ariadne.UI.Qt
        ( UiFace(..)
        , createAriadneUI
-       , killQtUI
        ) where
 
 import Control.Concurrent
@@ -19,8 +18,6 @@ import qualified Graphics.UI.Qtah.Event as Event
 import qualified Graphics.UI.Qtah.Gui.QFontDatabase as QFontDatabase
 import qualified Graphics.UI.Qtah.Gui.QIcon as QIcon
 import qualified Graphics.UI.Qtah.Widgets.QApplication as QApplication
-import qualified Graphics.UI.Qtah.Widgets.QMessageBox as QMessageBox
-import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
 
 import Control.Concurrent.STM.TBQueue
 
@@ -78,12 +75,6 @@ runUIEventLoop eventIORef dispatcherIORef uiWalletFace historyFace putPass langF
         handleAppEvent langFace putPass eventIORef mainWindow >> return True
 
     QCoreApplication.exec
-
-killQtUI :: SomeException -> IO ()
-killQtUI e = do
-  msg <- QWidget.new
-  void $ QMessageBox.critical msg ("Error" :: String) ("Got exception from backend: " <> show e :: String)
-  QCoreApplication.exit 1
 
 mkEventBQueue :: IO (UiEventBQueue)
 mkEventBQueue = newTBQueueIO 100

--- a/ui/qt-lib/src/Ariadne/UI/Qt.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt.hs
@@ -1,6 +1,7 @@
 module Ariadne.UI.Qt
        ( UiFace(..)
        , createAriadneUI
+       , killQtUI
        ) where
 
 import Control.Concurrent
@@ -75,6 +76,9 @@ runUIEventLoop eventIORef dispatcherIORef uiWalletFace historyFace putPass langF
         handleAppEvent langFace putPass eventIORef mainWindow >> return True
 
     QCoreApplication.exec
+
+killQtUI :: SomeException -> IO ()
+killQtUI _ = QCoreApplication.exit 1
 
 mkEventBQueue :: IO (UiEventBQueue)
 mkEventBQueue = newTBQueueIO 100

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -3,6 +3,7 @@ module Ariadne.UI.Qt.Face
        , UiCommandEvent (..)
        , UiWalletEvent (..)
        , UiBackendStatusUpdate (..)
+       , UiBackendExceptionEvent (..)
        , UiBackendEvent (..)
        , UiEvent (..)
        , UiCommand (..)
@@ -94,6 +95,7 @@ data UiEvent
   | UiWalletEvent UiWalletEvent
   | UiPasswordEvent UiPasswordEvent
   | UiConfirmEvent UiConfirmEvent
+  | UiBackendExceptionEvent UiBackendExceptionEvent
 
 -- | Commands issued by the UI widgets
 data UiCommand
@@ -148,7 +150,7 @@ data UiConfirmationType
   | UiConfirmSend [UiConfirmSendInfo] -- ^ lists of outputs
 
 data UiConfirmSendInfo =
-  UiConfirmSendInfo 
+  UiConfirmSendInfo
     { csiAddress :: Text
     , csiAmount  :: Text
     , csiCoin    :: Text
@@ -158,6 +160,9 @@ data UiDeletingItem
   = UiDelWallet (Maybe Text)
   | UiDelAccount (Maybe Text)
   deriving Eq
+
+-- | Ui event to handle backed exceptions
+data UiBackendExceptionEvent = UiBackendException SomeException
 
 -- The backend language (Knit by default) interface as perceived by the UI.
 data UiLangFace =

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -161,7 +161,7 @@ data UiDeletingItem
   | UiDelAccount (Maybe Text)
   deriving Eq
 
--- | Ui event to handle backed exceptions
+-- | Ui event to handle backend exceptions
 data UiBackendExceptionEvent = UiBackendException SomeException
 
 -- The backend language (Knit by default) interface as perceived by the UI.

--- a/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
@@ -118,7 +118,7 @@ handleMainWindowEvent langFace putPass = \case
         WalletConfirmationRequest resultVar confirmationType
   UiBackendExceptionEvent (UiBackendException e) -> liftIO $ do
     msg <- QWidget.new
-    void $ QMessageBox.critical msg ("Error" :: String) ("Got exception from backend: " <> show e :: String)
+    void $ QMessageBox.critical msg ("Error" :: String) ("Wallet backend died with exception: " <> show e :: String)
     QCoreApplication.exit 1
 
 connectGlobalSignals :: UI MainWindow ()

--- a/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/MainWindow.hs
@@ -8,9 +8,11 @@ import Control.Lens (magnify, makeLensesWith)
 
 import Graphics.UI.Qtah.Core.Types (QtWindowType(Dialog))
 
+import qualified Graphics.UI.Qtah.Core.QCoreApplication as QCoreApplication
 import qualified Graphics.UI.Qtah.Widgets.QBoxLayout as QBoxLayout
 import qualified Graphics.UI.Qtah.Widgets.QLayout as QLayout
 import qualified Graphics.UI.Qtah.Widgets.QMainWindow as QMainWindow
+import qualified Graphics.UI.Qtah.Widgets.QMessageBox as QMessageBox
 import qualified Graphics.UI.Qtah.Widgets.QVBoxLayout as QVBoxLayout
 import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
 
@@ -114,6 +116,10 @@ handleMainWindowEvent langFace putPass = \case
   UiConfirmEvent (UiConfirmRequest resultVar confirmationType) -> do
     magnify walletL $ handleWalletEvent langFace putPass $
         WalletConfirmationRequest resultVar confirmationType
+  UiBackendExceptionEvent (UiBackendException e) -> liftIO $ do
+    msg <- QWidget.new
+    void $ QMessageBox.critical msg ("Error" :: String) ("Got exception from backend: " <> show e :: String)
+    QCoreApplication.exit 1
 
 connectGlobalSignals :: UI MainWindow ()
 connectGlobalSignals = do

--- a/ui/vty-app/Main.hs
+++ b/ui/vty-app/Main.hs
@@ -31,6 +31,7 @@ main = defaultMain mainSettings
         , msPutPasswordEventToUI = putPasswordEventToUI
         , msKnitFaceToUI = knitFaceToUI
         , msUiExecContext = \uiFace -> Step (Knit.UiExecCtx uiFace, Base ())
+        , msKillUI = \_ -> pass
         }
 
     createUI

--- a/ui/vty-app/Main.hs
+++ b/ui/vty-app/Main.hs
@@ -31,7 +31,7 @@ main = defaultMain mainSettings
         , msPutPasswordEventToUI = putPasswordEventToUI
         , msKnitFaceToUI = knitFaceToUI
         , msUiExecContext = \uiFace -> Step (Knit.UiExecCtx uiFace, Base ())
-        , msKillUI = \_ -> pass
+        , msPutBackendErrorToUI = \_ _ -> pass
         }
 
     createUI


### PR DESCRIPTION
**Description:** Backend exceptions couldn't be successfully handled by Qt app due to it's FFI calls. Now when exception on backed thread happens, it is being handled by custom link function, that finalize UI and rethrow this exception to UI thread.
To check this add something like `threadDelay 5000000 >> throwM (ExitFailure 42)` to [serviceAction](https://github.com/serokell/ariadne/blob/b21274c96038069f42293dacbe621c8e95432790/ariadne/cardano/src/Ariadne/MainTemplate.hs#L158)

**YT issue:** https://issues.serokell.io/issue/AD-432

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
