### PR TITLE
[AD-445] Add logging, fix one issue, refactor vty code

### DIFF
--- a/ariadne/cardano/src/Ariadne/MainTemplate.hs
+++ b/ariadne/cardano/src/Ariadne/MainTemplate.hs
@@ -25,7 +25,7 @@ import Ariadne.Config.History (HistoryConfig(..))
 import Ariadne.Config.Logging (LoggingConfig(..))
 import Ariadne.Config.Wallet (WalletConfig(..))
 import Ariadne.Knit.Backend (Components, KnitFace, createKnitBackend)
-import Ariadne.Logging (logDebug, loggingComponent)
+import Ariadne.Logging (Logging, logDebug, loggingComponent)
 import Ariadne.TaskManager.Backend
 import Ariadne.Update.Backend
 import Ariadne.UX.CommandHistory
@@ -53,6 +53,7 @@ data MainSettings (uiComponents :: [*]) uiFace uiLangFace = MainSettings
     -- executables, not when we build the library.
     , msCreateUI :: !(
         WalletUIFace ->
+        Logging ->
         CommandHistory ->
         PutPassword ->
         ComponentM (uiFace, uiLangFace -> IO ())
@@ -111,7 +112,7 @@ initializeEverything MainSettings {..}
       }
   PasswordManager {..} <- createPasswordManager
 
-  (uiFace, mkUiAction) <- msCreateUI walletUIFace history putPassword
+  (uiFace, mkUiAction) <- msCreateUI walletUIFace logging history putPassword
   CardanoBackend
     { cbFace = cardanoFace
     , cbMkAction = mkCardanoAction

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend.hs
@@ -109,7 +109,7 @@ createWalletBackend walletConfig cardanoFace sendWalletEvent getPass voidPass lo
                 , walletNewWallet = newWallet pwl walletConfig this getPassTemp waitUiConfirm logging
                 , walletRestore = restoreWallet pwl runCardanoMode getPassTemp
                 , walletRestoreFromFile = restoreFromKeyFile pwl runCardanoMode
-                , walletRename = renameSelection pwl this walletSelRef
+                , walletRename = renameSelection pwl this walletSelRef logging
                 , walletRemove = removeSelection pwl this walletSelRef waitUiConfirm
                 , walletRefreshState =
                     refreshState pwl walletSelRef sendWalletEvent

--- a/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Backend/KeyStorage.hs
@@ -415,9 +415,11 @@ renameSelection
   :: PassiveWalletLayer IO
   -> WalletFace
   -> IORef (Maybe WalletSelection)
+  -> Logging
   -> Text
   -> IO ()
-renameSelection pwl WalletFace{..} walletSelRef name = do
+renameSelection pwl WalletFace{..} walletSelRef logging name = do
+  logInfo logging $ "Renaming selection to '" <> name <> "'…"
   mWalletSel <- readIORef walletSelRef
   case mWalletSel of
     Nothing -> pass

--- a/ariadne/core/package.yaml
+++ b/ariadne/core/package.yaml
@@ -8,6 +8,7 @@ library:
     - Earley
     - ansi-wl-pprint
     - async
+    - bytestring
     - componentm
     - concurrent-extra
     - containers

--- a/ariadne/core/src/Ariadne/Logging.hs
+++ b/ariadne/core/src/Ariadne/Logging.hs
@@ -3,15 +3,18 @@
 
 module Ariadne.Logging
        (
-         -- | Logging handle and the corresponding component.
+         -- * Logging handle and the corresponding component.
          Logging
        , loggingComponent
 
-         -- | Functions to actually log something
+         -- * Functions to actually log something
        , logDebug
        , logInfo
        , logWarning
        , logError
+
+         -- * Temporary logging
+       , temporaryLog
        ) where
 
 import Colog.Actions (logTextHandle)
@@ -22,6 +25,7 @@ import Colog.Message
 import Control.Monad.Component (ComponentM, buildComponent)
 import System.FilePath ((</>))
 import System.IO (hClose, hFlush)
+import System.IO.Unsafe (unsafePerformIO)
 
 -- | An opaque type with everything needed to do logging.
 newtype Logging = Logging
@@ -61,19 +65,23 @@ log' logging messageSeverity messageText =
 -- as an argument to this function.
 -- 2. Messages are formatted using 'fmtMessage' function from 'co-log'.
 loggingComponent :: FilePath -> ComponentM Logging
-loggingComponent logFile = fst <$> buildComponent "Logging" mkLogging snd
+loggingComponent logDir =
+    fst <$> buildComponent "Logging" (mkLogging logFile) snd
   where
-    mkLogging :: IO (Logging, IO ())
-    mkLogging = do
-        hdl <- openFile (logFile </> "ariadne.log") AppendMode
-        let logToFile :: LogAction IO (RichMessage IO)
-            logToFile =
-                cmapM fmtRichMessageDefault (logTextHandle hdl) <>
-                logFlush hdl
-        let logToFile' :: LogAction IO Message
-            logToFile' = upgradeMessageAction fieldMap logToFile
-        return (Logging logToFile', hClose hdl)
+    logFile = logDir </> "ariadne.log"
 
+-- Private function, returns Logging handle and an action to release it.
+mkLogging :: FilePath -> IO (Logging, IO ())
+mkLogging logFile = do
+    hdl <- openFile logFile AppendMode
+    let logToFile :: LogAction IO (RichMessage IO)
+        logToFile =
+            cmapM fmtRichMessageDefault (logTextHandle hdl) <>
+            logFlush hdl
+    let logToFile' :: LogAction IO Message
+        logToFile' = upgradeMessageAction fieldMap logToFile
+    return (Logging logToFile', hClose hdl)
+  where
     fieldMap :: FieldMap IO
     fieldMap = defaultFieldMap
 
@@ -81,3 +89,28 @@ loggingComponent logFile = fst <$> buildComponent "Logging" mkLogging snd
 -- flushes the handle.
 logFlush :: Handle -> LogAction IO a
 logFlush hdl = LogAction $ const (hFlush hdl)
+
+----------------------------------------------------------------------------
+-- Temporary hacky logging
+----------------------------------------------------------------------------
+
+-- | Sometimes one needs to quickly add logging to some place,
+-- e. g. to debug something. Propagating 'Logging' there might be
+-- cumbersome and tedious. Doing it for temporary logging which is not
+-- supposed to be merged to the integration branch does not make much
+-- sense. This function can be used directly to log something from 'IO'.
+-- However, it is not intended for long-term usage and its usage emits
+-- a warning. The reasons are at least the following:
+--
+-- 1. It's not configurable (making it configurable would require adding
+-- more constraints or arguments).
+-- 2. It uses a global variable.
+-- 3. Having more than one way to log something is confusing.
+{-# WARNING temporaryLog "'temporaryLog' remains in code" #-}
+temporaryLog :: MonadIO m => Text -> m ()
+temporaryLog = logDebug globalLogging
+{-# SPECIALIZE temporaryLog :: Text -> IO () #-}
+
+globalLogging :: Logging
+{-# NOINLINE globalLogging #-}
+globalLogging = unsafePerformIO (fst <$> mkLogging "ariadne-tmp.log")

--- a/ui/qt-app/Main.hs
+++ b/ui/qt-app/Main.hs
@@ -6,6 +6,7 @@ import Control.Monad.Component (ComponentM)
 import NType (N(..))
 
 import Ariadne.Config.TH (getCommitHash)
+import Ariadne.Logging (Logging)
 import Ariadne.MainTemplate (MainSettings(..), defaultMain)
 import Ariadne.UI.Qt
 import Ariadne.UI.Qt.Face (UiLangFace, UiWalletFace(..))
@@ -35,10 +36,11 @@ main = defaultMain mainSettings
 
     createUI
         :: WalletUIFace
+        -> Logging
         -> CommandHistory
         -> PutPassword
         -> ComponentM (UiFace, UiLangFace -> IO ())
-    createUI WalletUIFace{..} history putPass =
+    createUI WalletUIFace{..} _logging history putPass =
         let
           historyFace = historyToUI history
           uiWalletFace = UiWalletFace

--- a/ui/vty-app/Main.hs
+++ b/ui/vty-app/Main.hs
@@ -6,6 +6,7 @@ import Control.Monad.Component (ComponentM)
 import NType (N(..))
 
 import Ariadne.Config.TH (getCommitHash)
+import Ariadne.Logging (Logging)
 import Ariadne.MainTemplate (MainSettings(..), defaultMain)
 import Ariadne.UI.Vty
 import Ariadne.UI.Vty.Face
@@ -36,10 +37,11 @@ main = defaultMain mainSettings
 
     createUI
         :: walletUIFace
+        -> Logging
         -> CommandHistory
         -> PutPassword
         -> ComponentM (UiFace, UiLangFace -> IO ())
-    createUI _walletUIFace history putPass =
+    createUI _walletUIFace logging history putPass =
         let historyFace = historyToUI history
             features = UiFeatures
                 { featureStatus = True
@@ -48,4 +50,4 @@ main = defaultMain mainSettings
                 , featureTxHistory = False
                 , featureSecretKeyName = "Mnemonic"
                 }
-        in createAriadneUI features historyFace putPass
+        in createAriadneUI features logging historyFace putPass

--- a/ui/vty-lib/package.yaml
+++ b/ui/vty-lib/package.yaml
@@ -26,6 +26,7 @@ library:
     - serokell-util
     - streams
     - text
+    - text-format
     - text-zipper
     - transformers
     - vector

--- a/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/App.hs
@@ -101,7 +101,7 @@ initApp features putPass uiFace langFace historyFace =
       addWidgetChild WidgetNameAddWallet $ initAddWalletWidget langFace features
       addWidgetChild WidgetNameWallet $ initWalletWidget langFace features
       addWidgetChild WidgetNameAccount $ initAccountWidget langFace
-      addWidgetChild WidgetNameRepl $ initReplWidget uiFace langFace historyFace
+      addWidgetChild WidgetNameRepl $ initReplWidget langFace historyFace
         (widgetParentGetter $ (== AppScreenWallet) . appScreen)
       addWidgetChild WidgetNameHelp $ initHelpWidget langFace
       addWidgetChild WidgetNameAbout initAboutWidget
@@ -296,6 +296,8 @@ handleAppEvent brickEvent = do
                   return AppInProgress
               | otherwise ->
                   return AppInProgress
+            WidgetEventHalt -> return AppCompleted
+        WidgetEventHalt -> return AppCompleted
     B.VtyEvent (V.EvPaste raw) -> do
       whenRight (decodeUtf8' raw) $ \pasted -> do
         focus <- gets getAppFocus
@@ -318,8 +320,6 @@ handleAppEvent brickEvent = do
           setAppFocus name
           void $ runHandler $ handleWidgetMouseDown coords name
       return AppInProgress
-    B.AppEvent (UiCommandAction UiCommandQuit) -> do
-      return AppCompleted
     B.AppEvent event -> do
       runHandler $ handleWidgetEvent event
       return AppInProgress

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -149,7 +149,6 @@ data UiCommandEvent
 data UiCommandAction
   = UiCommandHelp
   | UiCommandLogs
-  | UiCommandQuit
 
 -- Update current displayed slot, chain difficulty, etc
 data UiBackendEvent

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -56,8 +56,10 @@ module Ariadne.UI.Vty.Face
 
 import qualified Control.Concurrent.Event as CE
 import Data.Loc (Loc, Span)
+import qualified Data.Text.Buildable as Buildable
 import Data.Tree (Tree)
 import Data.Version (Version)
+import Formatting (bprint, int, (%))
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.UX.PasswordManager (WalletId)
@@ -135,6 +137,12 @@ data UiCommandId = UiCommandId
   , cmdTaskId :: Maybe Natural
   }
 
+instance Buildable UiCommandId where
+    build UiCommandId {..} =
+        case cmdTaskIdRendered of
+            Just rendered -> Buildable.build rendered
+            Nothing -> bprint ("EqObject:"%int) cmdIdEqObject
+
 instance Eq UiCommandId where
   a == b = cmdIdEqObject a == cmdIdEqObject b
 
@@ -144,6 +152,7 @@ data UiCommandEvent
   | UiCommandFailure Doc
   | UiCommandOutput Doc
   | UiCommandWidget Doc
+  deriving (Show)
 
 -- UI event triggered by REPL command
 data UiCommandAction

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
@@ -176,9 +176,12 @@ data WidgetEvent
 -- Each UI event is sent to the deepest focused widget possible.
 -- If its handler returns @WidgetEventNotHandled@, the event "bubbles" up
 -- through the widget hierarchy and is fed to parent widget's event handler.
+-- Event handler can return @WidgetEventHalt@, which means that the whole
+-- application should be halted.
 data WidgetEventResult
   = WidgetEventHandled
   | WidgetEventNotHandled
+  | WidgetEventHalt
 
 -- | Base widget type
 --
@@ -533,6 +536,7 @@ handleByName widget@WidgetInfo{..} name widgetHandler childHandler =
           case res of
             WidgetEventNotHandled -> widgetHandler
             WidgetEventHandled -> return res
+            WidgetEventHalt -> return res
 
 -- | Executes a particular widget's event handler, then executes parent's handlers for child→parent events, if any
 withWidget

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/AddWallet.hs
@@ -157,34 +157,36 @@ handleAddWalletWidgetEvent
   -> WidgetEventM AddWalletWidgetState p ()
 handleAddWalletWidgetEvent = \case
   UiWalletEvent UiWalletUpdate{..}
-    | isJust wuSelectionInfo -> do
+    | isJust wuSelectionInfo -> zoomWidgetState $ do
         addWalletNewResultL .= NewResultNone
         addWalletRestoreResultL .= RestoreResultNone
-  UiCommandResult commandId (UiNewWalletCommandResult result) -> do
-    use addWalletNewResultL >>= \case
-      NewResultWaiting commandId' | commandId == commandId' ->
-        case result of
-          UiNewWalletCommandSuccess mnemonic -> do
-            addWalletNewNameL .= ""
-            addWalletNewPassL .= ""
-            addWalletNewResultL .= NewResultSuccess mnemonic
-          UiNewWalletCommandFailure err -> do
-            addWalletNewResultL .= NewResultError err
-      _ ->
-        pass
-  UiCommandResult commandId (UiRestoreWalletCommandResult result) -> do
-    use addWalletRestoreResultL >>= \case
-      RestoreResultWaiting commandId' | commandId == commandId' ->
-        case result of
-          UiRestoreWalletCommandSuccess -> do
-            addWalletRestoreNameL .= ""
-            addWalletRestoreMnemonicL .= ""
-            addWalletRestorePassL .= ""
-            addWalletRestoreResultL .= RestoreResultSuccess
-          UiRestoreWalletCommandFailure err -> do
-            addWalletRestoreResultL .= RestoreResultError err
-      _ ->
-        pass
+  UiCommandResult commandId (UiNewWalletCommandResult result) ->
+    zoomWidgetState $ do
+      use addWalletNewResultL >>= \case
+        NewResultWaiting commandId' | commandId == commandId' ->
+          case result of
+            UiNewWalletCommandSuccess mnemonic -> do
+              addWalletNewNameL .= ""
+              addWalletNewPassL .= ""
+              addWalletNewResultL .= NewResultSuccess mnemonic
+            UiNewWalletCommandFailure err -> do
+              addWalletNewResultL .= NewResultError err
+        _ ->
+          pass
+  UiCommandResult commandId (UiRestoreWalletCommandResult result) ->
+    zoomWidgetState $ do
+      use addWalletRestoreResultL >>= \case
+        RestoreResultWaiting commandId' | commandId == commandId' ->
+          case result of
+            UiRestoreWalletCommandSuccess -> do
+              addWalletRestoreNameL .= ""
+              addWalletRestoreMnemonicL .= ""
+              addWalletRestorePassL .= ""
+              addWalletRestoreResultL .= RestoreResultSuccess
+            UiRestoreWalletCommandFailure err -> do
+              addWalletRestoreResultL .= RestoreResultError err
+        _ ->
+          pass
   _ ->
     pass
 
@@ -193,7 +195,7 @@ handleAddWalletWidgetEvent = \case
 ----------------------------------------------------------------------------
 
 performCreateWallet :: WidgetEventM AddWalletWidgetState p ()
-performCreateWallet = do
+performCreateWallet = zoomWidgetState $ do
   UiLangFace{..} <- use addWalletLangFaceL
   name <- use addWalletNewNameL
   passphrase <- use addWalletNewPassL
@@ -203,7 +205,7 @@ performCreateWallet = do
       assign addWalletNewResultL . either NewResultError NewResultWaiting
 
 performRestoreWallet :: WidgetEventM AddWalletWidgetState p ()
-performRestoreWallet = do
+performRestoreWallet = zoomWidgetState $ do
   UiLangFace{..} <- use addWalletLangFaceL
   name <- use addWalletRestoreNameL
   mnemonic <- use addWalletRestoreMnemonicL

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Dialog/Password.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Dialog/Password.hs
@@ -7,12 +7,12 @@ import Control.Lens (makeLensesWith, (.=))
 
 import qualified Brick as B
 
-import Ariadne.UIConfig
 import Ariadne.UI.Vty.Face
 import Ariadne.UI.Vty.Keyboard
 import Ariadne.UI.Vty.Widget
 import Ariadne.UI.Vty.Widget.Dialog.Utils
 import Ariadne.UI.Vty.Widget.Form.Edit hiding (initPasswordWidget)
+import Ariadne.UIConfig
 import Ariadne.Util
 import Ariadne.UX.PasswordManager
 
@@ -74,7 +74,7 @@ handlePasswordWidgetKey = \case
     _ -> return WidgetEventNotHandled
 
 performContinue :: WidgetEventM PasswordWidgetState p ()
-performContinue = do
+performContinue = zoomWidgetState $ do
     PasswordWidgetState{..} <- get
     whenJust passwordWidgetRecipient $ \(walletId, cEvent) -> do
         liftIO $ passwordWidgetPutPassword walletId passwordWidgetContent $ Just cEvent
@@ -86,6 +86,6 @@ handlePasswordWidgetEvent
     :: UiEvent
     -> WidgetEventM PasswordWidgetState p ()
 handlePasswordWidgetEvent = \case
-    UiPasswordEvent (UiPasswordRequest walletId cEvent) ->
+    UiPasswordEvent (UiPasswordRequest walletId cEvent) -> zoomWidgetState $
         passwordWidgetRecipientL .= Just (walletId, cEvent)
     _ -> pass

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Checkbox.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/Checkbox.hs
@@ -70,5 +70,5 @@ handleCheckboxWidgetMouseDown _ = do
 toggle :: WidgetEventM (CheckboxWidgetState p) p ()
 toggle = do
   widgetEvent WidgetEventCheckboxToggled
-  CheckboxWidgetState{..} <- get
+  CheckboxWidgetState{..} <- getWidgetState
   useWidgetLens checkboxWidgetLens >>= assignWidgetLens checkboxWidgetLens . not

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/List.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Form/List.hs
@@ -52,17 +52,18 @@ handleListWidgetKey
   -> WidgetEventM (ListWidgetState p a) p WidgetEventResult
 handleListWidgetKey key
   | key `elem` [KeyEnter, KeyChar ' '] = do
-      ListWidgetState{..} <- get
-      items <- map listWidgetItemsGetter . lift . lift $ get
+      ListWidgetState{..} <- getWidgetState
+      items <- map listWidgetItemsGetter . lift $ get
       widgetEvent $ WidgetEventListSelected $ clampToList items listWidgetLocation
       return WidgetEventHandled
-  | KeyUp <- key = do
+  | KeyUp <- key = zoomWidgetState $ do
       listWidgetLocationL %= max 0 . pred . max 0
       return WidgetEventHandled
   | KeyDown <- key = do
-      ListWidgetState{..} <- get
-      items <- map listWidgetItemsGetter . lift . lift $ get
-      listWidgetLocationL %= clampToList items . succ . clampToList items
+      ListWidgetState{..} <- getWidgetState
+      items <- map listWidgetItemsGetter . lift $ get
+      widgetStateL . listWidgetLocationL %=
+        clampToList items . succ . clampToList items
       return WidgetEventHandled
   | otherwise = do
       return WidgetEventNotHandled
@@ -71,7 +72,7 @@ handleListWidgetMouseDown
   :: B.Location
   -> WidgetEventM (ListWidgetState p a) p WidgetEventResult
 handleListWidgetMouseDown (B.Location (_, row)) = do
-  listWidgetLocationL .= row
+  widgetStateL . listWidgetLocationL .= row
   widgetEvent $ WidgetEventListSelected row
   return WidgetEventHandled
 

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Menu.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Menu.hs
@@ -106,7 +106,7 @@ handleMenuWidgetMouseDown
   :: B.Location
   -> WidgetEventM (MenuWidgetState p a) p WidgetEventResult
 handleMenuWidgetMouseDown (B.Location (col, _)) = do
-    MenuWidgetState{..} <- get
+    MenuWidgetState{..} <- getWidgetState
     whenJust (colToSelection menuWidgetElems col) (assignWidgetLens menuWidgetSelectionLens)
     widgetEvent WidgetEventMenuSelected
     return WidgetEventHandled
@@ -126,7 +126,7 @@ handleMenuWidgetKey
   => KeyboardEvent
   -> WidgetEventM (MenuWidgetState p a) p WidgetEventResult
 handleMenuWidgetKey key = do
-  MenuWidgetState{..} <- get
+  MenuWidgetState{..} <- getWidgetState
   let
     rotate dir = do
       selection <- useWidgetLens menuWidgetSelectionLens

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Status.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Status.hs
@@ -77,12 +77,14 @@ handleStatusWidgetEvent
   :: UiEvent
   -> WidgetEventM StatusWidgetState p ()
 handleStatusWidgetEvent = \case
-  UiBackendEvent (UiBackendStatusUpdateEvent UiBackendStatusUpdate{..}) -> do
-    statusWidgetSyncProgressL .= syncProgress
-    statusWidgetBlockchainLocalL .= blockchainLocal
-    statusWidgetBlockchainNetworkL .= blockchainNetwork
-  UiNewVersionEvent UiNewVersion{..} -> do
-    statusWidgetNewVersionL .= Just nvVersion
-    statusWidgetUpdateURLL .= Just nvUpdateURL
+  UiBackendEvent (UiBackendStatusUpdateEvent UiBackendStatusUpdate{..})
+    -> zoomWidgetState $ do
+      statusWidgetSyncProgressL .= syncProgress
+      statusWidgetBlockchainLocalL .= blockchainLocal
+      statusWidgetBlockchainNetworkL .= blockchainNetwork
+  UiNewVersionEvent UiNewVersion{..}
+    -> zoomWidgetState $ do
+      statusWidgetNewVersionL .= Just nvVersion
+      statusWidgetUpdateURLL .= Just nvUpdateURL
   _ ->
     pass


### PR DESCRIPTION
## Description

This PR contains the first set of changes I made while working on AD-445. The bug happens because the UI thread in some cases calls `putUiEvent` which can block and the UI thread is the only one which can unblock it. More details can be found in the issue comments. It's recommended to review this PR on per-commit basis. Contents:
1. Some changes related to logging which I made to facilitate debugging. 
2. One place where `putUiEvent` can be called from the UI thread has been reworked, so that now it's impossible.
3. Refactored TUI code to make it more understandable by eliminating one `StateT` layer (see the corresponding commit description).

Note: there will be at least one more PR, I just want to avoid too large PRs.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/AD-445

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again. ← No, because I don't know how to do it.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - [TUI usage guide](../tree/master/docs/usage-tui.md)
    - [GUI usage guide](../tree/master/docs/usage-gui.md)
    - [Configuration documentation](../tree/master/docs/configuration.md)
    - [GUI architecture documentation](../tree/master/docs/gui-architecture.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
