### PR TITLE
pkgs.nix: bump to update all-cabal-hashes

### DIFF
--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,5 @@
 import (fetchGit {
   url = https://github.com/serokell/serokell-closure;
-  rev = "89a0592f4af2562e1f45e51b6e5c98d104e334ce";
+  rev = "81232e12e352da356bf4e1e7402a4e6a274a3d9d";
+  ref = "20181207140705";
 })


### PR DESCRIPTION
Bump closure pin to update all-cabal-hashes. Local build succeeds:

```
/nix/store/jzvlyhc8vhc75c2k6fyn153lhxp1qvyx-acid-view-0.3.1.0
/nix/store/q9939y2ac4q38cvpmygdvh4mnmqhaz42-ariadne-cardano-0.3.1.0
/nix/store/xv226703j6anzkg4fdi1z59zxcdgm39x-ariadne-core-0.3.1.0
/nix/store/xmhrh8r2pzd0b34q8vqhmlhg9j1d68pb-ariadne-qt-app-0.3.1.0
/nix/store/d94qxjmkg5z26k8jmn5a1gfjbb2jjb7c-ariadne-qt-lib-0.3.1.0
/nix/store/b45yxbzjhg7q7nx1r1xf9q3m8w0yydxw-ariadne-vty-app-0.3.1.0
/nix/store/bywk1d8sikkg85fsa1s8mw2gsdkyadv6-ariadne-vty-lib-0.3.1.0
/nix/store/kn4qypmp52l5qr2mrypr5fjiq4vgljsj-knit-0.3.1.0
```