### PR TITLE
[AD-481] Use newer version of cardano-sl

### DIFF
--- a/ariadne/cardano/config/configuration.yaml
+++ b/ariadne/cardano/config/configuration.yaml
@@ -57,7 +57,7 @@ dev: &dev
         ftsSeed: "c2tvdm9yb2RhIEdndXJkYSBib3JvZGEgcHJvdm9kYSA="
         heavyDelegation: {}
         avvmDistr: {}
-
+    requiresNetworkMagic: NMMustBeNothing
     dbSerializeVersion: 0
 
   ntp: &dev_ntp
@@ -14775,12 +14775,13 @@ mainnet_full: &mainnet_full
       src:
         file: mainnet-genesis.json
         hash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
+    requiresNetworkMagic: NMMustBeNothing
 
 mainnet_wallet_win64: &mainnet_wallet_win64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 8
+    applicationVersion: 10
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14790,7 +14791,7 @@ mainnet_wallet_macos64: &mainnet_wallet_macos64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 8
+    applicationVersion: 10
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14800,7 +14801,7 @@ mainnet_wallet_linux64: &mainnet_wallet_linux64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 8
+    applicationVersion: 10
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14813,14 +14814,50 @@ mainnet_wallet_linux64: &mainnet_wallet_linux64
 ##                                                                          ##
 ##############################################################################
 
-testnet_full: &testnet_full
+# Should be used to generate genesis
+testnet_launch: &testnet_launch
   <<: *mainnet_base
-  core: &testnet_full_core
+  core: &testnet_gen_core
     <<: *mainnet_base_core
+    genesis: &testnet_gen_genesis
+      <<: *mainnet_base_genesis
+      spec: &testnet_gen_spec
+        <<: *mainnet_base_spec
+        protocolConstants:
+          k: 2160
+          protocolMagic: 1097911063
+          vssMinTTL: 2
+          vssMaxTTL: 6
+        avvmDistr: {}
+        initializer:
+          testBalance:
+            poors:        100
+            richmen:      7
+            richmenShare: 0.95
+            totalBalance: 42000000000000000 # 42e9 ADA
+            useHDAddresses: True
+          fakeAvvmBalance:
+            count: 100
+            oneBalance: 20000000000000 # 2e7 ADA
+          avvmBalanceFactor: 1
+          useHeavyDlg: True
+          seed: 0 # should be overridden using --configuration-seed
+        blockVersionData:
+          <<: *mainnet_base_blockVersionData
+          maxHeaderSize:      2000
+          maxProposalSize:   70000 # 70KB
+          maxTxSize:         65536 # 64KiB
+    requiresNetworkMagic: NMMustBeJust
+
+testnet_full: &testnet_full
+  <<: *testnet_launch
+  core: &testnet_full_core
+    <<: *testnet_gen_core
     genesis:
+      <<: *testnet_gen_genesis
       src:
         file: testnet-genesis.json
-        hash: f0204568043f6cb8068a81ddc1e9ca575615aed12a3a815678afc5ca12a94eb8
+        hash: b7f76950bc4866423538ab7764fc1c7020b24a5f717a5bee3109ff2796567214
 
   update: &testnet_full_update
     applicationName: cardano-sl
@@ -14837,7 +14874,7 @@ testnet_wallet: &testnet_wallet
     applicationVersion: 0
     lastKnownBlockVersion:
       bvMajor: 0
-      bvMinor: 1
+      bvMinor: 0
       bvAlt: 0
 
 testnet_wallet_win64: &testnet_wallet_win64
@@ -14858,32 +14895,6 @@ testnet_wallet_linux64: &testnet_wallet_linux64
     <<: *testnet_wallet_update
     systemTag: linux
 
-# Should be used to generate genesis
-testnet_launch: &testnet_launch
-  <<: *testnet_full
-  core: &testnet_gen_core
-    <<: *testnet_full_core
-    genesis:
-      <<: *mainnet_base_genesis
-      spec:
-        <<: *mainnet_base_spec
-        protocolConstants:
-          <<: *mainnet_base_protocolConstants
-          protocolMagic: 1097911063
-        avvmDistr: *mainnet_avvmDistr
-        initializer:
-          testBalance:
-            poors:        100
-            richmen:      7
-            richmenShare: 0.93
-            totalBalance: 13887504355000000
-            useHDAddresses: True
-          fakeAvvmBalance:
-            count: 100
-            oneBalance: 1000000000000 # 1e6 ADA
-          avvmBalanceFactor: 0.1
-          useHeavyDlg: True
-          seed: 0 # should be overridden using --configuration-seed
 
 ##############################################################################
 ##                                                                          ##
@@ -14899,12 +14910,13 @@ mainnet_dryrun_full: &mainnet_dryrun_full
       src:
         file: mainnet-genesis-dryrun-with-stakeholders.json
         hash: c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323
+    requiresNetworkMagic: NMMustBeNothing
 
 mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 14
+    applicationVersion: 15
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14914,7 +14926,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 14
+    applicationVersion: 15
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14924,7 +14936,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 14
+    applicationVersion: 15
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -15022,8 +15034,9 @@ devnet: &devnet
           avvmBalanceFactor: 1
           useHeavyDlg: True
           seed: 0
+    requiresNetworkMagic: NMMustBeNothing
 
-  update:
+  update: &devnet_update
     applicationName: cardano-sl
     applicationVersion: 0
     lastKnownBlockVersion:
@@ -15040,7 +15053,7 @@ devnet: &devnet
 devnet_win64:
   <<: *devnet
   update:
-    <<:
+    <<: *devnet_update
     applicationName: csl-daedalus
     applicationVersion: 0
     lastKnownBlockVersion:
@@ -15052,7 +15065,7 @@ devnet_win64:
 devnet_macos64:
   <<: *devnet
   update:
-    <<:
+    <<: *devnet_update
     applicationName: csl-daedalus
     applicationVersion: 0
     lastKnownBlockVersion:
@@ -15064,7 +15077,7 @@ devnet_macos64:
 devnet_linux64:
   <<: *devnet
   update:
-    <<:
+    <<: *devnet_update
     applicationName: csl-daedalus
     applicationVersion: 0
     lastKnownBlockVersion:

--- a/ariadne/cardano/src/Ariadne/Cardano/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Face.hs
@@ -131,11 +131,11 @@ type instance Distribution CardanoMode = Distribution CardanoModeMonad
 type instance MempoolExt CardanoMode = EmptyMempoolExt
 
 instance MonadBListener CardanoMode where
-  onApplyBlocks b = do
+  onApplyBlocks _ b = do
     CardanoContext{..} <- ask
     liftIO $ bhOnApply ccBListenerHandle $ b
     pure mempty
-  onRollbackBlocks b = do
+  onRollbackBlocks _ b = do
     CardanoContext{..} <- ask
     liftIO $ bhOnRollback ccBListenerHandle $ b
     pure mempty

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Tx.hs
@@ -188,7 +188,7 @@ sendTx
                 isp
                 ourAddresses
                 (map TxOutAux outs)
-                newChangeAddress
+                (const newChangeAddress)
         let tx = taTx txAux
         let txId = hash tx
         liftIO $ printAction $ formatSubmitTxMsg tx

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Bip32.hs
@@ -10,6 +10,7 @@ import Named ((:!), pattern Arg)
 
 import Cardano.Crypto.Wallet.Types (DerivationIndex)
 import Pos.Core.Common (Address, IsBootstrapEraAddr(..), makePubKeyHdwAddress)
+import Pos.Core.NetworkMagic (NetworkMagic)
 import Pos.Crypto.HD
   (ShouldCheckPassphrase(..), deriveHDPassphrase, deriveHDSecretKey,
   packHDAddressAttr)
@@ -36,11 +37,13 @@ deriveHDSecretKeyByPath shouldCheck pp sk (DerivationPath derPath) =
 -- | Like 'makePubKeyHdwAddress', but also creates HDPassphrase
 -- internally using derivation path and root public key.
 makePubKeyHdwAddressUsingPath ::
-       IsBootstrapEraAddr
+       NetworkMagic
+    -> IsBootstrapEraAddr
     -> DerivationPath
-    -> "root" :! PublicKey  -> "address" :! PublicKey  -> Address
-makePubKeyHdwAddressUsingPath era (DerivationPath derPath) (Arg rootPK) (Arg addrPK) =
-    makePubKeyHdwAddress era hdPayload addrPK
+    -> "root" :! PublicKey -> "address" :! PublicKey -> Address
+makePubKeyHdwAddressUsingPath nm era (DerivationPath derPath)
+  (Arg rootPK) (Arg addrPK) =
+    makePubKeyHdwAddress nm era hdPayload addrPK
   where
     hdPP = deriveHDPassphrase rootPK
     hdPayload = packHDAddressAttr hdPP derPath

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Internal.hs
@@ -12,13 +12,14 @@ module Ariadne.Wallet.Cardano.Kernel.Internal
        , walletKeystore
        , wallets
        , walletLogMessage
+       , walletProtocolMagic
        ) where
 
-import Control.Lens.TH
-
+import Control.Lens.TH (makeLenses)
+import Data.Acid (AcidState)
 import System.Wlog (Severity(..))
 
-import Data.Acid (AcidState)
+import Pos.Crypto (ProtocolMagic)
 
 import Ariadne.Wallet.Cardano.Kernel.DB.AcidState (DB)
 import Ariadne.Wallet.Cardano.Kernel.Keystore (Keystore)
@@ -35,10 +36,13 @@ import Ariadne.Wallet.Cardano.Kernel.Keystore (Keystore)
 data PassiveWallet = PassiveWallet {
       -- | Send log message
       _walletLogMessage :: Severity -> Text -> IO ()
-      -- ^ Logger
-    , _walletKeystore   :: Keystore
-      -- ^ An opaque handle to a place where we store the 'EncryptedSecretKey'.
-    , _wallets          :: AcidState DB
+      -- | An opaque handle to a place where we store the 'EncryptedSecretKey'.
+    , _walletKeystore :: Keystore
+      -- | Database handle
+    , _wallets :: AcidState DB
+      -- | The protocol magic used by an `ActiveWallet` to make transactions.
+    , _walletProtocolMagic :: ProtocolMagic
+
     }
 
 makeLenses ''PassiveWallet

--- a/ariadne/cardano/test/backend/Test/Infrastructure/Generator.hs
+++ b/ariadne/cardano/test/backend/Test/Infrastructure/Generator.hs
@@ -128,6 +128,9 @@ cardanoModel linearFeePolicy boot = GeneratorModel {
     , gmMaxNumOurs    = 5
     }
 
+-- [AD-500]
+-- @gromak: FIXME: this function is somewhat broken: it doesn't account
+-- for witnesses and tests pass only by accident.
 {-| Estimate the size of a transaction, in bytes.
 
      The magic numbers appearing in the formula have the following origins:
@@ -177,7 +180,7 @@ estimateSize saa sta ins outs
 --         here with some (hopefully) realistic values.
 estimateCardanoFee :: TxSizeLinear -> Int -> [Value] -> Value
 estimateCardanoFee linearFeePolicy ins outs
-    = round (calculateTxSizeLinear linearFeePolicy (estimateSize 128 16 ins outs))
+    = round (calculateTxSizeLinear linearFeePolicy (estimateSize 132 16 ins outs))
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ariadne/cardano/test/backend/Test/Spec/CreateWallet.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/CreateWallet.hs
@@ -76,7 +76,8 @@ spec = describe "CreateWallet" $ do
         prop "works as expected in the happy path scenario" $ withMaxSuccess 50 $ do
             monadicIO $ do
                 request <- genNewWalletRq =<< genSpendingPassword
-                withLayer $ \layer _ -> do
+                pm <- pick arbitrary
+                withLayer pm $ \layer _ -> do
                     liftIO $ do
                         res <- (WalletLayer.pwlCreateWallet layer) `applyNewWallet` request
                         (bimap STB STB res) `shouldSatisfy` isRight
@@ -84,7 +85,8 @@ spec = describe "CreateWallet" $ do
         prop "fails if the wallet already exists" $ withMaxSuccess 50 $ do
             monadicIO $ do
                 request <- genNewWalletRq =<< genSpendingPassword
-                withLayer $ \layer _ -> do
+                pm <- pick arbitrary
+                withLayer pm $ \layer _ -> do
                     liftIO $ do
                         -- The first time it must succeed.
                         res1 <- (WalletLayer.pwlCreateWallet layer) `applyNewWallet` request
@@ -101,7 +103,8 @@ spec = describe "CreateWallet" $ do
         prop "supports Unicode characters" $ withMaxSuccess 1 $ do
             monadicIO $ do
                 request <- genNewWalletRq =<< genSpendingPassword
-                withLayer $ \layer _ -> do
+                pm <- pick arbitrary
+                withLayer pm $ \layer _ -> do
                     let w' = request { newwalName = "İıÀļƒȑĕďŏŨƞįťŢęșťıİ 日本" }
                     liftIO $ do
                         res <- (WalletLayer.pwlCreateWallet layer) `applyNewWallet` w'
@@ -113,7 +116,8 @@ spec = describe "CreateWallet" $ do
             monadicIO $ do
                 request <- genNewWalletRq =<< genSpendingPassword
 
-                withLayer @IO $ \_ wallet -> do
+                pm <- pick arbitrary
+                withLayer @IO pm $ \_ wallet -> do
                     liftIO $ do
                         res <- (Kernel.createHdWallet wallet) `applyNewWallet` request
                         case res of

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/serokell/cardano-sl
-  commit: 5705ea928eb673ed24e854e397103dd541851d4f # ariadne branch
+  commit: 2986b304d8b89a14f1fd9be031f626d1c8a45088 # ariadne branch
   subdirs:
   - binary
   - binary/test
@@ -63,7 +63,7 @@ extra-deps:
   # We're waiting on next release
   commit: da4247b5b3420120e20451e6a252e2a2ca15b43c
 - git: https://github.com/input-output-hk/cardano-report-server
-  commit: 81eea7361a75923f9402fcb7840fb36722dbf88e # master 0.4.10
+  commit: 9b96874d0f234554a5779d98762cc0a6773a532a
 
 # These three are needed for cardano-sl-networking
 - git: https://github.com/serokell/network-transport-tcp
@@ -74,6 +74,9 @@ extra-deps:
   commit: 5d8ff2b07b9df35cf61329a3d975e2c8cf95c12a
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 33c7ecc6e4bd71c3ea0195e9d796eeace7be22cf
+  # to be removed when haskell-ip is in the current stackage version
+- git: https://github.com/andrewthad/haskell-ip
+  commit: 9bb453139aa82cc973125091800422a523e1eb8f
 
 # Required for explorer.
 # We forked it because it has some unacceptable version bounds. We didn't


### PR DESCRIPTION
**Description:**

cardano-sl in `ariadne` branch was bumped to 1.3.1.
See https://github.com/serokell/cardano-sl/pull/43
The most intrusive change is the addition of 'NetworkMagic'.

I had to swap the order of creation of Cardano and Wallet backends,
because Wallet backend creation now needs 'ProtocolMagic', which
is obtained from Cardano.

**YT issue:** https://issues.serokell.io/issue/AD-481

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
