### PR TITLE
[AD-445] Do not use UiFace to disable modality

### DIFF
--- a/ui/vty-lib/src/Ariadne/UI/Vty.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty.hs
@@ -29,7 +29,7 @@ createAriadneUI features logging historyFace putPass = buildComponent_ "UI-Vty" 
   eventChan <- mkEventChan
   let uiFace = mkUiFace eventChan logging
 
-  return (uiFace, runUI eventChan features logging putPass uiFace historyFace)
+  return (uiFace, runUI eventChan features logging putPass historyFace)
 
 -- Run the Ariadne UI. This action should be run in its own thread to provide a
 -- responsive interface, and the application should exit when this action
@@ -39,11 +39,10 @@ runUI
   -> UiFeatures
   -> Logging
   -> PutPassword
-  -> UiFace
   -> UiHistoryFace
   -> UiLangFace
   -> IO ()
-runUI eventChan features logging putPass uiFace historyFace langFace = do
+runUI eventChan features logging putPass historyFace langFace = do
   vtyConfig <- mkVtyConfig
 
   -- Run the Brick event loop:
@@ -74,7 +73,7 @@ runUI eventChan features logging putPass uiFace historyFace langFace = do
     app
 
     -- The fourth argument to 'customMain' is the initial application state.
-    (initApp features logging putPass uiFace langFace historyFace)
+    (initApp features logging putPass langFace historyFace)
 
 -- Build terminal configuration. This is where we can configure technical
 -- details like mouse support, input/output file descriptors, terminal name

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Face.hs
@@ -185,12 +185,10 @@ data UiNewVersionEvent = UiNewVersion
 -- | Ui event triggered by the password manager
 data UiPasswordEvent
   = UiPasswordRequest WalletId CE.Event
-  | UiPasswordSent
 
 -- | Ui event to handle confirmations
 data UiConfirmEvent
   = UiConfirmRequest (MVar Bool) UiConfirmationType
-  | UiConfirmDone
 
 data UiConfirmationType
   = UiConfirmMnemonic [Text]          -- ^ mnemonic

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget.hs
@@ -173,6 +173,7 @@ data WidgetEvent
   | WidgetEventEditLocationChanged
   | WidgetEventListSelected Int
   | WidgetEventCheckboxToggled
+  | WidgetEventModalExited
 
 -- | Result of handling a UI event
 --

--- a/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Dialog/ConfirmMnemonic.hs
+++ b/ui/vty-lib/src/Ariadne/UI/Vty/Widget/Dialog/ConfirmMnemonic.hs
@@ -17,8 +17,7 @@ import Ariadne.UIConfig
 import Ariadne.Util
 
 data ConfirmMnemonicWidgetState = ConfirmMnemonicWidgetState
-    { confirmMnemonicWidgetUiFace            :: !UiFace
-    , confirmMnemonicWidgetContent           :: !Text
+    { confirmMnemonicWidgetContent           :: !Text
     , confirmMnemonicWidgetAppMovedMessage   :: !Text
     , confirmMnemonicWidgetOnDeviceMessage   :: !Text
     , confirmMnemonicWidgetNoLooksMessage    :: !Text
@@ -38,14 +37,13 @@ data ConfirmationState
 
 makeLensesWith postfixLFields ''ConfirmMnemonicWidgetState
 
-initConfirmMnemonicWidget :: UiFace -> Widget p
-initConfirmMnemonicWidget uiFace = initWidget $ do
+initConfirmMnemonicWidget :: Widget p
+initConfirmMnemonicWidget = initWidget $ do
     setWidgetDrawWithFocus drawConfirmMnemonicWidget
     setWidgetHandleKey handleConfirmMnemonicWidgetKey
     setWidgetHandleEvent handleConfirmMnemonicWidgetEvent
     setWidgetState ConfirmMnemonicWidgetState
-        { confirmMnemonicWidgetUiFace            = uiFace
-        , confirmMnemonicWidgetContent           = ""
+        { confirmMnemonicWidgetContent           = ""
         , confirmMnemonicWidgetAppMovedMessage   = mnemonicAppMovedMessage
         , confirmMnemonicWidgetOnDeviceMessage   = mnemonicOnDeviceMessage
         , confirmMnemonicWidgetNoLooksMessage    = mnemonicNoLooksMessage
@@ -159,9 +157,8 @@ performCancel =
 
 closeDialog :: WidgetEventM ConfirmMnemonicWidgetState p ()
 closeDialog = do
+    widgetEvent WidgetEventModalExited
     zoomWidgetState $ do
-        UiFace{..} <- use confirmMnemonicWidgetUiFaceL
-        liftIO $ putUiEvent $ UiConfirmEvent UiConfirmDone
         confirmMnemonicWidgetContentL .= ""
         confirmMnemonicWidgetValueL .= []
         confirmMnemonicWidgetConfirmationStateL .= Before


### PR DESCRIPTION
## Description

Problem: sometimes vty app can go into modal mode and some widgets use
`putUiEvent` to let the app know that it should exit modal mode. They do it
from the UI thread and because of that `putUiEvent` can block forever.
Solution: add a new event to `WidgetEvent` to disable modality and send this
event to parent using `widgetEvent`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/AD-445

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - [TUI usage guide](../tree/master/docs/usage-tui.md)
    - [GUI usage guide](../tree/master/docs/usage-gui.md)
    - [Configuration documentation](../tree/master/docs/configuration.md)
    - [GUI architecture documentation](../tree/master/docs/gui-architecture.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
