### PR TITLE
[AD-488] Change hedgehog revision to existing one

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -101,7 +101,7 @@ extra-deps:
   commit: 1049699df411c9584523ba7424cba1f3f82ac419
 
 - git: https://github.com/input-output-hk/haskell-hedgehog
-  commit: 2c9e51804e8217dff89f5c32cbe0d79ce20bc508
+  commit: 2e741bb53afb085741807018948ae17d956c53af
   subdirs:
   - hedgehog
 


### PR DESCRIPTION
**Description:**

2c9e51804e8217dff89f5c32cbe0d79ce20bc508 doesn't exist anymore.

**YT issue:** https://issues.serokell.io/issue/AD-488

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
