### PR TITLE
[AD-487] Allow partial parses of names and keys

### DIFF
--- a/ariadne/cardano/test/Test/Ariadne/Knit.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Knit.hs
@@ -115,8 +115,8 @@ genTokenComponents = oneof $ componentTokens <> baseTokens
       , TokenParenthesis <$> elements [BracketSideOpening, BracketSideClosing]
       , return TokenEquals
       , return TokenSemicolon
-      , TokenName <$> genName
-      , TokenKey <$> genName
+      , curry TokenName Complete <$> genName
+      , curry TokenKey Complete <$> genName
       , elements (tokenUnknownList @components)
       ]
 

--- a/knit/src/Knit/ParseTreeExt.hs
+++ b/knit/src/Knit/ParseTreeExt.hs
@@ -17,10 +17,11 @@ type instance XXExpr ParseTreeExt cmd components =
     ExprInBrackets (TokenWithSpace components) (Expr ParseTreeExt cmd components)
 
 type instance XProcCall ParseTreeExt _ (Expr ParseTreeExt _ components) =
-    Maybe (TokenWithSpace components)
+    (Maybe (TokenWithSpace components), Completeness)
 
 type instance XArgPos ParseTreeExt _ = NoExt
-type instance XArgKw ParseTreeExt (Expr ParseTreeExt _ components) = TokenWithSpace components
+type instance XArgKw ParseTreeExt (Expr ParseTreeExt _ components) =
+    (TokenWithSpace components, Completeness)
 type instance XXArg ParseTreeExt _ = Void
 
 data ExprInBrackets br a = ExprInBrackets br a br

--- a/knit/src/Knit/Printer.hs
+++ b/knit/src/Knit/Printer.hs
@@ -52,9 +52,12 @@ ppToken = \case
   TokenParenthesis _ -> "parenthesis"
   TokenEquals -> "equality sign"
   TokenSemicolon -> "semicolon"
-  TokenName _ -> "procedure name"
-  TokenKey _ -> "key"
+  TokenName (comp, _) -> compStr comp <> "procedure name"
+  TokenKey (comp, _) -> compStr comp <> "key"
   TokenUnknown c -> text ("character '" <> T.singleton c <> "'")
+  where
+    compStr Complete = ""
+    compStr Incomplete = "incomplete "
 
 ppExpr
   :: AllConstrained ComponentPrinter components


### PR DESCRIPTION
**Description:** Allow partial parses of names and keys which end on '-'.

**YT issue:** https://issues.serokell.io/issue/AD-487

**Checklist:**

- [x] Updated docs if necessary
  - [x] [README](README.md)
  - [x] [TUI usage guide](docs/usage-tui.md)
  - [x] [GUI usage guide](docs/usage-gui.md)
  - [x] [Configuration documentation](docs/configuration.md)
  - [x] [GUI architecture documentation](docs/gui-architecture.md)
- [x] My code complies with the [style guide](docs/code-style.md)
- [x] Tested my changes if they modify code
