### PR TITLE
[AD-519] Add proper logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ dev-qt:
 
 # Run tests in all packages which have them.
 test:
-	stack test knit ariadne-cardano
+	stack test knit ariadne-core ariadne-cardano
 
 # Run haddock for all packages.
 haddock:

--- a/ariadne/cardano/src/Ariadne/Config/Ariadne.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Ariadne.hs
@@ -5,6 +5,7 @@ module Ariadne.Config.Ariadne
        , acWalletL
        , acUpdateL
        , acHistoryL
+       , acLoggingL
        ) where
 
 import Control.Lens (makeLensesWith)
@@ -17,6 +18,7 @@ import Dhall.TypeCheck (X)
 import Ariadne.Config.Cardano
 import Ariadne.Config.DhallUtil (parseField)
 import Ariadne.Config.History
+import Ariadne.Config.Logging
 import Ariadne.Config.Update
 import Ariadne.Config.Wallet
 import Ariadne.Util
@@ -29,6 +31,7 @@ defaultAriadneConfig dataDir =
         , acWallet  = defaultWalletConfig  dataDir
         , acUpdate  = defaultUpdateConfig
         , acHistory = defaultHistoryConfig dataDir
+        , acLogging = defaultLoggingConfig dataDir
         }
 
 parseFieldAriadne ::
@@ -42,6 +45,7 @@ ariadneFieldModifier = f
     f "acWallet" = "wallet"
     f "acUpdate" = "update"
     f "acHistory" = "history"
+    f "acLogging" = "logging"
     f x = x
 
 -- dhall representation of AriadneConfig is a record
@@ -53,6 +57,7 @@ data AriadneConfig = AriadneConfig
   , acWallet :: WalletConfig
   , acUpdate :: UpdateConfig
   , acHistory :: HistoryConfig
+  , acLogging :: LoggingConfig
   } deriving (Eq, Show)
 
 makeLensesWith postfixLFields ''AriadneConfig
@@ -65,6 +70,7 @@ instance D.Interpret AriadneConfig where
         acWallet <- parseFieldAriadne fields "acWallet" (D.auto @WalletConfig)
         acUpdate <- parseFieldAriadne fields "acUpdate" (D.auto @UpdateConfig)
         acHistory <- parseFieldAriadne fields "acHistory" (D.auto @HistoryConfig)
+        acLogging <- parseFieldAriadne fields "acLogging" (D.auto @LoggingConfig)
         return AriadneConfig {..}
       extractOut _ = Nothing
 
@@ -75,4 +81,5 @@ instance D.Interpret AriadneConfig where
                 , (ariadneFieldModifier "acWallet", D.expected (D.auto @WalletConfig))
                 , (ariadneFieldModifier "acUpdate", D.expected (D.auto @UpdateConfig))
                 , (ariadneFieldModifier "acHistory", D.expected (D.auto @HistoryConfig))
+                , (ariadneFieldModifier "acLogging", D.expected (D.auto @LoggingConfig))
                 ])

--- a/ariadne/cardano/src/Ariadne/Config/Logging.hs
+++ b/ariadne/cardano/src/Ariadne/Config/Logging.hs
@@ -1,0 +1,69 @@
+-- | Configuration of logging in Ariadne.
+
+module Ariadne.Config.Logging
+       ( defaultLoggingConfig
+       , loggingFieldModifier
+       , LoggingConfig (..)
+       , lcPathL
+       ) where
+
+import Control.Lens (makeLensesWith)
+import qualified Data.HashMap.Strict.InsOrd as Map
+import qualified Dhall as D
+import Dhall.Core (Expr(..))
+import Dhall.Parser (Src(..))
+import Dhall.TypeCheck (X)
+import System.FilePath ((</>))
+
+import Ariadne.Config.DhallUtil (injectFilePath, interpretFilePath, parseField)
+import Ariadne.Util (postfixLFields)
+
+defaultLoggingConfig :: FilePath -> LoggingConfig
+defaultLoggingConfig dataDir =
+    LoggingConfig {lcPath = dataDir </> "logs"}
+
+parseFieldLogging ::
+       Map.InsOrdHashMap D.Text (Expr Src X) -> D.Text -> D.Type a -> Maybe a
+parseFieldLogging = parseField loggingFieldModifier
+
+loggingFieldModifier :: D.Text -> D.Text
+loggingFieldModifier = f
+  where
+    f "lcPath" = "path"
+    f x = x
+
+data LoggingConfig = LoggingConfig
+  { lcPath :: FilePath
+  } deriving (Eq, Show)
+
+makeLensesWith postfixLFields ''LoggingConfig
+
+instance D.Interpret LoggingConfig where
+  autoWith _ = D.Type extractOut expectedOut
+    where
+      extractOut (RecordLit fields) = do
+        lcPath <- parseFieldLogging fields "lcPath" interpretFilePath
+        return LoggingConfig {..}
+      extractOut _ = Nothing
+
+      expectedOut =
+        Record
+            (Map.fromList
+                [(loggingFieldModifier "lcPath", D.expected interpretFilePath)])
+
+instance D.Inject LoggingConfig where
+    injectWith _ = injectLoggingConfig
+
+injectLoggingConfig :: D.InputType LoggingConfig
+injectLoggingConfig = D.InputType {..}
+  where
+      embed LoggingConfig {..} = RecordLit
+          (Map.fromList
+              [ (loggingFieldModifier "lcPath",
+                D.embed injectFilePath lcPath)
+              ])
+
+      declared = Record
+          (Map.fromList
+              [ (loggingFieldModifier "lcPath", D.declared injectFilePath)
+              ])

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
@@ -15,6 +15,7 @@ import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.Cardano.Face
 import Ariadne.Config.Wallet (WalletConfig(..))
+import Ariadne.Logging (Logging)
 import Ariadne.UX.PasswordManager
 import Ariadne.Wallet.Backend.KeyStorage
 import Ariadne.Wallet.Backend.Restore (restoreFromKeyFile, restoreWallet)
@@ -38,8 +39,9 @@ createWalletBackend
     -> (WalletEvent -> IO ())
     -> GetPassword
     -> VoidPassword
+    -> Logging
     -> ComponentM WalletPreface
-createWalletBackend walletConfig cardanoFace sendWalletEvent getPass voidPass = do
+createWalletBackend walletConfig cardanoFace sendWalletEvent getPass voidPass logging = do
     walletSelRef <- newIORef Nothing
 
     keystore <- keystoreComponent
@@ -103,7 +105,7 @@ createWalletBackend walletConfig cardanoFace sendWalletEvent getPass voidPass = 
                 { walletNewAddress =
                     newAddress pwl this walletSelRef getPassPhrase voidWrongPass
                 , walletNewAccount = newAccount pwl this walletSelRef
-                , walletNewWallet = newWallet pwl walletConfig this getPassTemp waitUiConfirm
+                , walletNewWallet = newWallet pwl walletConfig this getPassTemp waitUiConfirm logging
                 , walletRestore = restoreWallet pwl runCardanoMode getPassTemp
                 , walletRestoreFromFile = restoreFromKeyFile pwl runCardanoMode
                 , walletRename = renameSelection pwl this walletSelRef

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -37,6 +37,7 @@ import Pos.Util (eitherToThrow, maybeThrow)
 
 import Ariadne.Cardano.Face
 import Ariadne.Config.Wallet (WalletConfig(..))
+import Ariadne.Logging (Logging, logInfo)
 import Ariadne.Wallet.Cardano.Kernel.Bip39 (entropyToMnemonic)
 import Ariadne.Wallet.Cardano.Kernel.DB.AcidState
 import Ariadne.Wallet.Cardano.Kernel.DB.HdWallet
@@ -288,16 +289,19 @@ generateMnemonic entropySize = do
 -- | Generate a mnemonic and a wallet from this mnemonic and add the
 -- wallet to the storage.
 newWallet ::
-       PassiveWalletLayer IO
+       HasCallStack
+    => PassiveWalletLayer IO
     -> WalletConfig
     -> WalletFace
     -> IO PassPhrase
     -> (ConfirmationType -> IO Bool)
+    -> Logging
     -> Bool
     -> Maybe WalletName
     -> Maybe Byte
     -> IO [Text]
-newWallet pwl walletConfig face getPassTemp waitUiConfirm noConfirm mbWalletName mbEntropySize = do
+newWallet pwl walletConfig face getPassTemp waitUiConfirm logging noConfirm mbWalletName mbEntropySize = do
+  logInfo logging "Creating a new wallet…"
   pp <- getPassTemp
   let entropySize = fromMaybe (wcEntropySize walletConfig) mbEntropySize
   mnemonic <- generateMnemonic entropySize

--- a/ariadne/cardano/test/Spec.hs
+++ b/ariadne/cardano/test/Spec.hs
@@ -31,12 +31,13 @@ import Ariadne.Config.Cardano
 import Ariadne.Config.CLI (mergeConfigs, opts)
 import Ariadne.Config.DhallUtil (fromDhall, toDhall)
 import Ariadne.Config.History (HistoryConfig(..))
+import Ariadne.Config.Logging (LoggingConfig(..))
 import Ariadne.Config.Update (UpdateConfig(..))
 import Ariadne.Config.Wallet (WalletConfig(..))
 import Ariadne.Util (postfixLFields)
 import Knit (ComponentValue(..), Core, TyProjection(..), toValue)
 
-import Test.Ariadne.Bip44 (bip44PathGen,bip44KeyPairGen)
+import Test.Ariadne.Bip44 (bip44KeyPairGen, bip44PathGen)
 import Test.Ariadne.Cardano.Arbitrary ()
 import Test.Ariadne.History.Arbitrary ()
 import Test.Ariadne.Knit (knitSpec)
@@ -66,6 +67,7 @@ configSpec = describe "Ariadne.Config" $ do
   prop "handles any WalletConfig" propHandleWalletConfig
   prop "handles any UpdateConfig" propHandleUpdateConfig
   prop "handles any HistoryConfig" propHandleHistoryConfig
+  prop "handles any LoggingConfig" propHandleHistoryConfig
 
 propHandleCardanoConfig :: CardanoConfig -> Property
 propHandleCardanoConfig conf = monadicIO $ do
@@ -84,6 +86,11 @@ propHandleUpdateConfig conf = monadicIO $ do
 
 propHandleHistoryConfig :: HistoryConfig -> Property
 propHandleHistoryConfig conf = monadicIO $ do
+  parsed <- run $ (fromDhall . toDhall) conf
+  assert (conf == parsed)
+
+propHandleLoggingConfig :: LoggingConfig -> Property
+propHandleLoggingConfig conf = monadicIO $ do
   parsed <- run $ (fromDhall . toDhall) conf
   assert (conf == parsed)
 
@@ -137,6 +144,7 @@ cliArgs =
   , "--update:update-url", "new-update-url"
   , "--update:check-delay", "21600"
   , "--history:path", "new-history-path"
+  , "--logging:path", "new-logging-path"
   ]
 
 
@@ -172,12 +180,16 @@ expectedAriadneConfig = defaultAriadneCfg
   , acHistory = defaultHistoryConfig
       { hcPath = "new-history-path"
       }
+  , acLogging = defaultLoggingConfig
+      { lcPath = "new-logging-path"
+      }
   }
   where
     defaultCardanoConfig = acCardano defaultAriadneCfg
     defaultWalletConfig = acWallet defaultAriadneCfg
     defaultUpdateConfig = acUpdate defaultAriadneCfg
     defaultHistoryConfig = acHistory defaultAriadneCfg
+    defaultLoggingConfig = acLogging defaultAriadneCfg
 
 cardanoKnitSpec :: Spec
 cardanoKnitSpec = do

--- a/ariadne/cardano/test/Test/Ariadne/Logging/Arbitrary.hs
+++ b/ariadne/cardano/test/Test/Ariadne/Logging/Arbitrary.hs
@@ -1,0 +1,13 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Test.Ariadne.Logging.Arbitrary () where
+
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import Ariadne.Config.Logging (LoggingConfig(..))
+
+import Test.Ariadne.Cardano.Arbitrary (genValidString)
+
+instance Arbitrary LoggingConfig where
+    arbitrary = do
+        lcPath <- genValidString
+        return LoggingConfig {..}

--- a/ariadne/core/package.yaml
+++ b/ariadne/core/package.yaml
@@ -11,6 +11,9 @@ library:
     - componentm
     - concurrent-extra
     - containers
+    - co-log
+    - co-log-core
+    - filepath
     - formatting
     - knit
     - lens
@@ -23,3 +26,15 @@ library:
     - time
     - transformers
     - unix
+
+tests:
+  ariadne-core-test:
+    <<: *test-common
+    main: Spec.hs
+    dependencies:
+      - ariadne-core
+      - componentm
+      - filepath
+      - hspec
+      - temporary
+      - text

--- a/ariadne/core/src/Ariadne/Logging.hs
+++ b/ariadne/core/src/Ariadne/Logging.hs
@@ -1,0 +1,73 @@
+-- | Logging component which is the primary way to log something from
+-- `ariadne` code.
+
+module Ariadne.Logging
+       (
+         -- | Logging handle and the corresponding component.
+         Logging
+       , loggingComponent
+
+         -- | Functions to actually log something
+       , logDebug
+       , logInfo
+       , logWarning
+       , logError
+       ) where
+
+import Colog.Actions (logTextHandle)
+import Colog.Core (LogAction(..), Severity(..), cmap, (<&))
+import Colog.Message (Message(..), fmtMessage)
+import Control.Monad.Component (ComponentM, buildComponent)
+import System.FilePath ((</>))
+import System.IO (hClose, hFlush)
+
+-- | An opaque type with everything needed to do logging.
+newtype Logging = Logging
+    { unLogging :: LogAction IO Message
+    }
+
+-- | Log a message with 'Debug' severity using 'Logging' handle.
+logDebug :: (MonadIO m, HasCallStack) => Logging -> Text -> m ()
+logDebug env = withFrozenCallStack $ log' env Debug
+
+-- | Log a message with 'Info' severity using 'Logging' handle.
+logInfo :: (MonadIO m, HasCallStack) => Logging -> Text -> m ()
+logInfo env = withFrozenCallStack $ log' env Info
+
+-- | Log a message with 'Warning' severity using 'Logging' handle.
+logWarning :: (MonadIO m, HasCallStack) => Logging -> Text -> m ()
+logWarning env = withFrozenCallStack $ log' env Warning
+
+-- | Log a message with 'Error' severity using 'Logging' handle.
+logError :: (MonadIO m, HasCallStack) => Logging -> Text -> m ()
+logError env = withFrozenCallStack $ log' env Error
+
+-- Internal helper function.
+-- Maybe we should export it, but I don't like its name.
+-- I'd like to call it just `log`, but we are using an old version of
+-- `universum` which exports another function called `log`.
+log' :: (MonadIO m, HasCallStack) => Logging -> Severity -> Text -> m ()
+log' logging messageSeverity messageText =
+    liftIO $ withFrozenCallStack (unLogging logging <& msg callStack)
+  where
+    msg messageStack = Message {..}
+
+-- | Create a 'Logging' handle using 'ComponentM' interface for RAII.
+--
+-- The resulting logging behaves as follows:
+-- 1. Messages are appended to a file inside the directory which is passed
+-- as an argument to this function.
+-- 2. Messages are formatted using 'fmtMessage' function from 'co-log'.
+loggingComponent :: FilePath -> ComponentM Logging
+loggingComponent logFile = fst <$> buildComponent "Logging" mkLogging snd
+  where
+    mkLogging :: IO (Logging, IO ())
+    mkLogging = do
+        hdl <- openFile (logFile </> "ariadne.log") AppendMode
+        let logToFile = cmap fmtMessage (logTextHandle hdl) <> logFlush hdl
+        return (Logging logToFile, hClose hdl)
+
+-- A 'LogAction' which does not actually log anything, only
+-- flushes the handle.
+logFlush :: Handle -> LogAction IO a
+logFlush hdl = LogAction $ const (hFlush hdl)

--- a/ariadne/core/test/Spec.hs
+++ b/ariadne/core/test/Spec.hs
@@ -1,0 +1,7 @@
+import Test.Hspec (hspec)
+
+import qualified Test.Ariadne.Logging as Logging
+
+main :: IO ()
+main = hspec $ do
+  Logging.spec

--- a/ariadne/core/test/Test/Ariadne/Logging.hs
+++ b/ariadne/core/test/Test/Ariadne/Logging.hs
@@ -1,0 +1,37 @@
+-- | Logging tests.
+
+module Test.Ariadne.Logging
+       ( spec
+       ) where
+
+import Control.Monad.Component (runComponentM)
+import Data.Text (isInfixOf)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (Expectation, Spec, describe, it, shouldSatisfy)
+
+import Ariadne.Logging (Logging, logDebug, logError, loggingComponent)
+
+spec :: Spec
+spec = describe "Logging" $ do
+  it "Can write messages to 'ariadne.log' in given directory" loggingUnitTest
+
+loggingUnitTest :: Expectation
+loggingUnitTest =
+    withSystemTempDirectory name $ \dir -> do
+        runComponentM name (loggingComponent dir) doLogging
+        doCheck dir
+  where
+    name :: IsString s => s
+    name = "ariadne-core-logging-test"
+
+    doLogging :: Logging -> IO ()
+    doLogging logging = do
+      logDebug logging "vanya"
+      logError logging "vanя"
+
+    doCheck :: FilePath -> Expectation
+    doCheck dir = do
+      line0:line1:_ <- lines <$> readFile (dir </> "ariadne.log")
+      "vanya" `shouldSatisfy` (`isInfixOf` line0)
+      "vanя" `shouldSatisfy` (`isInfixOf` line1)

--- a/config/ariadne-config.dhall
+++ b/config/ariadne-config.dhall
@@ -3,4 +3,5 @@
     , wallet = ./wallet.dhall
     , update = ./update.dhall
     , history = ./history.dhall
+    , logging = ./logging.dhall
 }

--- a/config/cardano.dhall
+++ b/config/cardano.dhall
@@ -9,7 +9,7 @@
 , rebuild-db = False
 , db-path = ["@DATA/db-mainnet"] : Optional Text
 , ekg-params = [] : Optional { IP : Text, PORT : Natural }
-, default-port = [+3000] : Optional Natural
+, default-port = [3000] : Optional Natural
 , node-id = ["node0"] : Optional Text
 , topology = [] : Optional Text
 }

--- a/config/logging.dhall
+++ b/config/logging.dhall
@@ -1,0 +1,3 @@
+{
+    path = "@DATA/logs"
+}

--- a/config/update.dhall
+++ b/config/update.dhall
@@ -1,5 +1,5 @@
 {
     version-check-url = "https://serokell.io/ariadne/version"
   , update-url = "https://serokell.io/ariadne/"
-  , check-delay = 3600
+  , check-delay = +3600 : Integer
 }

--- a/config/wallet.dhall
+++ b/config/wallet.dhall
@@ -1,5 +1,5 @@
 {
-    entropy-size = +16
+    entropy-size = 16
   , keyfile = "@DATA/secret-mainnet.key" : Text
   , wallet-db-path = "@DATA/wallet-db"
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,3 +84,10 @@ Update configuration parameterizes update checker.
 
 History configuration has only one value with the key `path`. It's a
 path to the file with command history.
+
+## Logging configuration
+
+History configuration has only one value with the key `path`. Logs
+produced by Ariadne itself will be in that folder. Note that Cardano
+uses different machinery for logging, so its logs are configured by
+Cardano configuration.

--- a/stack.yaml
+++ b/stack.yaml
@@ -211,6 +211,7 @@ extra-deps:
 - teardown-0.5.0.0
 - unix-compat-0.5.1 # https://github.com/jystic/unix-compat/pull/40
 - ntype-0.1.0.0
+- dhall-1.15.1
 
 # Required by https://github.com/input-output-hk/cardano-sl/pull/3232
 - micro-recursion-schemes-5.0.2.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -211,7 +211,11 @@ extra-deps:
 - teardown-0.5.0.0
 - unix-compat-0.5.1 # https://github.com/jystic/unix-compat/pull/40
 - ntype-0.1.0.0
-- dhall-1.15.1
+- contravariant-1.5 # needed for co-log
+- typerep-map-0.3.0 # needed for co-log
+- dhall-1.15.1      # needed due to contravariant
+- co-log-core-0.1.1
+- co-log-0.2.0
 
 # Required by https://github.com/input-output-hk/cardano-sl/pull/3232
 - micro-recursion-schemes-5.0.2.2


### PR DESCRIPTION
## Description

Problem: it's not clear what one should do when they want to log something from Ariadne code. One approach is to use log-warper's functions, because log-warper is used by cardano-sl. However, it's not clear from the code that it should be used.
Moreover, I think using log-warper is not the best idea (see below).
We can't just use `putStrLn`, because it will break TUI. Also it would be good to print additional data with each message. `writeFile` won't break TUI, but it's not clear to which file one should log.

Solution: add `Ariadne.Logging` module with a simple `co-log`-based logging implementation to `ariadne-core`.
Current logging behavior is quite simple: each message is logged into a file called `ariadne.log`, location of this file is configurable.
It would be good to also put messages into Logs widgets in UI.
In GUI we can also print them to terminal.
Some additional information is attached to each message, specifically: severity and call site. In order to make the latter better, you should add `HasCallStack` constraint to each place from which you log. But it's not necessary.
It would be good to also print at least timestamps.
`co-log` has been chosen because it's quite simple and we don't need too many features, at least for now. Also it's quite extensible, so we can have more features later.
A consequence of using `co-log` is that Cardano uses different logging engine. One alternative would be to modify Cardano code, but it would be too painful. Another alternative would be to use `log-warper`, but IOHK, to the best of my knowledge, are going to stop using `log-warper` (maybe they've done it already) and in Serokell we think that `log-warper` has several drawbacks and we are not going to maintain it. Overall I think this consequence is not a big deal.
Logging is implemented as an opaque handle which is passed to logging functions. No monadic interface is used for it. It's in line with our existing code base, which mostly operates in `IO` and uses explicit argument passing.
Another concern is concurrency. Currently it's possible that logging output will be messy if several threads use it concurrently. A simple solution for it is using an `MVar`. I haven't implemented it, because Ariadne itself is mostly single-threaded, so I don't expect it to be a
problem. We can do it later if it turns out to be a problem.

P. S. As you can see, there are several `Would be good` which I haven't done in this PR. The goal of AD-519 is to just make it easy to log something and I believe this PR achieves it. Further improvements can be done in follow-up issues.

## Related issue(s)

<!--
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/AD-519

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - [TUI usage guide](../tree/master/docs/usage-tui.md)
    - [GUI usage guide](../tree/master/docs/usage-gui.md)
    - [Configuration documentation](../tree/master/docs/configuration.md)
    - [GUI architecture documentation](../tree/master/docs/gui-architecture.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
