### PR TITLE
[AD-445] Do not send command to REPL from UI thread

### DIFF
--- a/ariadne/core/src/Ariadne/Knit/Backend.hs
+++ b/ariadne/core/src/Ariadne/Knit/Backend.hs
@@ -35,6 +35,7 @@ createKnitBackend mkExecCtxs TaskManagerFace{..} =
         putCommandResult Nothing $ KnitCommandProcError e
         return Nothing
       Right expr' -> fmap Just . spawnTask $ \taskId -> do
+        putCommandToUI expr taskId
         let execCtxs = mkExecCtxs (putCommandOutput taskId)
         -- We catch asynchronous exceptions intentionally here to send them to UI and
         -- rethrow them afterwards.

--- a/ariadne/core/src/Ariadne/Knit/Face.hs
+++ b/ariadne/core/src/Ariadne/Knit/Face.hs
@@ -25,12 +25,12 @@ data KnitCommandResult components
 
 data KnitCommandHandle components
   = KnitCommandHandle
-  { putCommandResult :: (Maybe TaskId) -> KnitCommandResult components -> IO ()
-  , putCommandOutput :: TaskId -> Doc -> IO ()
+  { putCommandResult :: !((Maybe TaskId) -> KnitCommandResult components -> IO ())
+  , putCommandOutput :: !(TaskId -> Doc -> IO ())
   -- | Send a command back to UI to add it to REPL.
   -- It might be a good idea to make various widgets send such events
   -- to REPL widget directly, but interwidget communication is complicated.
-  , putCommandToUI :: Knit.Expr Knit.NoExt Knit.CommandId components -> TaskId -> IO ()
+  , putCommandToUI :: !(Knit.Expr Knit.NoExt Knit.CommandId components -> TaskId -> IO ())
   }
 
 -- API for the knit interpreter.

--- a/ariadne/core/src/Ariadne/Knit/Face.hs
+++ b/ariadne/core/src/Ariadne/Knit/Face.hs
@@ -27,6 +27,10 @@ data KnitCommandHandle components
   = KnitCommandHandle
   { putCommandResult :: (Maybe TaskId) -> KnitCommandResult components -> IO ()
   , putCommandOutput :: TaskId -> Doc -> IO ()
+  -- | Send a command back to UI to add it to REPL.
+  -- It might be a good idea to make various widgets send such events
+  -- to REPL widget directly, but interwidget communication is complicated.
+  , putCommandToUI :: Knit.Expr Knit.NoExt Knit.CommandId components -> TaskId -> IO ()
   }
 
 -- API for the knit interpreter.

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -82,6 +82,7 @@ knitFaceToUI UiFace{..} KnitFace{..} putPass =
           whenJust (knitCommandResultToUI (commandIdToUI commandId mtid) result) putUiEvent
       , putCommandOutput = \tid doc ->
           putUiEvent $ knitCommandOutputToUI (commandIdToUI commandId (Just tid)) doc
+      , putCommandToUI = \_expr _taskId -> pass
       }
 
     putUiCommand op = case opToExpr op of
@@ -95,6 +96,7 @@ knitFaceToUI UiFace{..} KnitFace{..} putPass =
             putUiEvent . UiCommandResult (commandIdToUI commandId mtid)
       , putCommandOutput = \_ _ ->
           pass
+      , putCommandToUI = \_expr _taskId -> pass
       }
 
     extractPass = \case


### PR DESCRIPTION
## Description

Problem: `langPutUiCommand` is executed from the UI thread and it calls
`putUiEvent` which can block and only the UI thread can unblock it. So deadlock is possible.
Solution: call `putUiEvent` from Knit backend, inside action passed to
`spawnTask`. That action is executed from non-UI thread, so it can't deadlock.
One alternative would be to introduce a way to send an event from widgets to
REPL. However, that seems to be too hard.
Another alternative is to fork a thread specifically for `putUiEvent`, but
this event should be processed before the command is executed, because
otherwise `updateCommandResult` will ignore all events related to this command.
This problem was present before, because `putUiEvent` was called after
`putCommand`.
This approach is quite simple and doesn't require additional thread management.

This is the last fix for AD-445.

## Related issue(s)

<!--
Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/AD-445

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again. ← don't know how to do it.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - [TUI usage guide](../tree/master/docs/usage-tui.md)
    - [GUI usage guide](../tree/master/docs/usage-gui.md)
    - [Configuration documentation](../tree/master/docs/configuration.md)
    - [GUI architecture documentation](../tree/master/docs/gui-architecture.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
