### PR TITLE
[AD-502] `getstate` function fails if there is an empty db

### DIFF
--- a/ariadne/cardano/package.yaml
+++ b/ariadne/cardano/package.yaml
@@ -163,6 +163,7 @@ tests:
       - safe-exceptions
       - serokell-util
       - tabl
+      - temporary
       - text
       - text-format
       - time

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/BlockMeta.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/BlockMeta.hs
@@ -41,6 +41,7 @@ data BlockMeta = BlockMeta {
     , -- | Address metadata
       _blockMetaAddressMeta :: !(InDb (Map Core.Address AddressMeta))
     }
+    deriving Eq
 
 makeLenses ''AddressMeta
 makeLenses ''BlockMeta

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -70,7 +70,7 @@ import qualified Data.ByteString as BS
 import qualified Data.IxSet.Typed as IxSet
 import Data.SafeCopy (base, deriveSafeCopySimple)
 
-import Test.QuickCheck (Arbitrary(..), elements, oneof, vectorOf)
+import Test.QuickCheck (Arbitrary(..), Gen, elements, oneof, vectorOf)
 
 import qualified Data.Text.Buildable
 import Formatting (bprint, build, (%))
@@ -95,7 +95,7 @@ newtype WalletName = WalletName
       deriving newtype (Buildable)
 
 instance Arbitrary WalletName where
-    arbitrary = pure "New wallet"
+    arbitrary = WalletName . toText <$> (arbitrary :: Gen String)
 
 -- | Account name
 newtype AccountName = AccountName
@@ -154,6 +154,7 @@ data HasSpendingPassword =
 
     -- | If there is a spending password, we record when it was last updated.
   | HasSpendingPassword (InDb Core.Timestamp)
+  deriving Eq
 
 instance Buildable HasSpendingPassword where
     build NoSpendingPassword = "no"
@@ -230,6 +231,7 @@ data HdRoot = HdRoot {
       -- | When was this wallet created?
     , _hdRootCreatedAt   :: InDb Core.Timestamp
     }
+    deriving Eq
 
 instance Buildable HdRoot where
     build HdRoot{..} =
@@ -259,6 +261,9 @@ data HdAccount = HdAccount {
       -- as stipulated by the wallet specification
     , _hdAccountCheckpoints :: NonEmpty AccCheckpoint
     }
+instance Eq HdAccount where
+  acc1 == acc2 =
+    _hdAccountId acc1 == _hdAccountId acc2 && _hdAccountName acc1 == _hdAccountName acc2
 
 instance Buildable HdAccount where
     build HdAccount{..} =

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/HdWallet.hs
@@ -261,9 +261,7 @@ data HdAccount = HdAccount {
       -- as stipulated by the wallet specification
     , _hdAccountCheckpoints :: NonEmpty AccCheckpoint
     }
-instance Eq HdAccount where
-  acc1 == acc2 =
-    _hdAccountId acc1 == _hdAccountId acc2 && _hdAccountName acc1 == _hdAccountName acc2
+    deriving Eq
 
 instance Buildable HdAccount where
     build HdAccount{..} =

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Spec.hs
@@ -115,6 +115,7 @@ data AccCheckpoint = AccCheckpoint {
     , _accCheckpointPending     :: !Pending
     , _accCheckpointBlockMeta   :: !BlockMeta
     }
+    deriving Eq
 
 emptyAccCheckpoint :: AccCheckpoint
 emptyAccCheckpoint = AccCheckpoint {

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
@@ -105,6 +105,9 @@ newtype IxSet a = WrapIxSet {
 instance Show a => Show (IxSet a) where
     show = show . map unwrapOrdByPrimKey . IxSet.toList . unwrapIxSet
 
+instance (Eq a, Indexable a) => Eq (IxSet a) where
+    (WrapIxSet ixSet1) == (WrapIxSet ixSet2) = ixSet1 == ixSet2
+
 -- | Evidence that the specified indices are in fact available
 type Indexable a = IxSet.Indexable (PrimKey a ': IndicesOf a) (OrdByPrimKey a)
 

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/DB/Util/IxSet.hs
@@ -101,12 +101,10 @@ type family IndicesOf (a :: *) :: [*]
 newtype IxSet a = WrapIxSet {
       unwrapIxSet :: IxSet.IxSet (PrimKey a ': IndicesOf a) (OrdByPrimKey a)
     }
+deriving instance Indexable a => Eq (IxSet a)
 
 instance Show a => Show (IxSet a) where
     show = show . map unwrapOrdByPrimKey . IxSet.toList . unwrapIxSet
-
-instance (Eq a, Indexable a) => Eq (IxSet a) where
-    (WrapIxSet ixSet1) == (WrapIxSet ixSet2) = ixSet1 == ixSet2
 
 -- | Evidence that the specified indices are in fact available
 type Indexable a = IxSet.Indexable (PrimKey a ': IndicesOf a) (OrdByPrimKey a)

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/WalletLayer.hs
@@ -3,13 +3,13 @@ module Ariadne.Wallet.Cardano.WalletLayer
          passiveWalletLayerComponent
        , passiveWalletLayerCustomDBComponent
        , activeWalletLayerComponent
+       , walletDBComponent
          -- * We re-export the types since we want all the dependencies
          -- in this module, other modules shouldn't be touched.
        , module Types
        ) where
 
-import Ariadne.Wallet.Cardano.WalletLayer.Kernel
-  (activeWalletLayerComponent, passiveWalletLayerComponent,
-  passiveWalletLayerCustomDBComponent)
+import Ariadne.Wallet.Cardano.WalletLayer.Kernel (activeWalletLayerComponent, passiveWalletLayerComponent,
+  passiveWalletLayerCustomDBComponent, walletDBComponent)
 import Ariadne.Wallet.Cardano.WalletLayer.Types (PassiveWalletLayer)
 import Ariadne.Wallet.Cardano.WalletLayer.Types as Types

--- a/ariadne/cardano/test/backend/Test/Spec/Accounts.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/Accounts.hs
@@ -25,7 +25,7 @@ import qualified Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet as IxSet
 import Ariadne.Wallet.Cardano.Kernel.Word31 (unsafeMkWord31)
 
 import Test.Spec.Fixture
-  (GenPassiveWalletFixture, genSpendingPassword, withLayer,
+  (GenPassiveWalletFixture, genSpendingPassword, withLayerInMemoryStorage,
   withPassiveWalletFixture)
 import Util.Buildable (ShowThroughBuild(..))
 
@@ -106,7 +106,7 @@ spec = describe "Accounts" $ do
                 hdrId <- pick arbitrary
                 request <- genNewAccountRq hdrId
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     res <- (WalletLayer.pwlCreateAccount layer) `applyNewAccount` request
                     case res of
                          Left (Kernel.CreateAccountKeystoreNotFound _) ->
@@ -136,7 +136,7 @@ spec = describe "Accounts" $ do
             monadicIO $ do
                 hdAccId <- pick arbitrary
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     res <- (WalletLayer.pwlDeleteAccount layer) hdAccId
                     case res of
                          Left (Kernel.DeleteUnknownHdAccount (Kernel.UnknownHdAccountRoot _)) ->
@@ -183,7 +183,7 @@ spec = describe "Accounts" $ do
             monadicIO $ do
                 hdAccId <- pick arbitrary
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     res <- (WalletLayer.pwlUpdateAccountName layer) hdAccId "new account"
                     case res of
                          Left (Kernel.UnknownHdAccountRoot _) ->
@@ -229,7 +229,7 @@ spec = describe "Accounts" $ do
             monadicIO $ do
                 hdAccId <- pick arbitrary
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     res <- (WalletLayer.pwlGetAccount layer) hdAccId
                     case res of
                          Left (Kernel.UnknownHdAccountRoot _) ->
@@ -275,7 +275,7 @@ spec = describe "Accounts" $ do
             monadicIO $ do
                 hdrId <- pick arbitrary
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     res <- (WalletLayer.pwlGetAccounts layer) hdrId
                     case res of
                          Left (Kernel.UnknownHdRoot _) ->

--- a/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
@@ -31,7 +31,7 @@ spec = describe "Checking AcidState related functions behavior" $ do
              Left err -> fail err
              Right (acidDB, eventTag) -> do
                db <- liftIO $ query acidDB Snapshot
-               let isEmptyDB = chekEmptyWalletDB db
+               let isEmptyDB = checkEmptyWalletDB db
                return $ isEmptyDB && (eventTag == noEventsMsg)
   prop "Check that opened state is the same as it was before closing." $ withMaxSuccess 10 $ do
             monadicIO $ do
@@ -45,8 +45,8 @@ spec = describe "Checking AcidState related functions behavior" $ do
                       Left err -> fail $ toString err
                       Right () -> pass
 
-chekEmptyWalletDB :: DB -> Bool
-chekEmptyWalletDB (DB (HdWallets hdWallets hdAccounts hdAddresses)) =
+checkEmptyWalletDB :: DB -> Bool
+checkEmptyWalletDB (DB (HdWallets hdWallets hdAccounts hdAddresses)) =
   all (== 0) [size hdWallets, size hdAccounts, size hdAddresses]
 
 noEventsMsg :: BL.ByteString

--- a/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
@@ -27,8 +27,8 @@ import Ariadne.Wallet.Cardano.Kernel.Internal (PassiveWallet(..), wallets)
 import Ariadne.Wallet.Cardano.WalletLayer (PassiveWalletLayer, pwlCreateWallet)
 
 spec :: Spec
-spec = describe "Checking AcidState related functions behavior" $ do
-  prop "Check empty DB state" $ withMaxSuccess 1 $
+spec = describe "AcidState" $ do
+  prop "can open empty database" $ withMaxSuccess 1 $
     monadicIO $ run $ withSystemTempDirectory "testWalletDBEmpty" $ \path -> do
         getState path defDB 0 True >>= \case
           Left _ -> return False
@@ -36,7 +36,7 @@ spec = describe "Checking AcidState related functions behavior" $ do
             db <- liftIO $ query acidDB Snapshot
             let isEmptyDB = checkEmptyWalletDB db
             return $ isEmptyDB && (eventTag == noEventsMsg)
-  prop "Check that opened state is the same as it was before closing." $ withMaxSuccess 10 $ do
+  prop "opened state is the same as it was before closing" $ withMaxSuccess 10 $ do
     monadicIO $ do
       passwds <- genSpendingPasswords 10
       requests <- mapM genNewWalletRq $ ordNub passwds

--- a/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
@@ -1,0 +1,80 @@
+module Test.Spec.AcidState (spec) where
+
+import System.IO.Temp
+
+import Data.Acid (closeAcidState, openLocalStateFrom, query)
+import Data.Acid.Local (getState)
+
+import qualified Data.ByteString.Lazy as BL
+import Data.Text.Buildable (build)
+import Data.Text.Lazy.Builder (toLazyText)
+
+import Test.Hspec (Spec, describe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (arbitrary, withMaxSuccess)
+import Test.QuickCheck.Monadic (monadicIO, pick, run)
+
+import Test.Spec.CreateWallet (NewWallet, applyNewWallet, genNewWalletRq)
+import Test.Spec.Fixture (genSpendingPasswords, withLayerLocalStorage)
+
+import Ariadne.Wallet.Cardano.Kernel.DB.AcidState (DB(..), Snapshot(..), defDB)
+import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet (HdWallets(..))
+import Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet (IxSet, size)
+import Ariadne.Wallet.Cardano.Kernel.Internal (PassiveWallet(..), wallets)
+import Ariadne.Wallet.Cardano.WalletLayer (PassiveWalletLayer, pwlCreateWallet)
+
+spec :: Spec
+spec = describe "Checking AcidState related functions behavior" $ do
+  prop "Check empty DB state" $ withMaxSuccess 1 $
+    monadicIO $ run $ withSystemTempDirectory "testWalletDBEmpty" $ \path -> do
+      getState path defDB 0 True >>= \case
+             Left err -> fail err
+             Right (acidDB, eventTag) -> do
+               db <- liftIO $ query acidDB Snapshot
+               let isEmptyDB = chekEmptyWalletDB db
+               return $ isEmptyDB && (eventTag == noEventsMsg)
+  prop "Check that opened state is the same as it was before closing." $ withMaxSuccess 10 $ do
+            monadicIO $ do
+                passwds <- genSpendingPasswords 10
+                requests <- mapM genNewWalletRq $ ordNub passwds
+                pm <- pick arbitrary
+                liftIO $ withSystemTempDirectory "testWalletDBNonEmpty" $ \path -> do
+                  withLayerLocalStorage pm path $ \layer wallet -> do
+                    res <- checkAcidDBOpenedState wallet layer path requests
+                    case res of
+                      Left err -> fail $ toString err
+                      Right () -> pass
+
+chekEmptyWalletDB :: DB -> Bool
+chekEmptyWalletDB (DB (HdWallets hdWallets hdAccounts hdAddresses)) =
+  all (== 0) [size hdWallets, size hdAccounts, size hdAddresses]
+
+noEventsMsg :: BL.ByteString
+noEventsMsg = "This is the initial state. No methods were applied to the DB."
+
+checkAcidDBOpenedState
+  :: PassiveWallet
+  -> PassiveWalletLayer IO
+  -> FilePath
+  -> [NewWallet]
+  -> IO (Either Text ())
+checkAcidDBOpenedState pw pwl tempDBDir walletsToCreate = do
+  let oldDB = pw ^. wallets
+  mapM_ (applyNewWallet  (pwlCreateWallet pwl)) walletsToCreate
+  (DB (HdWallets oldWallets _ _)) <- query oldDB Snapshot
+  closeAcidState oldDB
+  newDB <- openLocalStateFrom tempDBDir defDB
+  (DB (HdWallets newWallets _ _)) <- query newDB Snapshot
+
+  if (oldWallets /= newWallets)
+  then return . Left $ showDifferences oldWallets newWallets
+  else return $ Right ()
+  where
+    showDifferences
+      :: Buildable a => IxSet a -> IxSet a -> Text
+    showDifferences oldSet newSet = "There are differences \
+      \between the database's state when it was closed and its state after opening.\n" <>
+      "Here is the the old list (Before closing of the Acid State DB) of wallets: " <>
+      (toStrict . toLazyText $ build oldSet) <> "\n" <>
+      "Here is the the new list (After opening of the Acid State DB) of wallets: " <>
+      (toStrict . toLazyText $ build newSet) <> "\n"

--- a/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/AcidState.hs
@@ -2,7 +2,7 @@ module Test.Spec.AcidState (spec) where
 
 import Control.Exception.Base (ErrorCall(..), handle)
 import Control.Monad.Component hiding (throwM)
--- import qualified Control.Monad.Component as C (throwM)
+
 import System.IO.Temp
 
 import Data.Acid (closeAcidState, openLocalStateFrom, query)
@@ -78,7 +78,7 @@ checkAcidDBOpenedState
   -> IO (Either Text ())
 checkAcidDBOpenedState pw pwl tempDBDir walletsToCreate = do
   let oldDB = pw ^. wallets
-  mapM_ (applyNewWallet  (pwlCreateWallet pwl)) walletsToCreate
+  mapM_ (applyNewWallet (pwlCreateWallet pwl)) walletsToCreate
   (DB (HdWallets oldWallets _ _)) <- query oldDB Snapshot
   closeAcidState oldDB
   newDB <- openLocalStateFrom tempDBDir defDB

--- a/ariadne/cardano/test/backend/Test/Spec/CreateWallet.hs
+++ b/ariadne/cardano/test/backend/Test/Spec/CreateWallet.hs
@@ -24,10 +24,11 @@ import Ariadne.Wallet.Cardano.Kernel.Types (WalletId(..))
 import Ariadne.Wallet.Cardano.Kernel.Wallets
   (CreateWalletError(..), CreateWithAddress(..), HasNonemptyPassphrase,
   mkHasPP)
+
 import qualified Ariadne.Wallet.Cardano.Kernel.Wallets as Kernel
 import qualified Ariadne.Wallet.Cardano.WalletLayer as WalletLayer
 
-import Test.Spec.Fixture (genSpendingPassword, withLayer)
+import Test.Spec.Fixture (genSpendingPassword, withLayerInMemoryStorage)
 import Util.Buildable (ShowThroughBuild(..))
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
@@ -77,7 +78,7 @@ spec = describe "CreateWallet" $ do
             monadicIO $ do
                 request <- genNewWalletRq =<< genSpendingPassword
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     liftIO $ do
                         res <- (WalletLayer.pwlCreateWallet layer) `applyNewWallet` request
                         (bimap STB STB res) `shouldSatisfy` isRight
@@ -86,7 +87,7 @@ spec = describe "CreateWallet" $ do
             monadicIO $ do
                 request <- genNewWalletRq =<< genSpendingPassword
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     liftIO $ do
                         -- The first time it must succeed.
                         res1 <- (WalletLayer.pwlCreateWallet layer) `applyNewWallet` request
@@ -104,7 +105,7 @@ spec = describe "CreateWallet" $ do
             monadicIO $ do
                 request <- genNewWalletRq =<< genSpendingPassword
                 pm <- pick arbitrary
-                withLayer pm $ \layer _ -> do
+                withLayerInMemoryStorage pm $ \layer _ -> do
                     let w' = request { newwalName = "İıÀļƒȑĕďŏŨƞįťŢęșťıİ 日本" }
                     liftIO $ do
                         res <- (WalletLayer.pwlCreateWallet layer) `applyNewWallet` w'
@@ -117,7 +118,7 @@ spec = describe "CreateWallet" $ do
                 request <- genNewWalletRq =<< genSpendingPassword
 
                 pm <- pick arbitrary
-                withLayer @IO pm $ \_ wallet -> do
+                withLayerInMemoryStorage @IO pm $ \_ wallet -> do
                     liftIO $ do
                         res <- (Kernel.createHdWallet wallet) `applyNewWallet` request
                         case res of

--- a/ariadne/cardano/test/backend/WalletUnitTest.hs
+++ b/ariadne/cardano/test/backend/WalletUnitTest.hs
@@ -10,6 +10,7 @@ import UTxO.DSL (GivenHash, Transaction)
 import UTxO.Translate (runTranslateNoErrors, withConfig)
 
 import qualified Test.Spec.Accounts
+import qualified Test.Spec.AcidState
 import qualified Test.Spec.CreateAddress
 import qualified Test.Spec.CreateWallet
 import qualified Test.Spec.Kernel
@@ -51,3 +52,4 @@ tests = describe "Wallet unit tests" $ do
     Test.Spec.CreateAddress.spec
     Test.Spec.CreateWallet.spec
     Test.Spec.Accounts.spec
+    Test.Spec.AcidState.spec

--- a/stack.yaml
+++ b/stack.yaml
@@ -102,7 +102,7 @@ extra-deps:
 # Because it includes a bunch of safecopy instances that we currently rely upon.
 # Also the 'Serokell.AcidState.ExtendedState' thing.
 - git: https://github.com/serokell/acid-state
-  commit: 219c7217ef52318a74bfa2aa54006b2505112f83
+  commit: 77291b5f7796a919414ce86fa47733e767bc5fdf
 
 - git: https://github.com/input-output-hk/haskell-hedgehog
   commit: 2e741bb53afb085741807018948ae17d956c53af

--- a/stack.yaml
+++ b/stack.yaml
@@ -102,7 +102,7 @@ extra-deps:
 # Because it includes a bunch of safecopy instances that we currently rely upon.
 # Also the 'Serokell.AcidState.ExtendedState' thing.
 - git: https://github.com/serokell/acid-state
-  commit: 77291b5f7796a919414ce86fa47733e767bc5fdf
+  commit: bae90f7565b4fc621cd45ac94d211b7b84627465
 
 - git: https://github.com/input-output-hk/haskell-hedgehog
   commit: 2e741bb53afb085741807018948ae17d956c53af


### PR DESCRIPTION
**Description:**

This PR fixes the bugs that were added in the  PR #350 due to the bug in acid-state: 
  1. Ariadne failed to be started with an empty database.
  2. `openLocalState` function loads not the current state of DB, but the previous one.
Also, it adds tests to check the behavior of the `acid-state` related functions. 

**YT issue:** https://issues.serokell.io/issue/AD-452

**Checklist:**

- [ ] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [GUI usage guide](docs/usage-gui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
  - [ ] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
