### PR TITLE
[AD-486] Display wallet id in GUI

### DIFF
--- a/docs/usage-gui.md
+++ b/docs/usage-gui.md
@@ -53,6 +53,10 @@ you understand what you are doing.
 When an account is selected you can open its settings by clicking the "Account settings" button in
 the wallet pane. A dialog will open where you can change your account's name or delete it.
 
+If you hover your mouse over wallet's name in the right pane, you will see a tooltip with wallet's
+internal stable database id. You can use that id in several knit commands, such as `send` or `new-account`.
+To copy that id to clipboard just right-click on the wallet name.
+
 ## Blockchain operations
 
 Wallet pane has two buttons for working with the blockchain &mdash; "SEND" and "REQUEST". Both will

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -358,6 +358,7 @@ walletSelectionToInfo uiwd UiWalletSelection{..} =
     wallet UiWalletData{..} =
       UiWalletInfo
         { uwiLabel = Just _uwdName
+        , uwiWalletId = formatHdRootId _uwdId
         , uwiWalletIdx = uwsWalletIdx
         , uwiBalance = balance _uwdBalance
         , uwiAccounts = account <$> V.toList _uwdAccounts

--- a/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
+++ b/ui/qt-lib/src/Ariadne/UI/Qt/Face.hs
@@ -262,6 +262,7 @@ data UiCurrency = ADA | Lovelace
 -- Display info for entities on all HD-wallet tree levels
 data UiWalletInfo = UiWalletInfo
   { uwiLabel :: !(Maybe Text)
+  , uwiWalletId :: !Text
   , uwiWalletIdx :: !Word
   , uwiBalance :: !(Text, UiCurrency)
   , uwiAccounts :: ![UiAccountInfo]


### PR DESCRIPTION

**Description:**
Problem: VTY UI displays wallet ids (HdRootId), that can be usable as
stable identifiers in some knit commands, more convenient than UI
indices. QT UI does not display them.

Solution: Make QT UI display wallet ids as tooltips on wallet names.

**YT issue:** https://issues.serokell.io/issue/AD-486

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
