### PR TITLE
[AD-496] Hide newWallet logic behind PassiveWalletLayer

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -22,6 +22,7 @@ module Ariadne.Wallet.Backend.KeyStorage
          -- * Util
        , generateMnemonic
        ) where
+import qualified Universum.Unsafe as Unsafe (init)
 
 import Control.Exception (Exception(displayException))
 import Control.Lens (ix)
@@ -303,7 +304,7 @@ newWallet pwl walletConfig face getPassTemp waitUiConfirm noConfirm mbWalletName
   unless noConfirm $
     unlessM (waitUiConfirm $ ConfirmMnemonic mnemonic) $
       throwM WGFailedUnconfirmedMnemonic
-  esk <- pwlCreateEncryptedKey pwl pp mnemonic
+  esk <- pwlCreateEncryptedKey pwl pp $ Unsafe.init mnemonic
   mnemonic <$
     addWallet pwl face esk mbWalletName mempty (mkHasPP pp) (WithAddress pp) assurance
   where

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -23,8 +23,6 @@ module Ariadne.Wallet.Backend.KeyStorage
        , generateMnemonic
        ) where
 
-import qualified Universum.Unsafe as Unsafe
-
 import Control.Exception (Exception(displayException))
 import Control.Lens (ix)
 import qualified Data.Text.Buildable
@@ -38,8 +36,7 @@ import Pos.Util (eitherToThrow, maybeThrow)
 
 import Ariadne.Cardano.Face
 import Ariadne.Config.Wallet (WalletConfig(..))
-import Ariadne.Wallet.Cardano.Kernel.Bip39
-  (entropyToMnemonic, mnemonicToSeedNoPassword)
+import Ariadne.Wallet.Cardano.Kernel.Bip39 (entropyToMnemonic)
 import Ariadne.Wallet.Cardano.Kernel.DB.AcidState
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet.Derivation (deriveBip44KeyPair)
@@ -306,8 +303,7 @@ newWallet pwl walletConfig face getPassTemp waitUiConfirm noConfirm mbWalletName
   unless noConfirm $
     unlessM (waitUiConfirm $ ConfirmMnemonic mnemonic) $
       throwM WGFailedUnconfirmedMnemonic
-  let seed = mnemonicToSeedNoPassword $ unwords $ Unsafe.init mnemonic
-      (_, esk) = safeDeterministicKeyGen seed pp
+  esk <- pwlCreateEncryptedKey pwl pp mnemonic
   mnemonic <$
     addWallet pwl face esk mbWalletName mempty (mkHasPP pp) (WithAddress pp) assurance
   where

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Kernel.hs
@@ -3,7 +3,7 @@ module Ariadne.Wallet.Cardano.WalletLayer.Kernel
        , passiveWalletLayerCustomDBComponent
        ) where
 
-import qualified Universum.Unsafe as Unsafe (fromJust, init)
+import qualified Universum.Unsafe as Unsafe (fromJust)
 
 import Control.Monad.Component (ComponentM, buildComponent)
 import Data.Acid (AcidState, closeAcidState, openLocalStateFrom)
@@ -130,7 +130,7 @@ passiveWalletLayerCustomDBComponent logFunction keystore acidDB = do
             , pwlRollbackBlocks        = liftIO . invoke . Actions.RollbackBlocks
 
             , pwlCreateEncryptedKey = \pp mnemonic ->
-                let seed     = mnemonicToSeedNoPassword $ unwords $ Unsafe.init mnemonic
+                let seed     = mnemonicToSeedNoPassword $ unwords mnemonic
                     (_, esk) = safeDeterministicKeyGen seed pp
                 in pure esk
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer/Types.hs
@@ -16,6 +16,8 @@ import Pos.Core (Coin)
 import Pos.Core.Chrono (NE, NewestFirst(..), OldestFirst(..))
 import Pos.Crypto (EncryptedSecretKey, PassPhrase)
 
+type Mnemonic = [Text]
+
 ------------------------------------------------------------
 -- Passive wallet layer
 ------------------------------------------------------------
@@ -90,6 +92,12 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , pwlRollbackBlocks
           :: NewestFirst NE Blund
           -> m ()
+
+    -- | generate EncryptedSecretKey
+    , pwlCreateEncryptedKey
+        :: PassPhrase
+        -> Mnemonic
+        -> m EncryptedSecretKey
 
     -- | internal, hopefully these will go in the future
     , pwlGetDBSnapshot


### PR DESCRIPTION
**Description:** newWallet uses mnemonicToSeedNoPassword and safeDeterministicKeyGen. We should hide this logic behind PassiveWalletLayer.

**YT issue:** https://issues.serokell.io/issue/AD-496

**Checklist:**

- [x] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [GUI usage guide](docs/usage-gui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
  - [ ] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
