### PR TITLE
[AD-512] Update cardano-sl due to reverted UserSecret changes

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Restore.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/Cardano/Kernel/Restore.hs
@@ -21,7 +21,7 @@ import qualified Pos.Crypto as Crypto
   safeDeterministicKeyGen)
 import Pos.Txp.Toil.Types (Utxo)
 import Pos.Util.BackupPhrase (BackupPhrase(..), safeKeysFromPhrase)
-import Pos.Util.UserSecret (usKeys0)
+import Pos.Util.UserSecret (usKeys)
 
 import Ariadne.Cardano.Face (Address, CardanoMode)
 import Ariadne.Wallet.Cardano.Kernel.AddressDiscovery
@@ -128,7 +128,7 @@ readNonAriadneKeys path = do
   keyFile <- BS.readFile path
   case decodeFull' keyFile of
     Left e   -> throwM $ SecretsDecodingError path e
-    Right us -> pure $ us ^. usKeys0
+    Right us -> pure $ us ^. usKeys
 
 collectUtxo ::
        HasConfiguration

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/serokell/cardano-sl
-  commit: aebb30b931d24386cdf959fd71c61cf01ba1edbf # ariadne branch
+  commit: 1e0a4923b433fd54bee2e4e2bb6d47fcc96715b5 # ariadne branch
   subdirs:
   - binary
   - binary/test


### PR DESCRIPTION

## Description

Problem: some changes have been made to `cardano-sl`, see
https://github.com/serokell/cardano-sl/pull/46.
Solution: update `cardano-sl` to the latest version.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/AD-512

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - [TUI usage guide](../tree/master/docs/usage-tui.md)
    - [GUI usage guide](../tree/master/docs/usage-gui.md)
    - [Configuration documentation](../tree/master/docs/configuration.md)
    - [GUI architecture documentation](../tree/master/docs/gui-architecture.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
