### PR TITLE
[AD-379] Display full id of sent transaction

### DIFF
--- a/ariadne/cardano/src/Ariadne/Wallet/UiAdapter.hs
+++ b/ariadne/cardano/src/Ariadne/Wallet/UiAdapter.hs
@@ -22,6 +22,7 @@ module Ariadne.Wallet.UiAdapter
        , toUiWalletSelection
        , formatAddressHash
        , formatHdRootId
+       , formatAHash
        ) where
 
 import qualified Data.Vector as V
@@ -35,7 +36,7 @@ import Ariadne.Wallet.Cardano.Kernel.DB.Util.IxSet (IxSet)
 import Ariadne.Wallet.Face
 
 import Pos.Core (AddressHash, unsafeIntegerToCoin)
-import Pos.Crypto.Hashing (hashHexF)
+import Pos.Crypto.Hashing (AHash(..), hashHexF)
 import Serokell.Util (enumerate)
 
 import Control.Lens (makeLenses)
@@ -164,3 +165,6 @@ formatAddressHash = sformat ("#" % hashHexF)
 
 formatHdRootId :: HdRootId -> Text
 formatHdRootId = formatAddressHash . _fromDb . getHdRootId
+
+formatAHash :: AHash -> Text
+formatAHash = sformat hashHexF . getAHash

--- a/ui/qt-app/Glue.hs
+++ b/ui/qt-app/Glue.hs
@@ -175,7 +175,7 @@ knitFaceToUI UiFace{..} KnitFace{..} putPass =
       UiSend {} ->
         Just . UiSendCommandResult . either UiSendCommandFailure UiSendCommandSuccess $
           fromResult result >>= fromValue >>= \case
-            Knit.ValueHash h -> Right $ pretty h
+            Knit.ValueHash h -> Right $ formatAHash h
             _ -> Left "Unrecognized return value"
       UiCalcTotal {} ->
         Just . UiCalcTotalCommandResult . either UiCalcTotalCommandFailure UiCalcTotalCommandSuccess $

--- a/ui/vty-app/Glue.hs
+++ b/ui/vty-app/Glue.hs
@@ -200,7 +200,7 @@ knitFaceToUI UiFace{..} KnitFace{..} putPass =
       UiSend{} ->
         Just . UiSendCommandResult . either UiSendCommandFailure UiSendCommandSuccess $
           fromResult result >>= fromValue >>= \case
-            Knit.ValueHash h -> Right $ pretty h
+            Knit.ValueHash h -> Right $ formatAHash h
             _ -> Left "Unrecognized return value"
       UiFee{} ->
         Just . UiFeeCommandResult . either UiFeeCommandFailure UiFeeCommandSuccess $


### PR DESCRIPTION
## Description
Problem: both TUI and GUI display hash of just sent transaction using
only prefix of 16 symbols. However, there is enough space to display the
whole hash.

Solution: use full hash formatting function to display hash in TUI and
GUI.
## Related issue(s)

https://issues.serokell.io/issue/AD-379

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - [TUI usage guide](../tree/master/docs/usage-tui.md)
    - [GUI usage guide](../tree/master/docs/usage-gui.md)
    - [Configuration documentation](../tree/master/docs/configuration.md)
    - [GUI architecture documentation](../tree/master/docs/gui-architecture.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
