### PR TITLE
[AD-491] remove DB from comfirmationType

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Face.hs
@@ -10,6 +10,7 @@ module Ariadne.Wallet.Face
        , AccountReference(..)
        , LocalAccountReference(..)
        , WalletSelection(..)
+       , AccountName(..)
        , WalletName(..)
        , Mnemonic(..)
        , WalletRestoreType (..)
@@ -97,7 +98,8 @@ data WalletEvent
 
 data ConfirmationType
   = ConfirmMnemonic [Text]           -- ^ mnemonic
-  | ConfirmRemove DB WalletSelection -- ^ walletDB, selection
+  | ConfrimRemoveWallet WalletName
+  | ConfirmRemoveAccount AccountName
   | ConfirmSend [ConfirmSendInfo]    -- ^ lists of outputs' info
 
 data ConfirmSendInfo =

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -280,10 +280,10 @@ walletEventToUI = \case
   WalletRequireConfirm resVar confirmationType ->
     Just . UiConfirmEvent . UiConfirmRequest resVar $ case confirmationType of
       ConfirmMnemonic mnemonic -> UiConfirmMnemonic mnemonic
-      ConfirmRemove db sel     -> UiConfirmRemove $
-        case walletSelectionToInfo (toUiWalletDatas db) $ toUiWalletSelection db sel of
-          UiSelectionWallet UiWalletInfo {..} -> UiDelWallet uwiLabel
-          UiSelectionAccount UiAccountInfo {..} -> UiDelAccount uaciLabel
+      ConfrimRemoveWallet walletName ->
+          UiConfirmRemove $ UiDelWallet $ Just $ unWalletName walletName
+      ConfirmRemoveAccount accountName ->
+          UiConfirmRemove $ UiDelAccount $ Just $ unAccountName accountName
       ConfirmSend confsendInfo -> UiConfirmSend $ map toUiConfirmSendInfo confsendInfo
 
 toUiConfirmSendInfo :: ConfirmSendInfo -> UiConfirmSendInfo

--- a/ui/vty-app/Glue.hs
+++ b/ui/vty-app/Glue.hs
@@ -303,10 +303,10 @@ walletEventToUI = \case
   WalletRequireConfirm resVar confirmationType ->
     Just . UiConfirmEvent . UiConfirmRequest resVar $ case confirmationType of
       ConfirmMnemonic mnemonic -> UiConfirmMnemonic mnemonic
-      ConfirmRemove db sel     -> UiConfirmRemove $
-        case walletSelectionToInfo (toUiWalletDatas db) $ toUiWalletSelection db sel of
-          UiSelectionWallet UiWalletInfo {..} -> UiDelWallet uwiLabel
-          UiSelectionAccount UiAccountInfo {..} -> UiDelAccount uaciLabel
+      ConfrimRemoveWallet walletName ->
+        UiConfirmRemove $ UiDelWallet $ Just $ unWalletName walletName
+      ConfirmRemoveAccount accountName ->
+        UiConfirmRemove $ UiDelAccount $ Just $ unAccountName accountName
       ConfirmSend confsendInfo -> UiConfirmSend $ map toUiConfirmSendInfo confsendInfo
 
 toUiConfirmSendInfo :: ConfirmSendInfo -> UiConfirmSendInfo


### PR DESCRIPTION
**Description:** Replace confirmRemove constructors with two constructors: `ConfirmRemoveWallet WalletName` and `ConfirmRemoveAccount AccountName`.

**YT issue:** https://issues.serokell.io/issue/AD-491

**Checklist:**

- [x] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [GUI usage guide](docs/usage-gui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
  - [ ] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
