### PR TITLE
[AD-476] Add Account Settings dialog

### DIFF
--- a/docs/usage-gui.md
+++ b/docs/usage-gui.md
@@ -52,6 +52,9 @@ If you want to delete an account or a wallet, just click "Delete" button in the 
 deleting a wallet is a rather dangerous operation, you will be asked to enter its name to confirm
 you understand what you are doing.
 
+When an account is selected you can open its settings by clicking the "Account settings" button in
+the wallet pane. A dialog will open where you can change your account's name or delete it.
+
 ## Blockchain operations
 
 Wallet pane has two buttons for working with the blockchain &mdash; "SEND" and "REQUEST". Both will

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -153,6 +153,11 @@ knitFaceToUI UiFace{..} KnitFace{..} putPass =
             ]
           )
 
+      UiRename newName -> do
+        Right $ exprProcCall
+          (procCall Knit.renameCommandName $
+            [argKw "name" . exprLit . Knit.toLit . Knit.LitString $ newName]
+          )
       UiRemoveCurrentItem -> do
         Right $ exprProcCall $ procCall Knit.removeCommandName []
 

--- a/ui/qt-lib/resources/stylesheet.qss
+++ b/ui/qt-lib/resources/stylesheet.qss
@@ -275,6 +275,14 @@ QDialog QPushButton[dialogButtonRole="dialogAction"] {
     padding-right: 80px;
 }
 
+QDialog QPushButton[dialogButtonRole="textDangerButton"] {
+    font-size: 14px;
+    font-weight: bold;
+    background: transparent;
+    color: #ca5000;
+    border: none;
+}
+
 QDialog QPushButton[dialogButtonRole="gifButton"] {
     font-weight: bold;
     padding-top: 18px;

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -105,6 +105,7 @@ data UiCommand
   | UiRestoreWallet Text (Maybe Text) Text Bool -- ^ Name, password, mnemonic, full restore
   | UiNewAccount Text  -- ^ Name
   | UiNewAddress Word Word -- ^ Wallet index, account index
+  | UiRename Text -- ^ New name
   | UiKill Natural
   | UiRemoveCurrentItem
 

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/AccountSettings.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Widgets/Dialogs/AccountSettings.hs
@@ -1,0 +1,97 @@
+module Ariadne.UI.Qt.Widgets.Dialogs.AccountSettings
+  ( RenameHandler
+  , DeleteHandler
+  , runAccountSettings
+  ) where
+
+import qualified Data.Text as T
+import Graphics.UI.Qtah.Core.HSize (HSize(..))
+import Graphics.UI.Qtah.Core.Types (QtCursorShape(..))
+import Graphics.UI.Qtah.Signal (connect_)
+
+import qualified Graphics.UI.Qtah.Core.QEvent as QEvent
+import qualified Graphics.UI.Qtah.Event as Event
+import qualified Graphics.UI.Qtah.Gui.QCursor as QCursor
+import qualified Graphics.UI.Qtah.Gui.QMouseEvent as QMouseEvent
+import qualified Graphics.UI.Qtah.Widgets.QAbstractButton as QAbstractButton
+import qualified Graphics.UI.Qtah.Widgets.QApplication as QApplication
+import qualified Graphics.UI.Qtah.Widgets.QBoxLayout as QBoxLayout
+import qualified Graphics.UI.Qtah.Widgets.QDialog as QDialog
+import qualified Graphics.UI.Qtah.Widgets.QHBoxLayout as QHBoxLayout
+import qualified Graphics.UI.Qtah.Widgets.QLabel as QLabel
+import qualified Graphics.UI.Qtah.Widgets.QLineEdit as QLineEdit
+import qualified Graphics.UI.Qtah.Widgets.QPushButton as QPushButton
+import qualified Graphics.UI.Qtah.Widgets.QWidget as QWidget
+
+import Ariadne.UI.Qt.UI
+import Ariadne.UI.Qt.Widgets.Dialogs.Util
+
+data AccountSettings =
+  AccountSettings
+    { accountSettings :: QDialog.QDialog
+    }
+
+type RenameHandler = Text -> IO ()
+type DeleteHandler = IO ()
+
+initAccountSettings :: Text -> RenameHandler -> DeleteHandler -> IO AccountSettings
+initAccountSettings currentName renameHandler deleteHandler = do
+  accountSettings <- QDialog.new
+  layout <- createLayout accountSettings
+
+  let headerString = toString $ T.toUpper "ACCOUNT SETTINGS"
+
+  QWidget.setWindowTitle accountSettings headerString
+
+  header <- QLabel.newWithText headerString
+  addHeader layout header
+
+  accountNameLabel <- QLabel.newWithText ("ACCOUNT NAME" :: String)
+  accountNameEdit <- QLineEdit.newWithText $ toString currentName
+
+  addRow layout accountNameLabel accountNameEdit
+
+  pointingCursor <- QCursor.newWithCursorShape PointingHandCursor
+  buttonsLayout <- QHBoxLayout.new
+  deleteButton <- QPushButton.newWithText ("Delete account" :: String)
+  QWidget.setCursor deleteButton pointingCursor
+
+  QBoxLayout.addStretch buttonsLayout
+  QBoxLayout.addWidget buttonsLayout deleteButton
+  QBoxLayout.addStretch buttonsLayout
+
+  QBoxLayout.addLayout layout buttonsLayout
+
+  QPushButton.setDefault deleteButton False
+  QPushButton.setAutoDefault deleteButton False
+
+  setProperty deleteButton ("dialogButtonRole" :: Text) ("textDangerButton" :: Text)
+
+  let asettings = AccountSettings{..}
+
+  connect_ deleteButton QAbstractButton.clickedSignal $ \_ ->
+    deleteHandler >> QDialog.accept accountSettings
+  connect_ accountNameEdit QLineEdit.editingFinishedSignal $
+    QLineEdit.text accountNameEdit <&> fromString >>= renameHandler
+
+  QWidget.adjustSize accountSettings
+  -- Let user resize the dialog, but not too much
+  HSize{width = asWidth, height = asHeight} <- QWidget.size accountSettings
+  QWidget.setMinimumSize accountSettings $ HSize{width = asWidth, height = asHeight}
+  QWidget.setMaximumSize accountSettings $ HSize{width = 2 * asWidth, height = asHeight}
+
+  -- This unfocuses any focused widget when user clicks outside input fields,
+  -- essentially triggering editingFinished signal.
+  void $ Event.onEvent accountSettings $ \(ev :: QMouseEvent.QMouseEvent) -> do
+    evType <- QEvent.eventType ev
+    when (evType == QEvent.MouseButtonRelease) $
+      QApplication.focusWidget >>= QWidget.clearFocus
+    return False
+
+  return asettings
+
+runAccountSettings :: Text -> RenameHandler -> DeleteHandler -> IO ()
+runAccountSettings currentName renameHandler deleteHandler = do
+  AccountSettings{..} <- initAccountSettings currentName renameHandler deleteHandler
+
+  void $ QDialog.exec accountSettings


### PR DESCRIPTION
**Description:** Dialog to rename or delete account

UX is a bit sad: to actually rename you need to either unfocus the edit widget (not possible since there are no other widgets) or press enter.
If you click "Delete account" and then cancel that dialog, account settings will close as well. Fixing that will require more `IORef` trickery and I don't suppose it's super important to do.

**YT issue:** https://issues.serokell.io/issue/AD-476

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
