### PR TITLE
[AD-489] remove pwlGetDBSnapshot from addWallet

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -336,19 +336,13 @@ addWallet ::
 addWallet pwl WalletFace {..} esk mbWalletName utxoByAccount hasPP createWithA assurance = do
   walletName <-
       fromMaybe
-      (genWalletName <$> pwlGetDBSnapshot pwl)
+      (pure $ WalletName "Untitled wallet")
       (pure <$> mbWalletName)
 
   throwLeftIO $ void <$>
     pwlCreateWallet pwl esk hasPP createWithA assurance walletName utxoByAccount
 
   walletRefreshState
-  where
-    genWalletName :: DB -> WalletName
-    genWalletName walletDb = do -- no monad
-      let hdRoots = toList (walletDb ^. dbHdWallets . hdWalletsRoots)
-          namesVec = V.fromList $ map (unWalletName . view hdRootName) hdRoots
-      WalletName $ mkUntitled "Untitled wallet " namesVec
 
 -- | Convert path in index representation and write it to
 -- 'IORef WalletSelection'.

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -334,10 +334,7 @@ addWallet ::
     -> AssuranceLevel
     -> IO ()
 addWallet pwl WalletFace {..} esk mbWalletName utxoByAccount hasPP createWithA assurance = do
-  walletName <-
-      fromMaybe
-      (pure $ WalletName "Untitled wallet")
-      (pure <$> mbWalletName)
+  let walletName = fromMaybe (WalletName "Untitled wallet") mbWalletName
 
   throwLeftIO $ void <$>
     pwlCreateWallet pwl esk hasPP createWithA assurance walletName utxoByAccount

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -27,11 +27,8 @@ import qualified Universum.Unsafe as Unsafe
 
 import Control.Exception (Exception(displayException))
 import Control.Lens (ix)
-import qualified Data.Text as T
 import qualified Data.Text.Buildable
-import qualified Data.Vector as V (fromList, mapMaybe)
 import Formatting (bprint, int, (%))
-import Numeric.Natural (Natural)
 import Serokell.Data.Memory.Units (Byte)
 
 import Pos.Core (mkCoin)
@@ -262,20 +259,16 @@ newAccount
   -> IO ()
 newAccount pwl WalletFace{..} walletSelRef walletRef mbAccountName = do
   walletDb <- pwlGetDBSnapshot pwl
-  (hdrId, accList) <- second toList <$>
+  (hdrId, _) <- second toList <$>
       resolveWalletRefThenRead walletSelRef walletRef walletDb readAccountsByRootId
 
-  let accountName = fromMaybe (genAccountName accList) mbAccountName
+  let accountName = fromMaybe (AccountName "Untitled account ") mbAccountName
 
   throwLeftIO $ void <$>
     pwlCreateAccount pwl hdrId accountName
 
   walletRefreshState
-  where
-    genAccountName :: [HdAccount] -> AccountName
-    genAccountName accList =
-      let namesVec = V.fromList $ map (unAccountName . view hdAccountName) accList
-      in AccountName $ mkUntitled "Untitled account " namesVec
+
 
 data InvalidEntropySize =
     InvalidEntropySize !Byte
@@ -437,11 +430,3 @@ renameSelection pwl WalletFace{..} walletSelRef name = do
 
 throwLeftIO :: (Exception e) => IO (Either e a) -> IO a
 throwLeftIO ioEith = ioEith >>= eitherToThrow
-
-mkUntitled :: Text -> Vector Text -> Text
-mkUntitled untitled namesVec = do -- no monad
-  let untitledSuffixes = V.mapMaybe (T.stripPrefix $ untitled) namesVec
-      numbers = V.mapMaybe ((readMaybe @Natural) . toString) untitledSuffixes
-  if null untitledSuffixes || null numbers
-      then untitled <> "0"
-      else untitled <> (show $ (maximum numbers) + 1)

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -259,10 +259,9 @@ newAccount
   -> IO ()
 newAccount pwl WalletFace{..} walletSelRef walletRef mbAccountName = do
   walletDb <- pwlGetDBSnapshot pwl
-  (hdrId, _) <- second toList <$>
-      resolveWalletRefThenRead walletSelRef walletRef walletDb readAccountsByRootId
+  hdrId <- resolveWalletRef walletSelRef walletRef walletDb
 
-  let accountName = fromMaybe (AccountName "Untitled account ") mbAccountName
+  let accountName = fromMaybe (AccountName "Untitled account") mbAccountName
 
   throwLeftIO $ void <$>
     pwlCreateAccount pwl hdrId accountName


### PR DESCRIPTION
**Description:** Drop logic for creation of unique wallet name and set default wallet name to "Untitled wallet" within `addWallet` function

**YT issue:** https://issues.serokell.io/issue/AD-489

**Checklist:**

- [x] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [GUI usage guide](docs/usage-gui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
  - [ ] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
