### PR TITLE
[AD-398] Display of validation errors in dialogs

### DIFF
--- a/ariadne/cardano/src/Ariadne/Cardano/Knit.hs
+++ b/ariadne/cardano/src/Ariadne/Cardano/Knit.hs
@@ -17,6 +17,7 @@ module Ariadne.Cardano.Knit
        , ComponentCommandProcs(..)
 
        , showCoin
+       , adaToCoin
        , txOutCommandName
        , tyPublicKey
        , tyTxOut

--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -18,6 +18,7 @@ import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.Cardano.Backend (CardanoBackend(..), createCardanoBackend)
 import Ariadne.Cardano.Face (CardanoEvent, CardanoFace(..), decodeTextAddress)
+import Ariadne.Cardano.Knit (adaToCoin)
 import Ariadne.Config.Ariadne (AriadneConfig(..))
 import Ariadne.Config.CLI (getConfig)
 import Ariadne.Config.History (HistoryConfig(..))
@@ -100,7 +101,8 @@ initializeEverything MainSettings {..}
     walletUIFace = WalletUIFace
       { walletGenerateMnemonic = generateMnemonic
       , walletDefaultEntropySize = wcEntropySize walletConfig
-      , walletValidateAddress = isRight . decodeTextAddress
+      , walletValidateAddress = leftToMaybe . decodeTextAddress
+      , walletValidateCoin = isJust . adaToCoin
       , walletCoinPrecision = 6
       }
   PasswordManager {..} <- createPasswordManager

--- a/ariadne/cardano/src/Ariadne/Wallet/Face.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Face.hs
@@ -21,6 +21,7 @@ module Ariadne.Wallet.Face
        , walletPassExceptionFromException
        ) where
 
+import Data.Scientific (Scientific)
 import Data.Typeable (cast)
 import qualified GHC.Show as Show (Show(show))
 
@@ -113,7 +114,8 @@ data WalletUIFace =
   WalletUIFace
     { walletGenerateMnemonic :: Byte -> IO [Text]
     , walletDefaultEntropySize :: Byte
-    , walletValidateAddress :: Text -> Bool
+    , walletValidateAddress :: Text -> Maybe Text
+    , walletValidateCoin :: Scientific -> Bool
     , walletCoinPrecision :: Int
     }
 

--- a/ui/qt-app/Main.hs
+++ b/ui/qt-app/Main.hs
@@ -45,6 +45,7 @@ main = defaultMain mainSettings
             { uiGenerateMnemonic = walletGenerateMnemonic
             , uiDefaultEntropySize = walletDefaultEntropySize
             , uiValidateAddress = walletValidateAddress
+            , uiValidateCoin = walletValidateCoin
             , uiCoinPrecision = walletCoinPrecision
             }
         in createAriadneUI uiWalletFace historyFace putPass

--- a/ui/qt-lib/package.yaml
+++ b/ui/qt-lib/package.yaml
@@ -35,6 +35,7 @@ library:
     - stm
     - text
     - open-browser
+    - validation
 
 custom-setup:
   dependencies:

--- a/ui/qt-lib/resources/stylesheet.qss
+++ b/ui/qt-lib/resources/stylesheet.qss
@@ -481,5 +481,13 @@ QDialog QLineEdit#sendAmountEdit, QDialog QLineEdit#sendAmountEdit:focus {
     qproperty-alignment: AlignRight;
 }
 
+QWidget[styleRole="validationErrorDisplay"] {
+    font-size: 14px;
+    background: #ca5000;
+}
+QWidget[styleRole="validationErrorDisplay"] QLabel {
+    color: #fafafa;
+}
+
 /* vim: ft=css
 */

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -182,7 +182,8 @@ data UiWalletFace =
   UiWalletFace
     { uiGenerateMnemonic :: Byte -> IO [Text]
     , uiDefaultEntropySize :: Byte
-    , uiValidateAddress :: Text -> Bool
+    , uiValidateAddress :: Text -> Maybe Text
+    , uiValidateCoin :: Scientific -> Bool
     , uiCoinPrecision :: Int
     }
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Util.hs
@@ -1,5 +1,5 @@
 module Ariadne.UI.Qt.Widgets.Dialogs.Util
-       ( CheckboxPosition (..) 
+       ( CheckboxPosition (..)
        , createLayout
        , addHeader
        , addRow
@@ -10,15 +10,17 @@ module Ariadne.UI.Qt.Widgets.Dialogs.Util
        , createCheckBoxWithLabel
        , createPasswordField
        , createRowLayout
+       , onEventType
        ) where
 
-import Data.Bits
+import Data.Bits ((.|.))
 
 import Graphics.UI.Qtah.Core.Types (alignHCenter, alignVCenter)
 import Graphics.UI.Qtah.Signal (connect_)
 import Graphics.UI.Qtah.Widgets.QSizePolicy (QSizePolicyPolicy(..))
 
 import qualified Graphics.UI.Qtah.Core.QEvent as QEvent
+import qualified Graphics.UI.Qtah.Core.QObject as QObject
 import qualified Graphics.UI.Qtah.Event as Event
 import qualified Graphics.UI.Qtah.Gui.QIcon as QIcon
 import qualified Graphics.UI.Qtah.Gui.QMouseEvent as QMouseEvent
@@ -169,3 +171,10 @@ createPasswordField placeholder = do
     connect_ visibleButton QAbstractButton.toggledSignal togglePasswordVisibility
 
     return (layout, field)
+
+-- | Handle general 'QEvent' by passing the handler its 'QEvent.QEventType' and returning
+-- 'False' to Qt to continue event propagation.
+onEventType :: QObject.QObjectPtr this => this -> (QEvent.QEventType -> IO ()) -> IO ()
+onEventType this handler = void $
+  Event.onEvent this $ QEvent.eventType @QEvent.QEvent >=> (False <$) . handler
+

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Validation.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/Validation.hs
@@ -1,0 +1,146 @@
+module Ariadne.UI.Qt.Widgets.Dialogs.Validation
+  ( Validations
+  , createValidations
+  , showErrors
+  , showErrorsV
+  )
+  where
+
+import Data.Bifoldable (bitraverse_)
+import qualified Data.Map.Strict as Map
+import Data.Validation (Validation)
+
+import Graphics.UI.Qtah.Core.HPoint (HPoint(..))
+import Graphics.UI.Qtah.Core.HSize (HSize(..))
+import Graphics.UI.Qtah.Signal (connect_)
+import Graphics.UI.Qtah.Widgets.QSizePolicy (QSizePolicyPolicy(..))
+
+import qualified Graphics.UI.Qtah.Core.QEvent as QEvent
+import qualified Graphics.UI.Qtah.Core.QObject as QObject
+import qualified Graphics.UI.Qtah.Widgets.QBoxLayout as QBoxLayout
+import qualified Graphics.UI.Qtah.Widgets.QLabel as QLabel
+import qualified Graphics.UI.Qtah.Widgets.QLayout as QLayout
+import qualified Graphics.UI.Qtah.Widgets.QVBoxLayout as QVBoxLayout
+import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
+
+import Ariadne.UI.Qt.UI
+import Ariadne.UI.Qt.Widgets.Dialogs.Util
+
+data ValidationDisplay =
+  ValidationDisplay
+    { display :: QWidget.QWidget
+    , label :: QLabel.QLabel
+    , widget :: QWidget.QWidget
+    , hasError :: IORef Bool
+    , hasFocus :: IORef Bool
+    }
+
+createValidationErrorDisplay :: QWidget.QWidgetPtr wgt => wgt -> Text -> IO ValidationDisplay
+createValidationErrorDisplay (QWidget.cast -> widget) message = do
+  display <- QWidget.new
+  layout <- QVBoxLayout.new
+  QWidget.setLayout display layout
+  label <- QLabel.newWithText $ toString message
+  QBoxLayout.addWidget layout label
+
+  QLabel.setWordWrap label True
+  QWidget.setSizePolicyRaw label Minimum Minimum
+  QLayout.setSizeConstraint layout QLayout.SetMinimumSize
+
+  setProperty display ("styleRole" :: Text) ("validationErrorDisplay" :: Text)
+
+  hasError <- newIORef False
+  hasFocus <- newIORef False
+
+  return ValidationDisplay{..}
+
+attachValidationDisplay ::
+  (QWidget.QWidgetPtr wnd) =>
+  wnd -> ValidationDisplay -> IO ()
+attachValidationDisplay window vd@ValidationDisplay{..} = do
+  QWidget.setParent display window
+
+  connect_ window QObject.destroyedSignal $ \_ -> QObject.deleteLater display
+
+  QWidget.adjustSize display
+  QWidget.raise display
+
+  onEventType window $ \case
+    QEvent.Move -> moveDisplay vd
+    QEvent.Resize -> moveDisplay vd
+    QEvent.Hide -> QWidget.hide display
+    QEvent.Show -> do
+      hadError <- readIORef hasError
+      hadFocus <- readIORef hasFocus
+
+      QWidget.setVisible display $ hadError && not hadFocus
+    _ -> pass
+  onEventType widget $ \case
+    QEvent.FocusIn -> toggleFocus True
+    QEvent.FocusOut -> toggleFocus False
+    _ -> pass
+
+  where
+    toggleFocus setHasFocus = do
+      vHasError <- readIORef hasError
+      when vHasError $ QWidget.setVisible display $ not setHasFocus
+      writeIORef hasFocus setHasFocus
+
+moveDisplay :: ValidationDisplay -> IO ()
+moveDisplay ValidationDisplay{..} = do
+  HSize{width = widgetWidth, height = widgetHeight} <- QWidget.size widget
+  HSize{height = displayHeight} <- QWidget.size display
+
+  QWidget.resize display $ HSize{width = 2 * widgetWidth, height = displayHeight}
+  QWidget.adjustSize label
+  QWidget.adjustSize display
+
+  HSize{width = displayWidth'} <- QWidget.size display
+  HPoint{x = widgetX, y = widgetY} <- QWidget.pos widget
+
+  let displayPos = HPoint{x = widgetX + widgetWidth - displayWidth', y = widgetY + widgetHeight + 4}
+  QWidget.move display displayPos
+
+setMessage :: ValidationDisplay -> Text -> IO ()
+setMessage vd@ValidationDisplay{..} message = do
+  QLabel.setText label $ toString message
+  moveDisplay vd
+
+showError :: ValidationDisplay -> Bool -> IO ()
+showError ValidationDisplay{..} newHasError = do
+  hadFocus <- readIORef hasFocus
+  writeIORef hasError newHasError
+  unless hadFocus $ do
+    QWidget.setVisible display newHasError
+    QWidget.raise display
+
+newtype Validations = Validations (Map.Map QWidget.QWidget ValidationDisplay)
+
+newValidations :: Validations
+newValidations = Validations Map.empty
+
+addValidation :: QWidget.QWidgetPtr wnd => Validations -> Text -> wnd -> QWidget.QWidget -> IO Validations
+addValidation (Validations vals) message window widget = do
+  validation <- createValidationErrorDisplay widget message
+  attachValidationDisplay window validation
+
+  return $ Validations $ Map.insert widget validation vals
+
+createValidations :: QWidget.QWidgetPtr wnd => wnd -> [(Text, QWidget.QWidget)] -> IO Validations
+createValidations window =
+  foldlM (\vals (message, widget) -> addValidation vals message window widget) newValidations
+
+showErrors :: Validations -> [(Maybe Text, QWidget.QWidget)] -> IO ()
+showErrors (Validations vals) errors = do
+  forM_ (toList vals) $ flip showError False
+  forM_ errors $ \(mtext, err) -> do
+    let val = vals Map.! err
+    showError val True
+    whenJust mtext $ setMessage val
+
+showErrorsV :: Validations -> Validation [e] a -> (e -> Maybe (Maybe Text, QWidget.QWidget)) -> IO ()
+showErrorsV vals validation renderError =
+  bitraverse_
+    (showErrors vals . mapMaybe renderError)
+    (const $ showErrors vals [])
+    validation


### PR DESCRIPTION
**Description:**

Display validation errors for inputs in dialogs.

Known problems:

- [ ] No rounded corners -- unfixable in Qt without much effort (QRegion stuff, AD-315)
- [ ] Validation messages always stay on top, even when send dialog is minimized or WM switches to another window. Also they sometimes steal focus. I did not find a way to fix this :pepe_sad:
- [ ] Validations are implemented only for Send dialog
- [ ] Validation is shown 24px to the right of the input widget. This breaks for send amount input, since widget has ":ada:" label to the right. Validation API can be extended to take care of 1. input widget, responsible for focus 2. anchor widget, responsible for placement of error message

**YT issue:** https://issues.serokell.io/issue/AD-398

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
