### PR TITLE
[AD-501] Move wallet restore logic to cardano modules

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/Restore.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/Restore.hs
@@ -5,37 +5,23 @@ module Ariadne.Wallet.Backend.Restore
        , restoreFromKeyFile
        ) where
 
-import qualified Universum.Unsafe as Unsafe (init)
-
 import Control.Exception (Exception(displayException))
-import Control.Lens (at, non, (?~))
 import Control.Natural (type (~>))
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as Map
 
-import Pos.Binary.Class (decodeFull')
 import Pos.Core.Configuration (HasConfiguration)
 import Pos.Crypto (EncryptedSecretKey, PassPhrase)
-import qualified Pos.Crypto as Crypto
-import Pos.Txp.Toil.Types (Utxo)
-import Pos.Util.BackupPhrase (BackupPhrase(..), safeKeysFromPhrase)
-import Pos.Util.UserSecret (usKeys0)
+import qualified Pos.Crypto as Crypto (checkPassMatches, emptyPassphrase)
 
-import Ariadne.Cardano.Face
-import Ariadne.Wallet.Backend.AddressDiscovery
-  (AddressWithPathToUtxoMap, discoverHDAddressWithUtxo)
+import Ariadne.Cardano.Face (CardanoMode)
 import Ariadne.Wallet.Backend.KeyStorage (addWallet)
-import Ariadne.Wallet.Cardano.Kernel.Bip32 (DerivationPath(..))
-import Ariadne.Wallet.Cardano.Kernel.Bip39 (mnemonicToSeedNoPassword)
-import Ariadne.Wallet.Cardano.Kernel.Bip44
-  (Bip44DerivationPath(..), bip44PathToAddressId, decodeBip44DerivationPath)
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
-import Ariadne.Wallet.Cardano.Kernel.PrefilterTx
-  (PrefilteredUtxo, UtxoByAccount)
+  (AssuranceLevel(..), WalletName(..))
+import Ariadne.Wallet.Cardano.Kernel.Restore
+  (getKeyFromMnemonic, getUtxoByAccount, readNonAriadneKeys)
 import Ariadne.Wallet.Cardano.Kernel.Wallets
-  (HasNonemptyPassphrase(..), CreateWithAddress(..), mkHasPP)
+  (CreateWithAddress(..), HasNonemptyPassphrase(..), mkHasPP)
 import Ariadne.Wallet.Cardano.WalletLayer.Types (PassiveWalletLayer(..))
-import Ariadne.Wallet.Face
+import Ariadne.Wallet.Face (Mnemonic(..), WalletFace(..), WalletRestoreType(..))
 
 newtype WrongMnemonic = WrongMnemonic Text
  deriving (Eq, Show)
@@ -67,15 +53,7 @@ restoreWallet pwl face runCardanoMode getPassTemp mbWalletName (Mnemonic mnemoni
         isAriadneMnemonic = fromMaybe False $ do
           lastWord <- last <$> nonEmpty mnemonicWords
           pure (lastWord == "ariadne-v0") -- TODO AD-124: version parsing?
-    esk <- if
-      | isAriadneMnemonic ->
-          let seed = mnemonicToSeedNoPassword (unwords $ Unsafe.init mnemonicWords)
-          in pure . snd $ Crypto.safeDeterministicKeyGen seed pp
-      | length mnemonicWords == 12 ->
-          case safeKeysFromPhrase pp (BackupPhrase mnemonicWords) of
-              Left e        -> throwM $ WrongMnemonic e
-              Right (sk, _) -> pure sk
-      | otherwise -> throwM $ WrongMnemonic "Unknown mnemonic type"
+    esk <- getKeyFromMnemonic isAriadneMnemonic mnemonicWords pp
     let hasPP = mkHasPP pp
     restoreFromSecretKey pwl face runCardanoMode mbWalletName esk rType hasPP assurance
   where
@@ -92,10 +70,7 @@ restoreFromKeyFile ::
     -> WalletRestoreType
     -> IO ()
 restoreFromKeyFile pwl face runCardanoMode mbWalletName path rType = do
-    keyFile <- BS.readFile path
-    us <- case decodeFull' keyFile of
-      Left e   -> throwM $ SecretsDecodingError path e
-      Right us -> pure us
+    esks <- readNonAriadneKeys path
     let templateName i (WalletName n) = WalletName $ n <> " " <> pretty i
     traverse_
         (\(i,esk) -> do
@@ -110,7 +85,7 @@ restoreFromKeyFile pwl face runCardanoMode mbWalletName path rType = do
                 rType
                 hasPP
                 assurance)
-        (zip [(0 :: Int)..] $ us ^. usKeys0)
+        (zip [(0 :: Int)..] esks)
   where
     -- TODO(AD-251): allow selecting assurance.
     assurance = AssuranceLevelNormal
@@ -127,48 +102,5 @@ restoreFromSecretKey ::
     -> AssuranceLevel
     -> IO ()
 restoreFromSecretKey pwl face runCardanoMode mbWalletName esk rType hasPP assurance = do
-    utxoByAccount <- case rType of
-        WalletRestoreQuick -> pure mempty
-        WalletRestoreFull  -> runCardanoMode $ collectUtxo esk
+    utxoByAccount <- getUtxoByAccount runCardanoMode esk rType
     addWallet pwl face esk mbWalletName utxoByAccount hasPP WithoutAddress assurance
-
-collectUtxo ::
-       HasConfiguration
-    => EncryptedSecretKey
-    -> CardanoMode UtxoByAccount
-collectUtxo esk = do
-    m <- discoverHDAddressWithUtxo $ Crypto.deriveHDPassphrase $ Crypto.encToPublic esk
-    pure $ groupAddresses $ filterAddresses m
-  where
-    toHdAddressId :: Bip44DerivationPath -> HdAddressId
-    toHdAddressId = bip44PathToAddressId (eskToHdRootId esk)
-
-    -- TODO: simply ignoring addresses which are not BIP-44 compliant
-    -- is not perfect (though normal users shouldn't have addresses at
-    -- different levels). We should probably at least show some
-    -- message if we encounter such addresses. Let's do it after
-    -- switching to modern wallet data layer.
-
-    filterAddresses :: AddressWithPathToUtxoMap -> PrefilteredUtxo
-    filterAddresses = Map.fromList . mapMaybe f . toPairs
-      where
-        f ((DerivationPath derPath, addr), utxo) =
-            case decodeBip44DerivationPath derPath of
-                Nothing           -> Nothing
-                Just bip44DerPath -> Just ((toHdAddressId bip44DerPath, addr), utxo)
-
-    groupAddresses :: PrefilteredUtxo -> UtxoByAccount
-    groupAddresses =
-        -- See https://hackage.haskell.org/package/lens-3.10.1/docs/Control-Lens-Iso.html#v:non
-        -- or a comment in Ariadne.Wallet.Backend.AddressDiscovery.discoverHDAddressesWithUtxo
-        -- for an explanation of how this works.
-        let step :: UtxoByAccount ->
-                    (HdAddressId, Address) ->
-                    Utxo ->
-                    UtxoByAccount
-            step utxoByAccount addrWithId@(addressId, _) utxo =
-                utxoByAccount &
-                    at (addressId ^. hdAddressIdParent) .
-                    non mempty .
-                    at addrWithId ?~ utxo
-        in Map.foldlWithKey' step mempty

--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Restore.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Restore.hs
@@ -1,0 +1,128 @@
+-- | Cardano Wallet restoration logic.
+
+module Ariadne.Wallet.Cardano.Kernel.Restore
+       ( getKeyFromMnemonic
+       , getUtxoByAccount
+       , readNonAriadneKeys
+       ) where
+
+import qualified Universum.Unsafe as Unsafe (init)
+
+import Control.Exception (Exception(displayException))
+import Control.Lens (at, non, (?~))
+import Control.Natural (type (~>))
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+
+import Pos.Binary.Class (decodeFull')
+import Pos.Core.Configuration (HasConfiguration)
+import Pos.Crypto (EncryptedSecretKey, PassPhrase)
+import qualified Pos.Crypto as Crypto
+  (deriveHDPassphrase, encToPublic, safeDeterministicKeyGen)
+import Pos.Txp.Toil.Types (Utxo)
+import Pos.Util.BackupPhrase (BackupPhrase(..), safeKeysFromPhrase)
+import Pos.Util.UserSecret (usKeys0)
+
+import Ariadne.Cardano.Face (Address, CardanoMode)
+import Ariadne.Wallet.Backend.AddressDiscovery
+  (AddressWithPathToUtxoMap, discoverHDAddressWithUtxo)
+import Ariadne.Wallet.Cardano.Kernel.Bip32 (DerivationPath(..))
+import Ariadne.Wallet.Cardano.Kernel.Bip39 (mnemonicToSeedNoPassword)
+import Ariadne.Wallet.Cardano.Kernel.Bip44
+  (Bip44DerivationPath(..), bip44PathToAddressId, decodeBip44DerivationPath)
+import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
+  (HdAddressId, eskToHdRootId, hdAddressIdParent)
+import Ariadne.Wallet.Cardano.Kernel.PrefilterTx
+  (PrefilteredUtxo, UtxoByAccount)
+import Ariadne.Wallet.Face (WalletRestoreType(..))
+
+newtype WrongMnemonic = WrongMnemonic Text
+ deriving (Eq, Show)
+
+instance Exception WrongMnemonic where
+  displayException (WrongMnemonic txt) =
+    "Wrong mnemonic: " <> show txt
+
+data SecretsDecodingError = SecretsDecodingError FilePath Text
+  deriving (Eq, Show)
+
+instance Exception SecretsDecodingError where
+  displayException (SecretsDecodingError path txt) =
+    "Failed to decode " <> path <> ": " <> show txt
+
+getKeyFromMnemonic ::
+       MonadThrow m
+    => Bool
+    ->[Text]
+    -> PassPhrase
+    -> m EncryptedSecretKey
+getKeyFromMnemonic isAriadneMnemonic mnemonicWords pp =
+    if
+    | isAriadneMnemonic ->
+        let seed = mnemonicToSeedNoPassword (unwords $ Unsafe.init mnemonicWords)
+        in pure . snd $ Crypto.safeDeterministicKeyGen seed pp
+    | length mnemonicWords == 12 ->
+        case safeKeysFromPhrase pp (BackupPhrase mnemonicWords) of
+            Left e        -> throwM $ WrongMnemonic e
+            Right (sk, _) -> pure sk
+    | otherwise -> throwM $ WrongMnemonic "Unknown mnemonic type"
+
+
+-- | reads daedalus wallet keys from file for wallet restoration
+readNonAriadneKeys :: FilePath -> IO [EncryptedSecretKey]
+readNonAriadneKeys path = do
+  keyFile <- BS.readFile path
+  case decodeFull' keyFile of
+    Left e   -> throwM $ SecretsDecodingError path e
+    Right us -> pure $ us ^. usKeys0
+
+getUtxoByAccount ::
+       HasConfiguration
+    => (CardanoMode ~> IO)
+    -> EncryptedSecretKey
+    -> WalletRestoreType
+    -> IO UtxoByAccount
+getUtxoByAccount runCardanoMode esk  = \case
+    WalletRestoreQuick -> pure mempty
+    WalletRestoreFull  -> runCardanoMode $ collectUtxo esk
+
+collectUtxo ::
+       HasConfiguration
+    => EncryptedSecretKey
+    -> CardanoMode UtxoByAccount
+collectUtxo esk = do
+    m <- discoverHDAddressWithUtxo $ Crypto.deriveHDPassphrase $ Crypto.encToPublic esk
+    pure $ groupAddresses $ filterAddresses m
+  where
+    toHdAddressId :: Bip44DerivationPath -> HdAddressId
+    toHdAddressId = bip44PathToAddressId (eskToHdRootId esk)
+
+    -- TODO: simply ignoring addresses which are not BIP-44 compliant
+    -- is not perfect (though normal users shouldn't have addresses at
+    -- different levels). We should probably at least show some
+    -- message if we encounter such addresses. Let's do it after
+    -- switching to modern wallet data layer.
+
+    filterAddresses :: AddressWithPathToUtxoMap -> PrefilteredUtxo
+    filterAddresses = Map.fromList . mapMaybe f . toPairs
+      where
+        f ((DerivationPath derPath, addr), utxo) =
+            case decodeBip44DerivationPath derPath of
+                Nothing           -> Nothing
+                Just bip44DerPath -> Just ((toHdAddressId bip44DerPath, addr), utxo)
+
+    groupAddresses :: PrefilteredUtxo -> UtxoByAccount
+    groupAddresses =
+        -- See https://hackage.haskell.org/package/lens-3.10.1/docs/Control-Lens-Iso.html#v:non
+        -- or a comment in Ariadne.Wallet.Backend.AddressDiscovery.discoverHDAddressesWithUtxo
+        -- for an explanation of how this works.
+        let step :: UtxoByAccount ->
+                    (HdAddressId, Address) ->
+                    Utxo ->
+                    UtxoByAccount
+            step utxoByAccount addrWithId@(addressId, _) utxo =
+                utxoByAccount &
+                    at (addressId ^. hdAddressIdParent) .
+                    non mempty .
+                    at addrWithId ?~ utxo
+        in Map.foldlWithKey' step mempty


### PR DESCRIPTION
**Description:**

walletRestore and walletRestoreFromFile use a lot of Cardano-related stuff. Most of the logic from Restore.hs should be moved to Cardano modules.

**YT issue:** https://issues.serokell.io/issue/AD-501

**Checklist:**

- [x] Updated docs if necessary
  - [ ] [README](README.md)
  - [ ] [TUI usage guide](docs/usage-tui.md)
  - [ ] [GUI usage guide](docs/usage-gui.md)
  - [ ] [Configuration documentation](docs/configuration.md)
  - [ ] [GUI architecture documentation](docs/gui-architecture.md)
- [ ] My code complies with the [style guide](docs/code-style.md)
- [ ] Tested my changes if they modify code
